### PR TITLE
Add tournament blind template management features

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -31,6 +31,20 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "blindTemplates",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "isArchive",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -22,3 +22,5 @@ export * from "./user";
 export * from "./itemOrder";
 export * from "./userLogin";
 export * from "./utils";
+// トーナメントブラインドテンプレート関連関数
+export * from "./tournamentBlind";

--- a/functions/src/tournamentBlind/archiveBlindTemplate.ts
+++ b/functions/src/tournamentBlind/archiveBlindTemplate.ts
@@ -1,0 +1,30 @@
+import { onCall } from "firebase-functions/v2/https";
+import { getFirestore } from "firebase-admin/firestore";
+
+export const archiveBlindTemplate = onCall(async (request) => {
+  try {
+    const { blindTemplateId } = request.data;
+    
+    if (!blindTemplateId || typeof blindTemplateId !== 'string') {
+      return { success: false, error: 'ブラインドテンプレートIDは必須です' };
+    }
+
+    const db = getFirestore();
+    const docRef = db.collection('blindTemplates').doc(blindTemplateId);
+    const doc = await docRef.get();
+    
+    if (!doc.exists) {
+      return { success: false, error: '指定されたブラインドテンプレートが見つかりません' };
+    }
+
+    await docRef.update({
+      isArchive: true,
+      updatedAt: new Date(),
+    });
+
+    return { success: true, message: 'ブラインドテンプレートが正常にアーカイブされました' };
+  } catch (error) {
+    console.error('ブラインドテンプレートアーカイブエラー:', error);
+    return { success: false, error: 'ブラインドテンプレートのアーカイブに失敗しました' };
+  }
+});

--- a/functions/src/tournamentBlind/createBlindTemplate.ts
+++ b/functions/src/tournamentBlind/createBlindTemplate.ts
@@ -1,0 +1,87 @@
+import { onCall } from "firebase-functions/v2/https";
+import { getFirestore } from "firebase-admin/firestore";
+
+export const createBlindTemplate = onCall(async (request) => {
+  try {
+    const {
+      blindName,
+      numberOfBlindLevels,
+      defaultStartingChips,
+      blindIntervalBeforeReg,
+      blindIntervalAfterReg,
+      anteType,
+      lateRegUntilLevel,
+      breakTime,
+      levels,
+    } = request.data;
+
+    // バリデーション
+    if (!blindName || typeof blindName !== 'string') {
+      return { success: false, error: 'ブラインドテンプレート名は必須です' };
+    }
+    if (!numberOfBlindLevels || typeof numberOfBlindLevels !== 'number' || numberOfBlindLevels <= 0) {
+      return { success: false, error: 'ブラインドレベル数は正の数値で入力してください' };
+    }
+    if (!defaultStartingChips || typeof defaultStartingChips !== 'number' || defaultStartingChips <= 0) {
+      return { success: false, error: '開始チップ数は正の数値で入力してください' };
+    }
+    if (!blindIntervalBeforeReg || typeof blindIntervalBeforeReg !== 'number' || blindIntervalBeforeReg <= 0) {
+      return { success: false, error: 'レジスト前ブラインド間隔は正の数値で入力してください' };
+    }
+    if (!blindIntervalAfterReg || typeof blindIntervalAfterReg !== 'number' || blindIntervalAfterReg <= 0) {
+      return { success: false, error: 'レジスト後ブラインド間隔は正の数値で入力してください' };
+    }
+    if (!anteType || !['BBA', 'None'].includes(anteType)) {
+      return { success: false, error: 'アンティタイプはBBAまたはNoneで入力してください' };
+    }
+    if (!lateRegUntilLevel || typeof lateRegUntilLevel !== 'number' || lateRegUntilLevel <= 0) {
+      return { success: false, error: 'レイトレジ終了レベルは正の数値で入力してください' };
+    }
+    if (!breakTime || typeof breakTime !== 'number' || breakTime < 0) {
+      return { success: false, error: 'ブレイク時間は0以上の数値で入力してください' };
+    }
+    if (!levels || !Array.isArray(levels) || levels.length === 0) {
+      return { success: false, error: 'ブラインドレベル情報は必須です' };
+    }
+
+    const db = getFirestore();
+    const now = new Date();
+
+    // Firestoreに保存するデータを構築
+    const blindTemplateData = {
+      anteType,
+      blindIntervalAfterRegLev: blindIntervalAfterReg,
+      blindIntervalBeforeRegLev: blindIntervalBeforeReg,
+      blindName,
+      createdAt: now,
+      defaultStartingChips,
+      lateRegUntilLev: lateRegUntilLevel,
+      levels: levels.map((level: any) => ({
+        ante: level.ante || 0,
+        bigBlind: level.bigBlind,
+        duration: level.duration,
+        level: level.level,
+        smallBlind: level.smallBlind,
+        hasBreakAfter: level.hasBreakAfter || false,
+        endTime: level.endTime || 0,
+        timeFromLastBreak: level.timeFromLastBreak || 0,
+      })),
+      numberOfBlindLevels,
+      breakDuration: breakTime,
+      updatedAt: now,
+      isArchive: false,
+    };
+
+    const docRef = await db.collection('blindTemplates').add(blindTemplateData);
+
+    return {
+      success: true,
+      blindTemplateId: docRef.id,
+      message: 'ブラインドテンプレートが正常に作成されました'
+    };
+
+  } catch (error) {
+    console.error('ブラインドテンプレート作成エラー:', error);
+    return { success: false, error: 'ブラインドテンプレートの作成に失敗しました' };
+  }
+});

--- a/functions/src/tournamentBlind/getBlindTemplates.ts
+++ b/functions/src/tournamentBlind/getBlindTemplates.ts
@@ -1,0 +1,43 @@
+import { onCall } from "firebase-functions/v2/https";
+import { getFirestore } from "firebase-admin/firestore";
+
+export const getBlindTemplates = onCall(async (request) => {
+  try {
+    const db = getFirestore();
+    
+    const snapshot = await db.collection('blindTemplates')
+      .where('isArchive', '==', false)
+      .orderBy('createdAt', 'desc')
+      .get();
+
+    const blindTemplates = snapshot.docs.map(doc => {
+      const data = doc.data();
+      // Firestoreのデータを適切な型に変換
+      const convertedData: any = {
+        id: doc.id,
+        blindName: data.blindName || '',
+        numberOfBlindLevels: data.numberOfBlindLevels || 0,
+        defaultStartingChips: data.defaultStartingChips || 0,
+        blindIntervalBeforeRegLev: data.blindIntervalBeforeRegLev || 0,
+        blindIntervalAfterRegLev: data.blindIntervalAfterRegLev || 0,
+        lateRegUntilLev: data.lateRegUntilLev || 0,
+        anteType: data.anteType || '',
+        breakDuration: data.breakDuration || 0,
+        levels: data.levels || [],
+        createdAt: data.createdAt?.toDate?.() || data.createdAt,
+        updatedAt: data.updatedAt?.toDate?.() || data.updatedAt,
+      };
+      return convertedData;
+    });
+
+    return {
+      success: true,
+      blindTemplates,
+      message: 'ブラインドテンプレートを正常に取得しました'
+    };
+
+  } catch (error) {
+    console.error('ブラインドテンプレート取得エラー:', error);
+    return { success: false, error: 'ブラインドテンプレートの取得に失敗しました' };
+  }
+});

--- a/functions/src/tournamentBlind/index.ts
+++ b/functions/src/tournamentBlind/index.ts
@@ -1,0 +1,4 @@
+export { createBlindTemplate } from './createBlindTemplate';
+export { getBlindTemplates } from './getBlindTemplates';
+export { updateBlindTemplate } from './updateBlindTemplate';
+export { archiveBlindTemplate } from './archiveBlindTemplate';

--- a/functions/src/tournamentBlind/updateBlindTemplate.ts
+++ b/functions/src/tournamentBlind/updateBlindTemplate.ts
@@ -1,0 +1,97 @@
+import { onCall } from "firebase-functions/v2/https";
+import { getFirestore } from "firebase-admin/firestore";
+
+export const updateBlindTemplate = onCall(async (request) => {
+  try {
+    const {
+      blindTemplateId,
+      blindName,
+      numberOfBlindLevels,
+      defaultStartingChips,
+      blindIntervalBeforeReg,
+      blindIntervalAfterReg,
+      anteType,
+      lateRegUntilLevel,
+      breakTime,
+      levels,
+    } = request.data;
+
+    // バリデーション
+    if (!blindTemplateId || typeof blindTemplateId !== 'string') {
+      return { success: false, error: 'ブラインドテンプレートIDは必須です' };
+    }
+    if (!blindName || typeof blindName !== 'string') {
+      return { success: false, error: 'ブラインドテンプレート名は必須です' };
+    }
+    if (!numberOfBlindLevels || typeof numberOfBlindLevels !== 'number' || numberOfBlindLevels <= 0) {
+      return { success: false, error: 'ブラインドレベル数は正の数値で入力してください' };
+    }
+    if (!defaultStartingChips || typeof defaultStartingChips !== 'number' || defaultStartingChips <= 0) {
+      return { success: false, error: '開始チップ数は正の数値で入力してください' };
+    }
+    if (!blindIntervalBeforeReg || typeof blindIntervalBeforeReg !== 'number' || blindIntervalBeforeReg <= 0) {
+      return { success: false, error: 'レジスト前ブラインド間隔は正の数値で入力してください' };
+    }
+    if (!blindIntervalAfterReg || typeof blindIntervalAfterReg !== 'number' || blindIntervalAfterReg <= 0) {
+      return { success: false, error: 'レジスト後ブラインド間隔は正の数値で入力してください' };
+    }
+    if (!anteType || !['BBA', 'None'].includes(anteType)) {
+      return { success: false, error: 'アンティタイプはBBAまたはNoneで入力してください' };
+    }
+    if (!lateRegUntilLevel || typeof lateRegUntilLevel !== 'number' || lateRegUntilLevel <= 0) {
+      return { success: false, error: 'レイトレジ終了レベルは正の数値で入力してください' };
+    }
+    if (!breakTime || typeof breakTime !== 'number' || breakTime < 0) {
+      return { success: false, error: 'ブレイク時間は0以上の数値で入力してください' };
+    }
+    if (!levels || !Array.isArray(levels) || levels.length === 0) {
+      return { success: false, error: 'ブラインドレベル情報は必須です' };
+    }
+
+    const db = getFirestore();
+    const now = new Date();
+
+    // ドキュメントの存在確認
+    const docRef = db.collection('blindTemplates').doc(blindTemplateId);
+    const doc = await docRef.get();
+    
+    if (!doc.exists) {
+      return { success: false, error: '指定されたブラインドテンプレートが見つかりません' };
+    }
+
+    // 更新データを構築
+    const updateData = {
+      anteType,
+      blindIntervalAfterRegLev: blindIntervalAfterReg,
+      blindIntervalBeforeRegLev: blindIntervalBeforeReg,
+      blindName,
+      defaultStartingChips,
+      lateRegUntilLev: lateRegUntilLevel,
+      levels: levels.map((level: any) => ({
+        ante: level.ante || 0,
+        bigBlind: level.bigBlind,
+        duration: level.duration,
+        level: level.level,
+        smallBlind: level.smallBlind,
+        hasBreakAfter: level.hasBreakAfter || false,
+        endTime: level.endTime || 0,
+        timeFromLastBreak: level.timeFromLastBreak || 0,
+      })),
+      numberOfBlindLevels,
+      breakDuration: breakTime,
+      updatedAt: now,
+      isArchive: false,
+    };
+
+    await docRef.update(updateData);
+
+    return {
+      success: true,
+      message: 'ブラインドテンプレートが正常に更新されました'
+    };
+
+  } catch (error) {
+    console.error('ブラインドテンプレート更新エラー:', error);
+    return { success: false, error: 'ブラインドテンプレートの更新に失敗しました' };
+  }
+});

--- a/lib/Home/stayingUsersListPage.dart
+++ b/lib/Home/stayingUsersListPage.dart
@@ -64,7 +64,7 @@ class _StayingUsersListPageState extends State<StayingUsersListPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('入店中ユーザー一覧'),
+        title: const Text('入店中user一覧'),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),

--- a/lib/Home/terminalHomePage.dart
+++ b/lib/Home/terminalHomePage.dart
@@ -2,6 +2,7 @@ import 'package:amuse_app_template/Home/stayingUsersListPage.dart';
 import 'package:amuse_app_template/OrderView/MenuView/categorySelectPage.dart';
 import 'package:amuse_app_template/OrderView/MenuView/createMenuPage.dart';
 import 'package:amuse_app_template/OrderView/MenuView/menuEditorListPage.dart';
+import 'package:amuse_app_template/Tournament/tournamentHomePage.dart';
 import 'package:amuse_app_template/UserRegisterView/createUserAccountPage.dart';
 import 'package:amuse_app_template/UserLogin/userCheckInPage.dart';
 import 'package:flutter/material.dart';
@@ -24,8 +25,8 @@ class _terminalHomePageState extends State<terminalHomePage> {
       (label: 'ユーザーログイン', destination: const UserCheckInPage()),
       (label: 'メニュー追加', destination: const MenuEditorListPage()),
       (label: '注文画面', destination: const CategorySelectPage()),
-      (label: '来店中user一覧', destination: const StayingUsersListPage()),
-      (label: 'Terminal機能 6', destination: const PlaceholderPage(title: 'Terminal機能 6')),
+      (label: '入店中user一覧', destination: const StayingUsersListPage()),
+      (label: 'Tournament Home', destination: const TournamentHomePage()),
       (label: 'Terminal機能 7', destination: const PlaceholderPage(title: 'Terminal機能 7')),
       (label: 'Terminal機能 8', destination: const PlaceholderPage(title: 'Terminal機能 8')),
       (label: 'Terminal機能 9', destination: const PlaceholderPage(title: 'Terminal機能 9')),

--- a/lib/Tournament/createTournamentBlindBasic.dart
+++ b/lib/Tournament/createTournamentBlindBasic.dart
@@ -1,0 +1,443 @@
+import 'package:flutter/material.dart';
+import 'createTournamentBlindDetail.dart';
+
+class CreateTournamentBlindBasic extends StatefulWidget {
+  final String tournamentTemplateId;
+  final String tournamentTemplateName;
+  final Map<String, dynamic>? existingBlindTemplate; // 編集用の既存データ
+
+  const CreateTournamentBlindBasic({
+    super.key,
+    required this.tournamentTemplateId,
+    required this.tournamentTemplateName,
+    this.existingBlindTemplate,
+  });
+
+  @override
+  State<CreateTournamentBlindBasic> createState() => _CreateTournamentBlindBasicState();
+}
+
+class _CreateTournamentBlindBasicState extends State<CreateTournamentBlindBasic> {
+  final _formKey = GlobalKey<FormState>();
+  final _blindNameController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  
+  int _numberOfBlindLevels = 30;
+  int _defaultStartingChips = 10000;
+  int _blindIntervalBeforeReg = 15;
+  int _blindIntervalAfterReg = 15;
+  String _anteType = 'BBA';
+  int _lateRegUntilLevel = 3;
+  int _breakTime = 10;
+  String _startingBlindType = '100/200';
+
+  final List<String> _anteTypes = [
+    'BBA',
+    'None',
+  ];
+
+  final List<String> _startingBlindTypes = [
+    '100/200',
+    '100/100',
+  ];
+
+  final List<int> _breakTimeOptions = [5, 10, 15, 20, 25, 30];
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // 編集モードの場合、既存データで初期値を設定
+    if (widget.existingBlindTemplate != null) {
+      final template = widget.existingBlindTemplate!;
+      _blindNameController.text = template['blindName'] ?? '';
+      _descriptionController.text = template['description'] ?? '';
+      _numberOfBlindLevels = template['numberOfBlindLevels'] ?? 30;
+      _defaultStartingChips = template['defaultStartingChips'] ?? 10000;
+      _blindIntervalBeforeReg = template['blindIntervalBeforeRegLev'] ?? 15;
+      _blindIntervalAfterReg = template['blindIntervalAfterRegLev'] ?? 15;
+      _anteType = template['anteType'] ?? 'BBA';
+      _lateRegUntilLevel = template['lateRegUntilLev'] ?? 3;
+      _breakTime = template['breakDuration'] ?? 10;
+      
+      // 開始ブラインドタイプを推定（既存データから）
+      final levels = template['levels'] as List? ?? [];
+      if (levels.isNotEmpty) {
+        final firstLevel = levels.first;
+        final smallBlind = firstLevel['smallBlind'] ?? 0;
+        final bigBlind = firstLevel['bigBlind'] ?? 0;
+        
+        if (smallBlind == 100 && bigBlind == 100) {
+          _startingBlindType = '100/100';
+        } else {
+          _startingBlindType = '100/200';
+        }
+      }
+    }
+  }
+
+  /// 詳細入力ページに遷移する
+  void _navigateToDetail() {
+    if (_formKey.currentState!.validate()) {
+      final basicData = {
+        'blindName': _blindNameController.text.trim(),
+        'description': _descriptionController.text.trim(),
+        'numberOfBlindLevels': _numberOfBlindLevels,
+        'defaultStartingChips': _defaultStartingChips,
+        'blindIntervalBeforeReg': _blindIntervalBeforeReg,
+        'blindIntervalAfterReg': _blindIntervalAfterReg,
+        'anteType': _anteType,
+        'lateRegUntilLevel': _lateRegUntilLevel,
+        'breakTime': _breakTime,
+        'startingBlindType': _startingBlindType,
+        'tournamentTemplateId': widget.tournamentTemplateId,
+        'tournamentTemplateName': widget.tournamentTemplateName,
+      };
+
+      // デバッグログ: 送信するデータを確認
+      print('=== デバッグ: 送信する基本データ ===');
+      print('startingBlindType: ${_startingBlindType}');
+      print('basicData[\'startingBlindType\']: ${basicData['startingBlindType']}');
+      print('=====================================');
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => CreateTournamentBlindDetail(
+            basicData: basicData,
+            existingBlindTemplate: widget.existingBlindTemplate,
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.existingBlindTemplate != null 
+          ? 'ブラインドテンプレート編集 - 基本設定' 
+          : 'ブラインドテンプレート作成 - 基本設定'),
+        backgroundColor: Colors.purple,
+        foregroundColor: Colors.white,
+      ),
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // トーナメントテンプレート情報
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'トーナメントテンプレート',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.purple,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        widget.tournamentTemplateName,
+                        style: const TextStyle(fontSize: 16),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+
+              // ブラインド名
+              TextFormField(
+                controller: _blindNameController,
+                decoration: const InputDecoration(
+                  labelText: 'ブラインドテンプレート名 *',
+                  border: OutlineInputBorder(),
+                  hintText: '例: 標準ブラインド',
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'ブラインドテンプレート名を入力してください';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // 説明
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: '説明',
+                  border: OutlineInputBorder(),
+                  hintText: 'ブラインドテンプレートの説明',
+                ),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 16),
+
+
+
+              // 基本設定
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        '基本設定',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.blue,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+
+                                             // ブラインドレベル数と開始チップ数
+                       Row(
+                         children: [
+                           Expanded(
+                             child: TextFormField(
+                               initialValue: _numberOfBlindLevels.toString(),
+                               decoration: const InputDecoration(
+                                 labelText: 'ブラインドレベル数 *',
+                                 border: OutlineInputBorder(),
+                               ),
+                               keyboardType: TextInputType.number,
+                               validator: (value) {
+                                 if (value == null || value.isEmpty) {
+                                   return 'ブラインドレベル数を入力してください';
+                                 }
+                                 final number = int.tryParse(value);
+                                 if (number == null || number <= 0) {
+                                   return '有効な数値を入力してください';
+                                 }
+                                 return null;
+                               },
+                               onChanged: (value) {
+                                 _numberOfBlindLevels = int.tryParse(value) ?? 30;
+                               },
+                             ),
+                           ),
+                           const SizedBox(width: 16),
+                           Expanded(
+                             child: TextFormField(
+                               initialValue: _defaultStartingChips.toString(),
+                               decoration: const InputDecoration(
+                                 labelText: '開始チップ数 *',
+                                 border: OutlineInputBorder(),
+                               ),
+                               keyboardType: TextInputType.number,
+                               validator: (value) {
+                                 if (value == null || value.isEmpty) {
+                                   return '開始チップ数を入力してください';
+                                 }
+                                 final number = int.tryParse(value);
+                                 if (number == null || number <= 0) {
+                                   return '有効な数値を入力してください';
+                                 }
+                                 return null;
+                               },
+                               onChanged: (value) {
+                                 _defaultStartingChips = int.tryParse(value) ?? 10000;
+                               },
+                             ),
+                           ),
+                         ],
+                       ),
+                       const SizedBox(height: 16),
+
+                       // レジスト前・レジスト後ブラインド間隔
+                       Row(
+                         children: [
+                           Expanded(
+                             child: TextFormField(
+                               initialValue: _blindIntervalBeforeReg.toString(),
+                               decoration: const InputDecoration(
+                                 labelText: 'レジスト前ブラインド間隔（分） *',
+                                 border: OutlineInputBorder(),
+                               ),
+                               keyboardType: TextInputType.number,
+                               validator: (value) {
+                                 if (value == null || value.isEmpty) {
+                                   return 'レジスト前ブラインド間隔を入力してください';
+                                 }
+                                 final number = int.tryParse(value);
+                                 if (number == null || number <= 0) {
+                                   return '有効な数値を入力してください';
+                                 }
+                                 return null;
+                               },
+                               onChanged: (value) {
+                                 _blindIntervalBeforeReg = int.tryParse(value) ?? 15;
+                               },
+                             ),
+                           ),
+                           const SizedBox(width: 16),
+                           Expanded(
+                             child: TextFormField(
+                               initialValue: _blindIntervalAfterReg.toString(),
+                               decoration: const InputDecoration(
+                                 labelText: 'レジスト後ブラインド間隔（分） *',
+                                 border: OutlineInputBorder(),
+                               ),
+                               keyboardType: TextInputType.number,
+                               validator: (value) {
+                                 if (value == null || value.isEmpty) {
+                                   return 'レジスト後ブラインド間隔を入力してください';
+                                 }
+                                 final number = int.tryParse(value);
+                                 if (number == null || number <= 0) {
+                                   return '有効な数値を入力してください';
+                                 }
+                                 return null;
+                               },
+                               onChanged: (value) {
+                                 _blindIntervalAfterReg = int.tryParse(value) ?? 15;
+                               },
+                             ),
+                           ),
+                         ],
+                       ),
+                      const SizedBox(height: 16),
+
+                                             // 開始ブラインド
+                       DropdownButtonFormField<String>(
+                         value: _startingBlindType,
+                         decoration: const InputDecoration(
+                           labelText: '開始ブラインド *',
+                           border: OutlineInputBorder(),
+                         ),
+                         items: _startingBlindTypes.map((type) {
+                           return DropdownMenuItem(
+                             value: type,
+                             child: Text(type),
+                           );
+                         }).toList(),
+                         onChanged: (value) {
+                           if (value != null) {
+                             setState(() {
+                               _startingBlindType = value;
+                             });
+                           }
+                         },
+                       ),
+                      const SizedBox(height: 16),
+
+                                             // アンティタイプとレイトレジ
+                       Row(
+                         children: [
+                           Expanded(
+                             child: DropdownButtonFormField<String>(
+                               value: _anteType,
+                               decoration: const InputDecoration(
+                                 labelText: 'アンティタイプ *',
+                                 border: OutlineInputBorder(),
+                               ),
+                               items: _anteTypes.map((type) {
+                                 return DropdownMenuItem(
+                                   value: type,
+                                   child: Text(type == 'BBA' ? 'BBA' : 'なし'),
+                                 );
+                               }).toList(),
+                               onChanged: (value) {
+                                 if (value != null) {
+                                   setState(() {
+                                     _anteType = value;
+                                   });
+                                 }
+                               },
+                             ),
+                           ),
+                           const SizedBox(width: 16),
+                           Expanded(
+                             child: DropdownButtonFormField<int>(
+                               value: _lateRegUntilLevel,
+                               decoration: const InputDecoration(
+                                 labelText: 'レイトレジ終了レベル *',
+                                 border: OutlineInputBorder(),
+                               ),
+                               items: List.generate(_numberOfBlindLevels, (index) {
+                                 return DropdownMenuItem(
+                                   value: index + 1,
+                                   child: Text('レベル ${index + 1}'),
+                                 );
+                               }),
+                               onChanged: (value) {
+                                 if (value != null) {
+                                   setState(() {
+                                     _lateRegUntilLevel = value;
+                                   });
+                                 }
+                               },
+                             ),
+                           ),
+                         ],
+                       ),
+                      const SizedBox(height: 16),
+
+                                             // ブレイク時間
+                       DropdownButtonFormField<int>(
+                         value: _breakTime,
+                         decoration: const InputDecoration(
+                           labelText: 'ブレイク時間（分） *',
+                           border: OutlineInputBorder(),
+                         ),
+                         items: _breakTimeOptions.map((time) {
+                           return DropdownMenuItem(
+                             value: time,
+                             child: Text('${time}分'),
+                           );
+                         }).toList(),
+                         onChanged: (value) {
+                           if (value != null) {
+                             setState(() {
+                               _breakTime = value;
+                             });
+                           }
+                         },
+                       ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 32),
+
+              // 詳細設定ボタン
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: _navigateToDetail,
+                  icon: const Icon(Icons.arrow_forward),
+                  label: const Text('詳細設定へ進む'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.purple,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _blindNameController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/Tournament/createTournamentBlindDetail.dart
+++ b/lib/Tournament/createTournamentBlindDetail.dart
@@ -1,0 +1,641 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+class CreateTournamentBlindDetail extends StatefulWidget {
+  final Map<String, dynamic> basicData;
+  final Map<String, dynamic>? existingBlindTemplate; // 編集用の既存データ
+
+  const CreateTournamentBlindDetail({
+    super.key,
+    required this.basicData,
+    this.existingBlindTemplate,
+  });
+
+  @override
+  State<CreateTournamentBlindDetail> createState() => _CreateTournamentBlindDetailState();
+}
+
+class _CreateTournamentBlindDetailState extends State<CreateTournamentBlindDetail> {
+  final _formKey = GlobalKey<FormState>();
+  List<Map<String, dynamic>> _blindLevels = [];
+  bool _isLoading = true;
+  bool _isSaving = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _generateBlindLevels();
+  }
+
+  @override
+  void didUpdateWidget(CreateTournamentBlindDetail oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // 基本データが変更された場合、ブラインドレベルを再生成
+    if (oldWidget.basicData != widget.basicData) {
+      _generateBlindLevels();
+    }
+  }
+
+  /// 基本データからブラインドレベルを自動生成する
+  void _generateBlindLevels() {
+    setState(() {
+      _isLoading = true;
+    });
+
+    // 既存のブラインドテンプレートがある場合はそれを使用
+    if (widget.existingBlindTemplate != null) {
+      final existingLevels = widget.existingBlindTemplate!['levels'] as List? ?? [];
+      _blindLevels = existingLevels.map((level) {
+        final Map<String, dynamic> convertedLevel = {};
+        (level as Map).forEach((key, value) {
+          // null値を適切なデフォルト値に変換
+          if (key == 'hasBreakAfter') {
+            convertedLevel[key.toString()] = value ?? false;
+          } else if (key == 'isLateReg') {
+            convertedLevel[key.toString()] = value ?? false;
+          } else if (key == 'ante') {
+            convertedLevel[key.toString()] = value ?? 0;
+          } else if (key == 'endTime') {
+            convertedLevel[key.toString()] = value ?? 0;
+          } else if (key == 'timeFromLastBreak') {
+            convertedLevel[key.toString()] = value ?? 0;
+          } else if (key == 'breakDuration') {
+            convertedLevel[key.toString()] = value ?? 0;
+          } else {
+            convertedLevel[key.toString()] = value;
+          }
+        });
+        return convertedLevel;
+      }).toList();
+      _calculateTimes();
+      setState(() {
+        _isLoading = false;
+      });
+      return;
+    }
+
+    // 新規作成の場合
+    final numberOfLevels = widget.basicData['numberOfBlindLevels'] as int;
+    final startingBlindType = widget.basicData['startingBlindType'] as String;
+    final anteType = widget.basicData['anteType'] as String;
+    final lateRegUntilLevel = widget.basicData['lateRegUntilLevel'] as int;
+    final blindIntervalBeforeReg = widget.basicData['blindIntervalBeforeReg'] as int;
+    final blindIntervalAfterReg = widget.basicData['blindIntervalAfterReg'] as int;
+    final breakTime = widget.basicData['breakTime'] as int;
+
+    // デバッグログ: 受け取ったデータを確認
+    print('=== デバッグ: 受け取った基本データ ===');
+    print('startingBlindType: $startingBlindType');
+    print('numberOfLevels: $numberOfLevels');
+    print('lateRegUntilLevel: $lateRegUntilLevel');
+    print('blindIntervalBeforeReg: $blindIntervalBeforeReg');
+    print('blindIntervalAfterReg: $blindIntervalAfterReg');
+    print('breakTime: $breakTime');
+    print('=====================================');
+
+    // まずレジスト期間中のブラインドを計算
+    List<Map<String, dynamic>> blindLevels = [];
+    
+    for (int index = 0; index < numberOfLevels; index++) {
+      final level = index + 1;
+      
+      // 開始ブラインドタイプに基づいてブラインドを計算
+      int smallBlind, bigBlind;
+      
+      if (level <= lateRegUntilLevel) {
+        // レジスト期間中のブラインド計算
+        print('レベル$level: startingBlindType = $startingBlindType'); // デバッグログ
+        
+        if (startingBlindType == '100/200') {
+          // 100/200(200)の場合
+          smallBlind = 100 * (1 << (index));
+          bigBlind = smallBlind * 2;
+          print('レベル$level: 100/200パターン - SB: $smallBlind, BB: $bigBlind'); // デバッグログ
+        } else {
+          // 100/100(100)の場合
+          if (index == 0) {
+            // 1回目は100/100
+            smallBlind = 100;
+            bigBlind = 100;
+            print('レベル$level: 100/100パターン（1回目） - SB: $smallBlind, BB: $bigBlind'); // デバッグログ
+          } else if (index == 1) {
+            // 2回目は100/200
+            smallBlind = 100;
+            bigBlind = 200;
+            print('レベル$level: 100/100パターン（2回目） - SB: $smallBlind, BB: $bigBlind'); // デバッグログ
+          } else {
+            // 3回目以降は200/400, 400/800と倍になる
+            smallBlind = 200 * (1 << (index - 2));
+            bigBlind = smallBlind * 2;
+            print('レベル$level: 100/100パターン（3回目以降） - SB: $smallBlind, BB: $bigBlind'); // デバッグログ
+          }
+        }
+      } else {
+        // レジスト後のブラインド計算（カラーアップ）
+        if (level == lateRegUntilLevel + 1) {
+          // レジスト直後のブラインド（カラーアップ）
+          // BBが1000に届いていない場合は切り上げ、1000より大きい場合は切り捨て
+          final previousBigBlind = blindLevels[lateRegUntilLevel - 1]['bigBlind'] as int;
+          print('カラーアップ計算: レベル$level, 前のBB: $previousBigBlind'); // デバッグログ
+          
+          if (previousBigBlind < 1000) {
+            // 1000に届いていない場合は切り上げ
+            smallBlind = 1000;
+          } else {
+            // 1000より大きい場合は1000単位に切り捨て
+            smallBlind = (previousBigBlind ~/ 1000) * 1000;
+          }
+          
+          bigBlind = smallBlind * 2;
+          print('カラーアップ結果: SB: $smallBlind, BB: $bigBlind'); // デバッグログ
+        } else {
+          // レジスト後2番目以降のブラインド（通常の倍増）
+          final previousSmallBlind = blindLevels[level - 2]['smallBlind'] as int;
+          smallBlind = previousSmallBlind * 2;
+          bigBlind = smallBlind * 2;
+        }
+      }
+      
+      final ante = anteType == 'BBA' ? bigBlind : 0;
+      final duration = level <= lateRegUntilLevel ? blindIntervalBeforeReg : blindIntervalAfterReg;
+      
+      // レイトレジ終了レベルには必ずブレイクを挿入
+      final hasBreakAfter = level == lateRegUntilLevel;
+      
+      blindLevels.add({
+        'level': level,
+        'smallBlind': smallBlind,
+        'bigBlind': bigBlind,
+        'ante': ante,
+        'duration': duration,
+        'isLateReg': level <= lateRegUntilLevel,
+        'isBreak': false, // デフォルトではブレイクなし
+        'hasBreakAfter': hasBreakAfter, // レイトレジ終了レベルには必ずブレイク
+        'breakDuration': hasBreakAfter ? breakTime : 0,
+        'endTime': 0, // 終了時間（後で計算）
+        'timeFromLastBreak': 0, // 前回ブレイクからの時間（後で計算）
+      });
+    }
+
+    _blindLevels = blindLevels;
+
+    // 時間計算を行う
+    _calculateTimes();
+
+    setState(() {
+      _isLoading = false;
+    });
+  }
+
+  /// ブラインドレベルを再生成する（手動呼び出し用）
+  void _regenerateBlindLevels() {
+    _generateBlindLevels();
+  }
+
+  /// 各レベルの終了時間とブレイクからの時間を計算する
+  void _calculateTimes() {
+    int currentTime = 0; // トーナメント開始からの時間（分）
+    int timeFromLastBreak = 0; // 前回ブレイクからの時間（分）
+    final breakTime = widget.basicData['breakTime'] as int;
+
+    for (int i = 0; i < _blindLevels.length; i++) {
+      final level = _blindLevels[i];
+      
+      // このレベルの持続時間を加算
+      currentTime += level['duration'] as int;
+      timeFromLastBreak += level['duration'] as int;
+      
+      // 終了時間を設定（ブレイク時間は含まない）
+      level['endTime'] = currentTime;
+      
+      // 前回ブレイクからの時間を設定（当該ブラインド終了時点）
+      level['timeFromLastBreak'] = timeFromLastBreak;
+      
+      // ブレイクがある場合は時間を追加（次のレベルの計算用）
+      if (level['hasBreakAfter'] == true) {
+        currentTime += breakTime;
+        timeFromLastBreak = 0; // ブレイク後はリセット
+      }
+    }
+  }
+
+
+
+  /// ブラインドレベルを更新する
+  void _updateBlindLevel(int index, String field, dynamic value) {
+    setState(() {
+      _blindLevels[index][field] = value;
+    });
+  }
+
+  /// 時間をフォーマットする（分を時間:分の形式に変換）
+  String _formatTime(dynamic minutes) {
+    final mins = minutes ?? 0;
+    final hours = mins ~/ 60;
+    final remainingMins = mins % 60;
+    if (hours > 0) {
+      return '${hours}時間${remainingMins}分';
+    } else {
+      return '${remainingMins}分';
+    }
+  }
+
+  /// ブラインドテンプレートを保存する
+  Future<void> _saveBlindTemplate() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() {
+      _isSaving = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final functions = FirebaseFunctions.instance;
+      
+      // 編集モードかどうかで呼び出す関数を分ける
+      final isEditMode = widget.existingBlindTemplate != null;
+      final functionName = isEditMode ? 'updateBlindTemplate' : 'createBlindTemplate';
+      final callable = functions.httpsCallable(functionName);
+
+      // Cloud Functionsに送信するデータを構築
+      final blindTemplateData = {
+        if (isEditMode) 'blindTemplateId': widget.existingBlindTemplate!['id'],
+        'blindName': widget.basicData['blindName'],
+        'numberOfBlindLevels': widget.basicData['numberOfBlindLevels'],
+        'defaultStartingChips': widget.basicData['defaultStartingChips'],
+        'blindIntervalBeforeReg': widget.basicData['blindIntervalBeforeReg'],
+        'blindIntervalAfterReg': widget.basicData['blindIntervalAfterReg'],
+        'anteType': widget.basicData['anteType'],
+        'lateRegUntilLevel': widget.basicData['lateRegUntilLevel'],
+        'breakTime': widget.basicData['breakTime'],
+        'levels': _blindLevels.map((level) => ({
+          'ante': level['ante'],
+          'bigBlind': level['bigBlind'],
+          'duration': level['duration'],
+          'level': level['level'],
+          'smallBlind': level['smallBlind'],
+          'hasBreakAfter': level['hasBreakAfter'],
+          'endTime': level['endTime'],
+          'timeFromLastBreak': level['timeFromLastBreak'],
+        })).toList(),
+        'isArchive': false,
+      };
+
+      final result = await callable.call(blindTemplateData);
+      final response = result.data;
+
+      if (response['success'] == true) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(response['message'] ?? 
+            (isEditMode ? 'ブラインドテンプレートが正常に更新されました' : 'ブラインドテンプレートが正常に作成されました'))),
+        );
+        Navigator.pop(context, true); // 成功フラグを返す
+      } else {
+        setState(() {
+          _errorMessage = response['error'] ?? '保存に失敗しました';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = '保存に失敗しました: $e';
+      });
+    } finally {
+      setState(() {
+        _isSaving = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.existingBlindTemplate != null 
+          ? 'ブラインドテンプレート編集 - 詳細設定' 
+          : 'ブラインドテンプレート作成 - 詳細設定'),
+        backgroundColor: Colors.purple,
+        foregroundColor: Colors.white,
+        actions: [
+          if (_isSaving)
+            const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                ),
+              ),
+            ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Form(
+              key: _formKey,
+              child: Column(
+                children: [
+                  // 基本情報表示
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    color: Colors.grey[100],
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '${widget.basicData['blindName']}',
+                          style: const TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.purple,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                                                                         Text(
+                          'レベル数: ${widget.basicData['numberOfBlindLevels']} | '
+                          '開始ブラインド: ${widget.basicData['startingBlindType']} | '
+                          'レジスト前間隔: ${widget.basicData['blindIntervalBeforeReg']}分 | '
+                          'レジスト後間隔: ${widget.basicData['blindIntervalAfterReg']}分',
+                          style: const TextStyle(color: Colors.grey),
+                        ),
+                        const SizedBox(height: 8),
+                        ElevatedButton.icon(
+                          onPressed: _regenerateBlindLevels,
+                          icon: const Icon(Icons.refresh),
+                          label: const Text('ブラインドレベルを再計算'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.blue,
+                            foregroundColor: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  // エラーメッセージ
+                  if (_errorMessage != null)
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(16),
+                      color: Colors.red[100],
+                      child: Text(
+                        _errorMessage!,
+                        style: const TextStyle(color: Colors.red),
+                      ),
+                    ),
+
+                  // ブラインドレベル一覧
+                  Expanded(
+                    child: ListView.builder(
+                      padding: const EdgeInsets.all(16),
+                      itemCount: _blindLevels.length,
+                      itemBuilder: (context, index) {
+                        final level = _blindLevels[index];
+                        return Card(
+                          margin: const EdgeInsets.only(bottom: 8),
+                          child: ExpansionTile(
+                            title: Row(
+                              children: [
+                                Text(
+                                  'レベル ${level['level']}',
+                                  style: const TextStyle(fontWeight: FontWeight.bold),
+                                ),
+                                const SizedBox(width: 8),
+                                                                 if (level['isLateReg'] ?? false)
+                                   Container(
+                                     padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                                     decoration: BoxDecoration(
+                                       color: Colors.blue,
+                                       borderRadius: BorderRadius.circular(12),
+                                     ),
+                                     child: const Text(
+                                       'レイトレジスト',
+                                       style: TextStyle(color: Colors.white, fontSize: 12),
+                                     ),
+                                   ),
+                                 if (level['hasBreakAfter'] ?? false)
+                                   Container(
+                                     margin: const EdgeInsets.only(left: 8),
+                                     padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                                     decoration: BoxDecoration(
+                                       color: Colors.orange,
+                                       borderRadius: BorderRadius.circular(12),
+                                     ),
+                                     child: const Text(
+                                       'ブレイク',
+                                       style: TextStyle(color: Colors.white, fontSize: 12),
+                                     ),
+                                   ),
+                              ],
+                            ),
+                                                         subtitle: Column(
+                               crossAxisAlignment: CrossAxisAlignment.start,
+                               children: [
+                                 Text(
+                                   'SB: ${level['smallBlind']} / BB: ${level['bigBlind']}${(level['ante'] ?? 0) > 0 ? ' / Ante: ${level['ante']}' : ''}',
+                                   style: const TextStyle(color: Colors.grey),
+                                 ),
+                                 Text(
+                                   '開始後${_formatTime(level['endTime'])}まで | 前回ブレイクから${_formatTime(level['timeFromLastBreak'])}経過（当該ブラインド終了時点）',
+                                   style: const TextStyle(color: Colors.blue, fontSize: 12),
+                                 ),
+                               ],
+                             ),
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Column(
+                                  children: [
+                                    // スモールブラインド
+                                    TextFormField(
+                                      initialValue: level['smallBlind'].toString(),
+                                      decoration: const InputDecoration(
+                                        labelText: 'スモールブラインド',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      keyboardType: TextInputType.number,
+                                      validator: (value) {
+                                        if (value == null || value.isEmpty) {
+                                          return 'スモールブラインドを入力してください';
+                                        }
+                                        final number = int.tryParse(value);
+                                        if (number == null || number <= 0) {
+                                          return '有効な数値を入力してください';
+                                        }
+                                        return null;
+                                      },
+                                      onChanged: (value) {
+                                        final smallBlind = int.tryParse(value) ?? 0;
+                                        _updateBlindLevel(index, 'smallBlind', smallBlind);
+                                        _updateBlindLevel(index, 'bigBlind', smallBlind * 2);
+                                        if (widget.basicData['anteType'] == 'BBA') {
+                                          _updateBlindLevel(index, 'ante', smallBlind * 2);
+                                        }
+                                      },
+                                    ),
+                                    const SizedBox(height: 16),
+
+                                    // ビッグブラインド
+                                    TextFormField(
+                                      initialValue: level['bigBlind'].toString(),
+                                      decoration: const InputDecoration(
+                                        labelText: 'ビッグブラインド',
+                                        border: OutlineInputBorder(),
+                                      ),
+                                      keyboardType: TextInputType.number,
+                                      validator: (value) {
+                                        if (value == null || value.isEmpty) {
+                                          return 'ビッグブラインドを入力してください';
+                                        }
+                                        final number = int.tryParse(value);
+                                        if (number == null || number <= 0) {
+                                          return '有効な数値を入力してください';
+                                        }
+                                        return null;
+                                      },
+                                      onChanged: (value) {
+                                        final bigBlind = int.tryParse(value) ?? 0;
+                                        _updateBlindLevel(index, 'bigBlind', bigBlind);
+                                        if (widget.basicData['anteType'] == 'BBA') {
+                                          _updateBlindLevel(index, 'ante', bigBlind);
+                                        }
+                                      },
+                                    ),
+                                    const SizedBox(height: 16),
+
+                                    // アンティ
+                                    if (widget.basicData['anteType'] == 'BBA')
+                                      TextFormField(
+                                        initialValue: level['ante'].toString(),
+                                        decoration: const InputDecoration(
+                                          labelText: 'アンティ',
+                                          border: OutlineInputBorder(),
+                                        ),
+                                        keyboardType: TextInputType.number,
+                                        validator: (value) {
+                                          if (value == null || value.isEmpty) {
+                                            return 'アンティを入力してください';
+                                          }
+                                          final number = int.tryParse(value);
+                                          if (number == null || number < 0) {
+                                            return '有効な数値を入力してください';
+                                          }
+                                          return null;
+                                        },
+                                        onChanged: (value) {
+                                          final ante = int.tryParse(value) ?? 0;
+                                          _updateBlindLevel(index, 'ante', ante);
+                                        },
+                                      ),
+
+                                    const SizedBox(height: 16),
+
+                                                                         // 持続時間
+                                     TextFormField(
+                                       initialValue: level['duration'].toString(),
+                                       decoration: const InputDecoration(
+                                         labelText: '持続時間（分）',
+                                         border: OutlineInputBorder(),
+                                       ),
+                                       keyboardType: TextInputType.number,
+                                       validator: (value) {
+                                         if (value == null || value.isEmpty) {
+                                           return '持続時間を入力してください';
+                                         }
+                                         final number = int.tryParse(value);
+                                         if (number == null || number <= 0) {
+                                           return '有効な数値を入力してください';
+                                         }
+                                         return null;
+                                       },
+                                       onChanged: (value) {
+                                         final duration = int.tryParse(value) ?? 0;
+                                         _updateBlindLevel(index, 'duration', duration);
+                                         // 時間を再計算
+                                         _calculateTimes();
+                                       },
+                                     ),
+
+                                    const SizedBox(height: 16),
+
+                                    // ブレイク設定
+                                                                     if (level['hasBreakAfter'] ?? false)
+                                   TextFormField(
+                                     initialValue: widget.basicData['breakTime'].toString(),
+                                     decoration: const InputDecoration(
+                                       labelText: 'ブレイク時間（分）',
+                                       border: OutlineInputBorder(),
+                                     ),
+                                     keyboardType: TextInputType.number,
+                                     validator: (value) {
+                                       if (value == null || value.isEmpty) {
+                                         return 'ブレイク時間を入力してください';
+                                       }
+                                       final number = int.tryParse(value);
+                                       if (number == null || number < 0) {
+                                         return '有効な数値を入力してください';
+                                       }
+                                       return null;
+                                     },
+                                                                            onChanged: (value) {
+                                         final breakDuration = int.tryParse(value) ?? 0;
+                                         _updateBlindLevel(index, 'breakDuration', breakDuration);
+                                         // 時間を再計算
+                                         _calculateTimes();
+                                       },
+                                     ),
+
+                                                                         const SizedBox(height: 16),
+
+                                     // ブレイク挿入設定
+                                     SwitchListTile(
+                                       title: const Text('ブレイクの挿入'),
+                                       subtitle: const Text('このレベル終了後にブレイクを挿入'),
+                                       value: level['hasBreakAfter'] ?? false,
+                                       onChanged: (value) {
+                                         _updateBlindLevel(index, 'hasBreakAfter', value);
+                                         // ブレイク時間を設定
+                                         if (value) {
+                                           _updateBlindLevel(index, 'breakDuration', widget.basicData['breakTime']);
+                                         } else {
+                                           _updateBlindLevel(index, 'breakDuration', 0);
+                                         }
+                                         // 時間を再計算
+                                         _calculateTimes();
+                                       },
+                                     ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+
+                  // 保存ボタン
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton.icon(
+                        onPressed: _isSaving ? null : _saveBlindTemplate,
+                        icon: const Icon(Icons.save),
+                        label: const Text('ブラインドテンプレートを保存'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.purple,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/Tournament/tournamentBlindTemplateList.dart
+++ b/lib/Tournament/tournamentBlindTemplateList.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'createTournamentBlindBasic.dart';
+
+class TournamentBlindTemplateList extends StatefulWidget {
+  final String tournamentTemplateId;
+  final String tournamentTemplateName;
+
+  const TournamentBlindTemplateList({
+    super.key,
+    required this.tournamentTemplateId,
+    required this.tournamentTemplateName,
+  });
+
+  @override
+  State<TournamentBlindTemplateList> createState() => _TournamentBlindTemplateListState();
+}
+
+class _TournamentBlindTemplateListState extends State<TournamentBlindTemplateList> {
+  List<Map<String, dynamic>> _blindTemplates = [];
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBlindTemplates();
+  }
+
+  /// ブラインドテンプレートを読み込む
+  Future<void> _loadBlindTemplates() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('getBlindTemplates');
+
+      final result = await callable.call();
+      final response = result.data;
+
+      if (response['success'] == true) {
+        setState(() {
+          // Cloud Functionsから返されるデータを適切な型に変換
+          final rawTemplates = response['blindTemplates'] as List? ?? [];
+          _blindTemplates = rawTemplates.map((template) {
+            final Map<String, dynamic> convertedTemplate = {};
+            (template as Map).forEach((key, value) {
+              convertedTemplate[key.toString()] = value;
+            });
+            return convertedTemplate;
+          }).toList();
+          _isLoading = false;
+        });
+      } else {
+        setState(() {
+          _errorMessage = response['error'] ?? 'ブラインドテンプレートの取得に失敗しました';
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'ブラインドテンプレートの取得に失敗しました: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// ブラインドテンプレートをアーカイブする
+  Future<void> _archiveBlindTemplate(String blindTemplateId) async {
+    try {
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('archiveBlindTemplate');
+
+      final result = await callable.call({'blindTemplateId': blindTemplateId});
+      final response = result.data;
+
+      if (response['success'] == true) {
+        setState(() {
+          _blindTemplates.removeWhere((template) => template['id'] == blindTemplateId);
+        });
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(response['message'] ?? 'ブラインドテンプレートをアーカイブしました')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(response['error'] ?? 'アーカイブに失敗しました')),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('アーカイブに失敗しました: $e')),
+      );
+    }
+  }
+
+  /// ブラインドテンプレートの詳細を表示する
+  void _showBlindTemplateDetail(Map<String, dynamic> blindTemplate) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(blindTemplate['blindName'] ?? '無名テンプレート'),
+          content: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('レベル数: ${blindTemplate['numberOfBlindLevels']}'),
+                Text('開始チップ数: ${blindTemplate['defaultStartingChips']}'),
+                Text('レジスト前間隔: ${blindTemplate['blindIntervalBeforeRegLev']}分'),
+                Text('レジスト後間隔: ${blindTemplate['blindIntervalAfterRegLev']}分'),
+                Text('レジスト終了レベル: ${blindTemplate['lateRegUntilLev']}'),
+                Text('アンティタイプ: ${blindTemplate['anteType']}'),
+                Text('ブレイク時間: ${blindTemplate['breakDuration']}分'),
+                const SizedBox(height: 16),
+                const Text('ブラインドレベル:', style: TextStyle(fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                ...(blindTemplate['levels'] as List? ?? []).take(5).map((level) => 
+                  Text('レベル${level['level']}: ${level['smallBlind']}/${level['bigBlind']} (${level['duration']}分)')
+                ).toList(),
+                if ((blindTemplate['levels'] as List? ?? []).length > 5)
+                  Text('... (他${(blindTemplate['levels'] as List).length - 5}レベル)'),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('閉じる'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// アーカイブ確認ダイアログを表示する
+  void _showArchiveDialog(String blindTemplateId, String blindTemplateName) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('ブラインドテンプレートアーカイブ'),
+          content: Text('「$blindTemplateName」をアーカイブしますか？\nアーカイブされたテンプレートは一覧から非表示になります。'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('キャンセル'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _archiveBlindTemplate(blindTemplateId);
+              },
+              child: const Text('アーカイブ', style: TextStyle(color: Colors.orange)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${widget.tournamentTemplateName} - ブラインドテンプレート'),
+        backgroundColor: Colors.purple,
+        foregroundColor: Colors.white,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _isLoading ? null : _loadBlindTemplates,
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _errorMessage != null
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(_errorMessage!, style: const TextStyle(color: Colors.red)),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _loadBlindTemplates,
+                        child: const Text('再試行'),
+                      ),
+                    ],
+                  ),
+                )
+              : _blindTemplates.isEmpty
+                  ? const Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.casino, size: 64, color: Colors.grey),
+                          SizedBox(height: 16),
+                          Text(
+                            'ブラインドテンプレートがありません',
+                            style: TextStyle(fontSize: 18, color: Colors.grey),
+                          ),
+                          SizedBox(height: 8),
+                          Text(
+                            '新しいブラインドテンプレートを作成してください',
+                            style: TextStyle(fontSize: 14, color: Colors.grey),
+                          ),
+                        ],
+                      ),
+                    )
+                  : ListView.builder(
+                      padding: const EdgeInsets.all(16),
+                      itemCount: _blindTemplates.length,
+                      itemBuilder: (context, index) {
+                        final blindTemplate = _blindTemplates[index];
+                        return Card(
+                          margin: const EdgeInsets.only(bottom: 12),
+                          child: ListTile(
+                            leading: const Icon(Icons.casino, color: Colors.purple),
+                            title: Text(
+                              blindTemplate['blindName'] ?? '無名ブラインド',
+                              style: const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            subtitle: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'ブラインドレベル数: ${blindTemplate['numberOfBlindLevels'] ?? 0}',
+                                  style: const TextStyle(color: Colors.grey),
+                                ),
+                                Text(
+                                  '開始チップ: ${blindTemplate['defaultStartingChips'] ?? 0}',
+                                  style: const TextStyle(color: Colors.blue),
+                                ),
+                                Text(
+                                  'レジスト前間隔: ${blindTemplate['blindIntervalBeforeRegLev'] ?? 0}分 | レジスト後間隔: ${blindTemplate['blindIntervalAfterRegLev'] ?? 0}分',
+                                  style: const TextStyle(color: Colors.orange),
+                                ),
+                                Text(
+                                  'レジストまでの時間: ${_calculateRegTime(blindTemplate)}',
+                                  style: const TextStyle(color: Colors.purple),
+                                ),
+                              ],
+                            ),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  icon: const Icon(Icons.edit, color: Colors.blue),
+                                  tooltip: '編集',
+                                  onPressed: () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (context) => CreateTournamentBlindBasic(
+                                          tournamentTemplateId: widget.tournamentTemplateId,
+                                          tournamentTemplateName: widget.tournamentTemplateName,
+                                          existingBlindTemplate: blindTemplate,
+                                        ),
+                                      ),
+                                    );
+                                  },
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.delete, color: Colors.red),
+                                  tooltip: 'アーカイブ',
+                                  onPressed: () {
+                                    _showArchiveDialog(
+                                      blindTemplate['id'],
+                                      blindTemplate['blindName'] ?? '無名ブラインド',
+                                    );
+                                  },
+                                ),
+                              ],
+                            ),
+                            onTap: () {
+                              _showBlindTemplateDetail(blindTemplate);
+                            },
+                          ),
+                        );
+                      },
+                    ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => CreateTournamentBlindBasic(
+                tournamentTemplateId: widget.tournamentTemplateId,
+                tournamentTemplateName: widget.tournamentTemplateName,
+              ),
+            ),
+          );
+        },
+        backgroundColor: Colors.purple,
+        foregroundColor: Colors.white,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  /// レジストまでの時間を計算する
+  String _calculateRegTime(Map<String, dynamic> blindTemplate) {
+    final lateRegUntilLevel = blindTemplate['lateRegUntilLev'] as int? ?? 0;
+    final blindIntervalBeforeReg = blindTemplate['blindIntervalBeforeRegLev'] as int? ?? 0;
+    
+    if (lateRegUntilLevel <= 0 || blindIntervalBeforeReg <= 0) {
+      return '計算不可';
+    }
+    
+    final totalMinutes = lateRegUntilLevel * blindIntervalBeforeReg;
+    final hours = totalMinutes ~/ 60;
+    final minutes = totalMinutes % 60;
+    
+    if (hours > 0) {
+      return '${hours}時間${minutes}分';
+    } else {
+      return '${minutes}分';
+    }
+  }
+}

--- a/lib/Tournament/tournamentHomePage.dart
+++ b/lib/Tournament/tournamentHomePage.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'tournamentTemplateList.dart';
+
+class TournamentHomePage extends StatefulWidget {
+  const TournamentHomePage({super.key});
+
+  @override
+  State<TournamentHomePage> createState() => _TournamentHomePageState();
+}
+
+class _TournamentHomePageState extends State<TournamentHomePage> {
+  List<Map<String, dynamic>> _upcomingTournaments = [];
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadUpcomingTournaments();
+  }
+
+  /// 開催予定のトーナメントを読み込む
+  Future<void> _loadUpcomingTournaments() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      // TODO: Firestoreから開催予定のトーナメントを取得
+      // 現在はダミーデータを使用
+      await Future.delayed(const Duration(milliseconds: 500));
+      
+      setState(() {
+        _upcomingTournaments = [
+          {
+            'id': '1',
+            'name': '週末トーナメント',
+            'date': DateTime.now().add(const Duration(days: 2)),
+            'status': 'upcoming',
+            'participants': 0,
+            'maxParticipants': 20,
+          },
+          {
+            'id': '2',
+            'name': '月曜夜トーナメント',
+            'date': DateTime.now().add(const Duration(days: 5)),
+            'status': 'upcoming',
+            'participants': 5,
+            'maxParticipants': 15,
+          },
+        ];
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'トーナメント情報の取得に失敗しました';
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('トーナメント管理'),
+        backgroundColor: Colors.blue,
+        foregroundColor: Colors.white,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _errorMessage != null
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(_errorMessage!, style: const TextStyle(color: Colors.red)),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _loadUpcomingTournaments,
+                        child: const Text('再試行'),
+                      ),
+                    ],
+                  ),
+                )
+              : Column(
+                  children: [
+                    // 開催予定トーナメント一覧
+                    Expanded(
+                      child: _upcomingTournaments.isEmpty
+                          ? const Center(
+                              child: Text(
+                                '開催予定のトーナメントはありません',
+                                style: TextStyle(fontSize: 16, color: Colors.grey),
+                              ),
+                            )
+                          : ListView.builder(
+                              padding: const EdgeInsets.all(16),
+                              itemCount: _upcomingTournaments.length,
+                              itemBuilder: (context, index) {
+                                final tournament = _upcomingTournaments[index];
+                                return Card(
+                                  margin: const EdgeInsets.only(bottom: 12),
+                                  child: ListTile(
+                                    title: Text(
+                                      tournament['name'],
+                                      style: const TextStyle(fontWeight: FontWeight.bold),
+                                    ),
+                                    subtitle: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          '開催日: ${_formatDate(tournament['date'])}',
+                                          style: const TextStyle(color: Colors.grey),
+                                        ),
+                                        Text(
+                                          '参加者: ${tournament['participants']}/${tournament['maxParticipants']}',
+                                          style: const TextStyle(color: Colors.blue),
+                                        ),
+                                      ],
+                                    ),
+                                    trailing: const Icon(Icons.arrow_forward_ios),
+                                    onTap: () {
+                                      // TODO: トーナメント詳細ページへの遷移
+                                    },
+                                  ),
+                                );
+                              },
+                            ),
+                    ),
+                    // テンプレート管理ボタン
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      child: SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton.icon(
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => const TournamentTemplateList(),
+                              ),
+                            );
+                          },
+                          icon: const Icon(Icons.list_alt),
+                          label: const Text('トーナメントテンプレート管理'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.green,
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // TODO: 新規トーナメント作成ページへの遷移
+        },
+        backgroundColor: Colors.orange,
+        foregroundColor: Colors.white,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  /// 日付をフォーマットする
+  String _formatDate(DateTime date) {
+    return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/Tournament/tournamentTemplateList.dart
+++ b/lib/Tournament/tournamentTemplateList.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'tournamentBlindTemplateList.dart';
+
+class TournamentTemplateList extends StatefulWidget {
+  const TournamentTemplateList({super.key});
+
+  @override
+  State<TournamentTemplateList> createState() => _TournamentTemplateListState();
+}
+
+class _TournamentTemplateListState extends State<TournamentTemplateList> {
+  List<Map<String, dynamic>> _templates = [];
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTemplates();
+  }
+
+  /// トーナメントテンプレートを読み込む
+  Future<void> _loadTemplates() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      // 現在はダミーデータを使用（トーナメントテンプレート用のCloud Functionは未実装）
+      await Future.delayed(const Duration(milliseconds: 500));
+      
+      setState(() {
+        _templates = [
+          {
+            'id': '1',
+            'name': '週末トーナメント',
+            'description': '週末開催の標準トーナメント',
+            'createdAt': DateTime.now().subtract(const Duration(days: 5)),
+          },
+          {
+            'id': '2',
+            'name': '月曜夜トーナメント',
+            'description': '月曜日の夜開催トーナメント',
+            'createdAt': DateTime.now().subtract(const Duration(days: 2)),
+          },
+          {
+            'id': '3',
+            'name': '金曜夜ターボ',
+            'description': '金曜日のターボトーナメント',
+            'createdAt': DateTime.now().subtract(const Duration(hours: 12)),
+          },
+        ];
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'テンプレートの取得に失敗しました: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// テンプレートを削除する
+  Future<void> _deleteTemplate(String templateId) async {
+    try {
+      // 現在はダミーの削除処理（トーナメントテンプレート用のCloud Functionは未実装）
+      await Future.delayed(const Duration(milliseconds: 300));
+      
+      setState(() {
+        _templates.removeWhere((template) => template['id'] == templateId);
+      });
+      
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('テンプレートを削除しました')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('削除に失敗しました: $e')),
+      );
+    }
+  }
+
+  /// 削除確認ダイアログを表示する
+  void _showDeleteDialog(String templateId, String templateName) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('テンプレート削除'),
+          content: Text('「$templateName」を削除しますか？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('キャンセル'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _deleteTemplate(templateId);
+              },
+              child: const Text('削除', style: TextStyle(color: Colors.red)),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('トーナメントテンプレート'),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.list_alt),
+            tooltip: 'ブラインドテンプレート管理',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const TournamentBlindTemplateList(
+                    tournamentTemplateId: 'dummy',
+                    tournamentTemplateName: 'ブラインドテンプレート管理',
+                  ),
+                ),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: '更新',
+            onPressed: _isLoading ? null : _loadTemplates,
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _errorMessage != null
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(_errorMessage!, style: const TextStyle(color: Colors.red)),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _loadTemplates,
+                        child: const Text('再試行'),
+                      ),
+                    ],
+                  ),
+                )
+              : _templates.isEmpty
+                  ? const Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.list_alt, size: 64, color: Colors.grey),
+                          SizedBox(height: 16),
+                          Text(
+                            'テンプレートがありません',
+                            style: TextStyle(fontSize: 18, color: Colors.grey),
+                          ),
+                          SizedBox(height: 8),
+                          Text(
+                            '新しいテンプレートを作成してください',
+                            style: TextStyle(fontSize: 14, color: Colors.grey),
+                          ),
+                        ],
+                      ),
+                    )
+                  : ListView.builder(
+                      padding: const EdgeInsets.all(16),
+                      itemCount: _templates.length,
+                      itemBuilder: (context, index) {
+                        final template = _templates[index];
+                        return Card(
+                          margin: const EdgeInsets.only(bottom: 12),
+                          child: ListTile(
+                            title: Text(
+                              template['name'] ?? '無名テンプレート',
+                              style: const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            subtitle: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  '説明: ${template['description'] ?? '説明なし'}',
+                                  style: const TextStyle(color: Colors.grey),
+                                ),
+                                Text(
+                                  '作成日: ${_formatDate(template['createdAt'])}',
+                                  style: const TextStyle(color: Colors.blue),
+                                ),
+                              ],
+                            ),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  icon: const Icon(Icons.edit, color: Colors.blue),
+                                  onPressed: () {
+                                    // TODO: テンプレート編集ページへの遷移
+                                  },
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.delete, color: Colors.red),
+                                  onPressed: () {
+                                    _showDeleteDialog(
+                                      template['id'],
+                                      template['name'] ?? '無名テンプレート',
+                                    );
+                                  },
+                                ),
+                              ],
+                            ),
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => TournamentBlindTemplateList(
+                                    tournamentTemplateId: template['id'],
+                                    tournamentTemplateName: template['name'] ?? '無名テンプレート',
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        );
+                      },
+                    ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // TODO: 新規トーナメントテンプレート作成ページへの遷移
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('新規トーナメントテンプレート作成機能は準備中です'),
+              duration: Duration(seconds: 2),
+            ),
+          );
+        },
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+        tooltip: '新規トーナメントテンプレート作成',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  /// 日付をフォーマットする
+  String _formatDate(dynamic date) {
+    if (date is DateTime) {
+      return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
+    }
+    return '日付不明';
+  }
+}


### PR DESCRIPTION
- Add Cloud Functions for blind template CRUD operations
- Implement archive functionality instead of delete
- Add Firestore indexes for blindTemplates collection
- Create Flutter UI for blind template management
- Add edit functionality with existing data preservation
- Fix null value handling in blind template editing
- Add detailed view popup for blind templates
- Implement proper data flow between Basic and Detail pages