### PR TITLE
プライズ確定機能とトーナメント終了処理の実装

### DIFF
--- a/functions/src/callables/bustAndExit.ts
+++ b/functions/src/callables/bustAndExit.ts
@@ -68,6 +68,17 @@ export const bustAndExit = functions.https.onCall(async (data, context) => {
       const viewsMainData = viewsMainDoc.data()!;
       const currentPlayersBusted = viewsMainData.playersBusted || 0;
 
+      // 6. bustedドキュメントを取得（読み取り操作を先に実行）
+      const bustedRef = db
+        .collection('scheduledTournaments')
+        .doc(tournamentId)
+        .collection('tablesSeat')
+        .doc('busted');
+
+      const bustedDoc = await transaction.get(bustedRef);
+      const bustedData = bustedDoc.exists ? bustedDoc.data()! : { bustedUser: {} };
+      const bustedUser = bustedData.bustedUser || {};
+
       // 全ての読み取りが完了したので、ここから書き込み操作を開始
 
       // 4. シートからユーザーを削除
@@ -84,6 +95,20 @@ export const bustAndExit = functions.https.onCall(async (data, context) => {
       transaction.update(viewsMainRef, {
         playersBusted: currentPlayersBusted + 1,
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+      // 6. bustedドキュメントに退席情報を追加
+      // プレイヤー名を取得
+      const pokerName = seats[seatPokerNameKey];
+      
+      // bustedUserに追加
+      bustedUser[userId] = {
+        pokerName: pokerName,
+        bustAt: admin.firestore.FieldValue.serverTimestamp(),
+      };
+
+      transaction.update(bustedRef, {
+        bustedUser: bustedUser,
       });
 
       return { success: true, userId, tableId, seatNumber };

--- a/functions/src/callables/createScheduledTournament.ts
+++ b/functions/src/callables/createScheduledTournament.ts
@@ -114,6 +114,7 @@ export const createScheduledTournament = onCall(async (request) => {
         entriesPerPayout: templateData.entriesPerPayout || 8,
         maxEntrants: templateData.maxEntrants || null,
         category: templateData.tournamentCategory || templateData.category || 'regular',
+        pointType: templateData.pointType || 'pointA', // テンプレートのpointTypeを継承
       },
     };
 
@@ -258,6 +259,10 @@ export const createScheduledTournament = onCall(async (request) => {
       // tablesSeat/waiting を作成
       const waitingRef = tournamentRef.collection('tablesSeat').doc('waiting');
       transaction.set(waitingRef, waitingListData);
+      
+      // tablesSeat/busted を作成（空のbustedUserマップ）
+      const bustedRef = tournamentRef.collection('tablesSeat').doc('busted');
+      transaction.set(bustedRef, { bustedUser: {} });
       
       // views/runtime を作成
       const runtimeRef = tournamentRef.collection('views').doc('runtime');

--- a/functions/src/callables/endTournament.ts
+++ b/functions/src/callables/endTournament.ts
@@ -1,0 +1,75 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const endTournament = onCall(async (request) => {
+  try {
+    const { tournamentId } = request.data;
+    
+    if (!tournamentId) {
+      throw new HttpsError('invalid-argument', 'tournamentId is required');
+    }
+    
+    const db = getFirestore();
+    
+    await db.runTransaction(async (transaction) => {
+      // 全ての読み取り操作を先に実行
+      
+      // 1. tablesSeatサブコレクションからテーブル一覧を取得
+      const tablesSeatSnapshot = await transaction.get(
+        db.collection('scheduledTournaments')
+          .doc(tournamentId)
+          .collection('tablesSeat')
+      );
+      
+      const tableNames: string[] = [];
+      tablesSeatSnapshot.forEach((doc) => {
+        if (doc.id !== 'waiting' && doc.id !== 'busted') {
+          tableNames.push(doc.id);
+        }
+      });
+      
+      // 2. 各テーブルの存在確認（読み取り操作）
+      const tableDocs = new Map<string, any>();
+      for (const tableName of tableNames) {
+        const tableRef = db.collection('tables').doc(tableName);
+        const tableDoc = await transaction.get(tableRef);
+        if (tableDoc.exists) {
+          tableDocs.set(tableName, tableDoc.data());
+        }
+      }
+      
+      // 全ての読み取りが完了したので、ここから書き込み操作を開始
+      
+      // 3. scheduledTournamentのステータスを更新
+      const tournamentRef = db.collection('scheduledTournaments').doc(tournamentId);
+      transaction.update(tournamentRef, {
+        status: 'ended',
+        endedAt: new Date(),
+      });
+      
+      // 4. 各テーブルのステータスをopenに変更
+      for (const tableName of tableNames) {
+        if (tableDocs.has(tableName)) {
+          const tableRef = db.collection('tables').doc(tableName);
+          transaction.update(tableRef, {
+            status: 'open',
+          });
+        }
+      }
+    });
+    
+    return {
+      success: true,
+      message: 'Tournament ended successfully',
+    };
+    
+  } catch (error) {
+    console.error('endTournament error:', error);
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'Internal server error');
+  }
+});

--- a/functions/src/callables/getActionLogs.ts
+++ b/functions/src/callables/getActionLogs.ts
@@ -1,0 +1,254 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { z } from "zod";
+
+// 入力スキーマの定義
+const getActionLogsSchema = z.object({
+  tournamentId: z.string().min(1, "トーナメントIDは必須です"),
+  deviceId: z.string().optional(), // 特定のデバイスの操作のみを取得する場合
+  limit: z.number().min(1).max(100).optional().default(50), // 取得件数制限
+  startAfter: z.string().optional(), // ページネーション用
+});
+
+export const getActionLogs = onCall(async (request) => {
+  try {
+    // 入力検証
+    const validatedData = getActionLogsSchema.parse(request.data);
+    const { tournamentId, deviceId, limit, startAfter } = validatedData;
+
+    const db = getFirestore();
+    
+    // クエリを構築
+    let query = db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('actionLog')
+      .orderBy('createdAt', 'desc')
+      .limit(limit);
+
+    // 特定のデバイスの操作のみを取得する場合
+    if (deviceId) {
+      query = query.where('deviceId', '==', deviceId);
+    }
+
+    // ページネーション
+    if (startAfter) {
+      const startAfterDoc = await db
+        .collection('scheduledTournaments')
+        .doc(tournamentId)
+        .collection('actionLog')
+        .doc(startAfter)
+        .get();
+      
+      if (startAfterDoc.exists) {
+        query = query.startAfter(startAfterDoc);
+      }
+    }
+
+    // クエリ実行
+    const querySnapshot = await query.get();
+    
+    console.log('=== Query Result Debug ===');
+    console.log('Query result docs count:', querySnapshot.docs.length);
+    if (querySnapshot.docs.length > 0) {
+      const firstDoc = querySnapshot.docs[0];
+      console.log('First doc ID:', firstDoc.id);
+      console.log('First doc data keys:', Object.keys(firstDoc.data()));
+      console.log('First doc createdAt:', firstDoc.data().createdAt);
+      console.log('First doc createdAt type:', typeof firstDoc.data().createdAt);
+      console.log('First doc createdAt constructor:', firstDoc.data().createdAt?.constructor?.name);
+    }
+    console.log('=== End Query Result Debug ===');
+    
+    // 結果を整形
+    const actionLogs = querySnapshot.docs.map(doc => {
+      const data = doc.data();
+      
+      // デバッグ用：createdAtの詳細をログ出力
+      console.log(`=== ActionLog createdAt Debug for ${doc.id} ===`);
+      console.log('createdAt raw:', data.createdAt);
+      console.log('createdAt type:', typeof data.createdAt);
+      console.log('createdAt has toDate:', typeof data.createdAt?.toDate === 'function');
+      console.log('createdAt keys:', Object.keys(data.createdAt || {}));
+      console.log('createdAt constructor:', data.createdAt?.constructor?.name);
+      console.log('createdAt prototype:', Object.getPrototypeOf(data.createdAt));
+      
+      // より詳細なデバッグ情報
+      if (data.createdAt && typeof data.createdAt === 'object') {
+        console.log('createdAt is object, checking properties:');
+        for (const key in data.createdAt) {
+          console.log(`  ${key}: ${data.createdAt[key]} (${typeof data.createdAt[key]})`);
+        }
+      }
+      
+      console.log('Full data object:', JSON.stringify(data, null, 2));
+      
+      let createdAt = null;
+      
+      // Firestore Timestampの場合
+      if (data.createdAt && typeof data.createdAt === 'object' && data.createdAt.constructor.name === 'Timestamp') {
+        try {
+          createdAt = data.createdAt.toDate();
+          console.log('Firestore Timestamp detected, toDate():', createdAt);
+        } catch (error) {
+          console.error('toDate() error:', error);
+          createdAt = data.createdAt;
+        }
+      }
+      // Firestore Admin SDK Timestampの場合
+      else if (data.createdAt instanceof Timestamp) {
+        try {
+          createdAt = data.createdAt.toDate();
+          console.log('Firestore Admin SDK Timestamp detected, toDate():', createdAt);
+        } catch (error) {
+          console.error('Admin SDK toDate() error:', error);
+          createdAt = data.createdAt;
+        }
+      }
+      // Firestore Timestampの別の形式（toDateメソッドを持つオブジェクト）
+      else if (data.createdAt && typeof data.createdAt === 'object' && typeof data.createdAt.toDate === 'function') {
+        try {
+          createdAt = data.createdAt.toDate();
+          console.log('Firestore Timestamp-like object with toDate() detected, converted:', createdAt);
+        } catch (error) {
+          console.error('toDate() method error:', error);
+          createdAt = data.createdAt;
+        }
+      }
+      // Firestore Timestampの別の形式（_seconds, _nanosecondsを持つオブジェクト）
+      else if (data.createdAt && typeof data.createdAt === 'object' && data.createdAt._seconds !== undefined) {
+        try {
+          const seconds = data.createdAt._seconds;
+          const nanoseconds = data.createdAt._nanoseconds || 0;
+          createdAt = new Date(seconds * 1000 + nanoseconds / 1000000);
+          console.log('Firestore Timestamp-like object detected, converted:', createdAt);
+        } catch (error) {
+          console.error('Timestamp-like conversion error:', error);
+          createdAt = data.createdAt;
+        }
+      }
+      // Firestore Timestampの別の形式（seconds, nanosecondsを持つオブジェクト）
+      else if (data.createdAt && typeof data.createdAt === 'object' && data.createdAt.seconds !== undefined) {
+        try {
+          const seconds = data.createdAt.seconds;
+          const nanoseconds = data.createdAt.nanoseconds || 0;
+          createdAt = new Date(seconds * 1000 + nanoseconds / 1000000);
+          console.log('Firestore Timestamp-like object (seconds/nanoseconds) detected, converted:', createdAt);
+        } catch (error) {
+          console.error('Timestamp-like conversion error (seconds/nanoseconds):', error);
+          createdAt = data.createdAt;
+        }
+      }
+      // 通常のDateオブジェクトの場合
+      else if (data.createdAt instanceof Date) {
+        createdAt = data.createdAt;
+        console.log('Date object detected:', createdAt);
+      }
+      // その他の場合
+      else if (data.createdAt) {
+        createdAt = data.createdAt;
+        console.log('Other type detected:', createdAt);
+      }
+      
+      // createdAtがnullまたは無効な場合は元のデータをそのまま使用
+      if (createdAt === null || createdAt === undefined) {
+        createdAt = data.createdAt;
+        console.log('createdAt fallback to original:', createdAt);
+      }
+      
+      // 最終的なcreatedAtが無効な場合の追加チェック
+      if (createdAt && typeof createdAt === 'object' && Object.keys(createdAt).length === 0) {
+        console.log('WARNING: createdAt is an empty object, attempting to recover from original data');
+        // 元のデータから再度タイムスタンプを抽出
+        if (data.createdAt && typeof data.createdAt === 'object') {
+          const keys = Object.keys(data.createdAt);
+          console.log('Original createdAt keys:', keys);
+          if (keys.includes('_seconds') || keys.includes('seconds')) {
+            const seconds = data.createdAt._seconds || data.createdAt.seconds;
+            const nanoseconds = data.createdAt._nanoseconds || data.createdAt.nanoseconds || 0;
+            if (seconds) {
+              createdAt = new Date(seconds * 1000 + nanoseconds / 1000000);
+              console.log('Recovered createdAt from original data:', createdAt);
+            }
+          }
+        }
+      }
+      
+      // 最後の手段：Firestoreのタイムスタンプ型を直接ISO文字列に変換
+      if (createdAt && typeof createdAt === 'object' && Object.keys(createdAt).length === 0) {
+        console.log('FINAL ATTEMPT: Converting Firestore Timestamp to ISO string');
+        try {
+          // Firestoreのタイムスタンプ型を直接ISO文字列に変換
+          if (data.createdAt && typeof data.createdAt === 'object') {
+            // タイムスタンプ型の場合は、直接ISO文字列に変換
+            if (data.createdAt.constructor && data.createdAt.constructor.name === 'Timestamp') {
+              createdAt = data.createdAt.toDate().toISOString();
+              console.log('Converted to ISO string:', createdAt);
+            } else if (typeof data.createdAt.toDate === 'function') {
+              createdAt = data.createdAt.toDate().toISOString();
+              console.log('Converted to ISO string via toDate():', createdAt);
+            }
+          }
+        } catch (error) {
+          console.error('Final conversion attempt failed:', error);
+        }
+      }
+      
+      // 最終的なcreatedAtの値をログ出力
+      console.log('Final createdAt value:', createdAt);
+      console.log('Final createdAt type:', typeof createdAt);
+      console.log('Final createdAt constructor:', createdAt?.constructor?.name);
+      
+      let rollBackAt = null;
+      if (data.rollBackAt?.toDate && typeof data.rollBackAt.toDate === 'function') {
+        rollBackAt = data.rollBackAt.toDate();
+      } else if (data.rollBackAt) {
+        rollBackAt = data.rollBackAt;
+      }
+      
+      const result = {
+        id: doc.id,
+        action: data.action,
+        deviceId: data.deviceId,
+        deviceName: data.deviceName,
+        targetUid: data.targetUid,
+        targetPlayerName: data.targetPlayerName,
+        tableId: data.tableId,
+        seatNumber: data.seatNumber,
+        details: data.details,
+        createdAt: createdAt,
+        isRollBack: data.isRollBack,
+        rollBackBy: data.rollBackBy,
+        rollBackAt: rollBackAt,
+      };
+      
+      console.log('Final result object:', JSON.stringify(result, null, 2));
+      return result;
+    });
+
+    // 次のページがあるかチェック
+    const hasNextPage = querySnapshot.docs.length === limit;
+    const lastDoc = querySnapshot.docs[querySnapshot.docs.length - 1];
+
+    return {
+      success: true,
+      actionLogs,
+      hasNextPage,
+      nextCursor: hasNextPage ? lastDoc.id : null,
+      totalCount: actionLogs.length,
+    };
+
+  } catch (error) {
+    console.error('アクションログ取得エラー:', error);
+    
+    if (error instanceof z.ZodError) {
+      throw new HttpsError('invalid-argument', `入力検証エラー: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'アクションログの取得に失敗しました');
+  }
+});

--- a/functions/src/callables/getPrizeData.ts
+++ b/functions/src/callables/getPrizeData.ts
@@ -1,0 +1,68 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+import { z } from 'zod';
+
+const getPrizeDataSchema = z.object({
+  tournamentId: z.string().min(1, 'tournamentId is required'),
+});
+
+export const getPrizeData = onCall(async (request) => {
+  try {
+    // 入力検証
+    const { tournamentId } = getPrizeDataSchema.parse(request.data);
+    
+    const db = getFirestore();
+    
+    // トーナメントデータを取得
+    const tournamentDoc = await db.collection('scheduledTournaments').doc(tournamentId).get();
+    
+    if (!tournamentDoc.exists) {
+      throw new HttpsError('not-found', 'Tournament not found');
+    }
+    
+    const tournamentData = tournamentDoc.data();
+    
+    // mainビューデータを取得
+    const mainViewDoc = await db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('views')
+      .doc('main')
+      .get();
+    
+    if (!mainViewDoc.exists) {
+      throw new HttpsError('not-found', 'Main view data not found');
+    }
+    
+    const mainViewData = mainViewDoc.data();
+    
+    // tournamentDataから料金情報を取得してmainViewDataに追加
+    const snapshot = tournamentData?.snapshot;
+    if (snapshot && mainViewData) {
+      mainViewData.entryFee = snapshot.entryFee || 0;
+      mainViewData.reentryFee = snapshot.reentryFee || 0;
+      mainViewData.addonFee = snapshot.addonFee || 0;
+      mainViewData.entryStack = snapshot.startStack || 0;
+      mainViewData.addonStack = snapshot.addonStack || 0;
+    }
+    
+    return {
+      success: true,
+      tournamentData,
+      mainViewData,
+    };
+    
+  } catch (error) {
+    console.error('getPrizeData error:', error);
+    
+    if (error instanceof z.ZodError) {
+      throw new HttpsError('invalid-argument', `Input validation error: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'Internal server error');
+  }
+});

--- a/functions/src/callables/getRankingData.ts
+++ b/functions/src/callables/getRankingData.ts
@@ -1,0 +1,75 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const getRankingData = onCall(async (request) => {
+  try {
+    const { tournamentId } = request.data;
+    
+    if (!tournamentId) {
+      throw new HttpsError('invalid-argument', 'tournamentId is required');
+    }
+    
+    const db = getFirestore();
+    
+    // メインビューデータを取得
+    const mainViewDoc = await db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('views')
+      .doc('main')
+      .get();
+    
+    if (!mainViewDoc.exists) {
+      throw new HttpsError('not-found', 'Main view data not found');
+    }
+    
+    const mainViewData = mainViewDoc.data();
+    
+    // プライズプールの存在確認
+    if (!mainViewData?.prizePool) {
+      throw new HttpsError('failed-precondition', 'プライズの確定が行われていないため、先にプライズ確定を行ってください');
+    }
+    
+    // バストプレイヤーデータを取得
+    const bustedDoc = await db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('tablesSeat')
+      .doc('busted')
+      .get();
+    
+    let bustedPlayers: any[] = [];
+    
+    if (bustedDoc.exists) {
+      const bustedData = bustedDoc.data();
+      const bustedUser = bustedData?.bustedUser || {};
+      
+      // bustedUserを配列に変換し、bustAtでソート
+      bustedPlayers = Object.entries(bustedUser).map(([uid, playerData]: [string, any]) => ({
+        uid,
+        pokerName: playerData.pokerName,
+        bustAt: playerData.bustAt,
+      })).sort((a, b) => {
+        // bustAtでソート（新しい順）
+        const aTime = a.bustAt?._seconds || 0;
+        const bTime = b.bustAt?._seconds || 0;
+        return bTime - aTime;
+      });
+    }
+    
+    return {
+      success: true,
+      mainViewData,
+      bustedPlayers,
+    };
+    
+  } catch (error) {
+    console.error('getRankingData error:', error);
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'Internal server error');
+  }
+});

--- a/functions/src/callables/index.ts
+++ b/functions/src/callables/index.ts
@@ -16,4 +16,9 @@ export { bulkAddon } from './bulkAddon';
 export { pauseTournament } from './api.pause';
 export { resumeTournament } from './api.resume';
 export { registerDevice } from './registerDevice';
+export { getPrizeData } from './getPrizeData';
+export { setPrizeData } from './setPrizeData';
+export { getRankingData } from './getRankingData';
+export { setRankingData } from './setRankingData';
+export { endTournament } from './endTournament';
 

--- a/functions/src/callables/registerParticipants.ts
+++ b/functions/src/callables/registerParticipants.ts
@@ -141,6 +141,26 @@ export const registerParticipants = functions.https.onCall(async (data, context)
               waitingCount: currentWaitingCount + 1,
               updatedAt: admin.firestore.FieldValue.serverTimestamp(),
             });
+            
+            // bustedから該当ユーザーを削除
+            const bustedRef = db
+              .collection('scheduledTournaments')
+              .doc(tournamentId)
+              .collection('tablesSeat')
+              .doc('busted');
+            
+            const bustedDoc = await transaction.get(bustedRef);
+            if (bustedDoc.exists) {
+              const bustedData = bustedDoc.data()!;
+              const bustedUser = bustedData.bustedUser || {};
+              
+              if (bustedUser[userId]) {
+                delete bustedUser[userId];
+                transaction.update(bustedRef, {
+                  bustedUser: bustedUser,
+                });
+              }
+            }
           } else {
             // 初回エントリーの場合
             transaction.update(viewsMainRef, {

--- a/functions/src/callables/rollbackAction.ts
+++ b/functions/src/callables/rollbackAction.ts
@@ -1,0 +1,203 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { getFirestore } from "firebase-admin/firestore";
+import { z } from "zod";
+import { 
+  undoAddon,
+  undoBulkAddon,
+  undoBustAndExit,
+  undoBustAndReentry,
+  undoRegisterParticipants,
+  undoAssignSeatToPlayer,
+  undoReseatAllPlayers
+} from "../rollbackFunction/index";
+
+// 入力スキーマの定義
+const rollbackActionSchema = z.object({
+  tournamentId: z.string().min(1, "トーナメントIDは必須です"),
+  actionLogId: z.string().min(1, "アクションログIDは必須です"),
+  action: z.enum([
+    'addon',
+    'bulk_addon',
+    'bust_and_exit',
+    'bust_and_reentry',
+    'register_participants',
+    'assign_seat_to_player',
+    'reseat_all_players'
+  ], { errorMap: () => ({ message: "有効な操作タイプを指定してください" }) }),
+  rollBackBy: z.string().min(1, "ロールバック実行者のデバイスIDは必須です"),
+  // 操作固有のパラメータ
+  playerUid: z.string().optional(),
+  playerName: z.string().optional(),
+  tableId: z.string().optional(),
+  seatNumber: z.number().optional(),
+  playerUids: z.array(z.string()).optional(),
+  playerNames: z.array(z.string()).optional(),
+  previousSeatingData: z.record(z.any()).optional(),
+});
+
+export const rollbackAction = onCall(async (request) => {
+  try {
+    // 入力検証
+    const validatedData = rollbackActionSchema.parse(request.data);
+    const { 
+      tournamentId, 
+      actionLogId, 
+      action, 
+      rollBackBy,
+      playerUid,
+      playerName,
+      tableId,
+      seatNumber,
+      playerUids,
+      playerNames,
+      previousSeatingData
+    } = validatedData;
+
+    const db = getFirestore();
+
+    // アクションログの存在確認
+    const actionLogRef = db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('actionLog')
+      .doc(actionLogId);
+      
+    const actionLogDoc = await actionLogRef.get();
+    if (!actionLogDoc.exists) {
+      throw new HttpsError('not-found', '指定されたアクションログが見つかりません');
+    }
+
+    const actionLogData = actionLogDoc.data()!;
+    
+    // 既にロールバック済みかチェック
+    if (actionLogData.isRollBack) {
+      throw new HttpsError('failed-precondition', 'この操作は既にロールバック済みです');
+    }
+
+    // 操作タイプに応じてロールバック関数を呼び出し
+    switch (action) {
+      case 'addon':
+        if (!playerUid || !playerName || !tableId || seatNumber === undefined) {
+          throw new HttpsError('invalid-argument', 'addon操作のロールバックに必要なパラメータが不足しています');
+        }
+        await undoAddon({
+          tournamentId,
+          actionLogId,
+          playerUid,
+          playerName,
+          tableId,
+          seatNumber,
+          addonAmount: 0, // ログから取得するか、パラメータとして渡す
+          rollBackBy,
+        });
+        break;
+
+      case 'bulk_addon':
+        if (!playerUids || !playerNames || !tableId) {
+          throw new HttpsError('invalid-argument', 'bulk_addon操作のロールバックに必要なパラメータが不足しています');
+        }
+        await undoBulkAddon({
+          tournamentId,
+          actionLogId,
+          playerUids,
+          playerNames,
+          tableId,
+          rollBackBy,
+        });
+        break;
+
+      case 'bust_and_exit':
+        if (!playerUid || !playerName || !tableId || seatNumber === undefined) {
+          throw new HttpsError('invalid-argument', 'bust_and_exit操作のロールバックに必要なパラメータが不足しています');
+        }
+        await undoBustAndExit({
+          tournamentId,
+          actionLogId,
+          playerUid,
+          playerName,
+          tableId,
+          seatNumber,
+          rollBackBy,
+        });
+        break;
+
+      case 'bust_and_reentry':
+        if (!playerUid || !playerName || !tableId || seatNumber === undefined) {
+          throw new HttpsError('invalid-argument', 'bust_and_reentry操作のロールバックに必要なパラメータが不足しています');
+        }
+        await undoBustAndReentry({
+          tournamentId,
+          actionLogId,
+          playerUid,
+          playerName,
+          tableId,
+          seatNumber,
+          rollBackBy,
+        });
+        break;
+
+      case 'register_participants':
+        if (!playerUids || !playerNames) {
+          throw new HttpsError('invalid-argument', 'register_participants操作のロールバックに必要なパラメータが不足しています');
+        }
+        await undoRegisterParticipants({
+          tournamentId,
+          actionLogId,
+          playerUids,
+          playerNames,
+          rollBackBy,
+        });
+        break;
+
+      case 'assign_seat_to_player':
+        if (!playerUid || !playerName || !tableId || seatNumber === undefined) {
+          throw new HttpsError('invalid-argument', 'assign_seat_to_player操作のロールバックに必要なパラメータが不足しています');
+        }
+        await undoAssignSeatToPlayer({
+          tournamentId,
+          actionLogId,
+          playerUid,
+          playerName,
+          tableId,
+          seatNumber,
+          rollBackBy,
+        });
+        break;
+
+      case 'reseat_all_players':
+        if (!previousSeatingData) {
+          throw new HttpsError('invalid-argument', 'reseat_all_players操作のロールバックに必要なパラメータが不足しています');
+        }
+        await undoReseatAllPlayers({
+          tournamentId,
+          actionLogId,
+          previousSeatingData,
+          rollBackBy,
+        });
+        break;
+
+      default:
+        throw new HttpsError('invalid-argument', 'サポートされていない操作タイプです');
+    }
+
+    return {
+      success: true,
+      message: '操作のロールバックが完了しました',
+      actionLogId,
+      action,
+    };
+
+  } catch (error) {
+    console.error('ロールバック操作エラー:', error);
+    
+    if (error instanceof z.ZodError) {
+      throw new HttpsError('invalid-argument', `入力検証エラー: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', '操作のロールバックに失敗しました');
+  }
+});

--- a/functions/src/callables/setPrizeData.ts
+++ b/functions/src/callables/setPrizeData.ts
@@ -1,0 +1,55 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+import { z } from 'zod';
+
+const setPrizeDataSchema = z.object({
+  tournamentId: z.string().min(1, 'tournamentId is required'),
+  prizeData: z.object({
+    prizePool: z.number().min(0, 'prizePool must be non-negative'),
+    prizeReceiverCount: z.number().min(1, 'prizeReceiverCount must be at least 1').max(10, 'prizeReceiverCount cannot exceed 10'),
+    pointType: z.string().optional(), // ポイントタイプ（オプション）
+  }).and(z.record(z.string(), z.union([z.string(), z.number(), z.null()]))), // 追加のプライズフィールドを許可（nullも許可）
+});
+
+export const setPrizeData = onCall(async (request) => {
+  try {
+    // 入力検証
+    const { tournamentId, prizeData } = setPrizeDataSchema.parse(request.data);
+    
+    const db = getFirestore();
+    
+    // トーナメントが存在するかチェック
+    const tournamentDoc = await db.collection('scheduledTournaments').doc(tournamentId).get();
+    
+    if (!tournamentDoc.exists) {
+      throw new HttpsError('not-found', 'Tournament not found');
+    }
+    
+    // mainビューデータを更新
+    const mainViewRef = db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('views')
+      .doc('main');
+    
+    await mainViewRef.update(prizeData);
+    
+    return {
+      success: true,
+      message: 'Prize data saved successfully',
+    };
+    
+  } catch (error) {
+    console.error('setPrizeData error:', error);
+    
+    if (error instanceof z.ZodError) {
+      throw new HttpsError('invalid-argument', `Input validation error: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'Internal server error');
+  }
+});

--- a/functions/src/callables/setRankingData.ts
+++ b/functions/src/callables/setRankingData.ts
@@ -1,0 +1,44 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const setRankingData = onCall(async (request) => {
+  try {
+    const { tournamentId, rankingData } = request.data;
+    
+    if (!tournamentId) {
+      throw new HttpsError('invalid-argument', 'tournamentId is required');
+    }
+    
+    if (!rankingData || typeof rankingData !== 'object') {
+      throw new HttpsError('invalid-argument', 'rankingData is required');
+    }
+    
+    const db = getFirestore();
+    
+    // メインビューデータを更新
+    const mainViewRef = db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('views')
+      .doc('main');
+    
+    await mainViewRef.update({
+      ...rankingData,
+      updatedAt: new Date(),
+    });
+    
+    return {
+      success: true,
+      message: 'Ranking data saved successfully',
+    };
+    
+  } catch (error) {
+    console.error('setRankingData error:', error);
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'Internal server error');
+  }
+});

--- a/functions/src/lib/actionLogger.ts
+++ b/functions/src/lib/actionLogger.ts
@@ -1,0 +1,74 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { ActionLog, ActionType } from '../types/actionLog';
+
+export interface LogActionParams {
+  tournamentId: string;
+  action: ActionType;
+  deviceId: string;
+  deviceName: string;
+  targetUid?: string | null;
+  targetPlayerName?: string | null;
+  tableId?: string | null;
+  seatNumber?: number | null;
+  details?: Record<string, any>;
+}
+
+/**
+ * 操作ログを記録する
+ */
+export async function logAction(params: LogActionParams): Promise<string> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  const actionLogData: ActionLog = {
+    action: params.action,
+    deviceId: params.deviceId,
+    deviceName: params.deviceName,
+    targetUid: params.targetUid || null,
+    targetPlayerName: params.targetPlayerName || null,
+    tableId: params.tableId || null,
+    seatNumber: params.seatNumber || null,
+    details: params.details || {},
+    createdAt: now,
+    isRollBack: false,
+    rollBackBy: null,
+    rollBackAt: null,
+  };
+
+  const actionLogRef = db
+    .collection('scheduledTournaments')
+    .doc(params.tournamentId)
+    .collection('actionLog')
+    .doc();
+
+  await actionLogRef.set(actionLogData);
+  
+  console.log(`Action logged: ${params.action} for tournament ${params.tournamentId} by device ${params.deviceId}`);
+  
+  return actionLogRef.id;
+}
+
+/**
+ * 操作ログをロールバック済みとしてマークする
+ */
+export async function markActionAsRolledBack(
+  tournamentId: string,
+  actionLogId: string,
+  rollBackBy: string
+): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  await db
+    .collection('scheduledTournaments')
+    .doc(tournamentId)
+    .collection('actionLog')
+    .doc(actionLogId)
+    .update({
+      isRollBack: true,
+      rollBackBy,
+      rollBackAt: now,
+    });
+    
+  console.log(`Action ${actionLogId} marked as rolled back by ${rollBackBy}`);
+}

--- a/functions/src/rollbackFunction/index.ts
+++ b/functions/src/rollbackFunction/index.ts
@@ -1,0 +1,7 @@
+export { undoAddon } from './undoAddon';
+export { undoBulkAddon } from './undoBulkAddon';
+export { undoBustAndExit } from './undoBustAndExit';
+export { undoBustAndReentry } from './undoBustAndReentry';
+export { undoRegisterParticipants } from './undoRegisterParticipants';
+export { undoAssignSeatToPlayer } from './undoAssignSeatToPlayer';
+export { undoReseatAllPlayers } from './undoReseatAllPlayers';

--- a/functions/src/rollbackFunction/undoAddon.ts
+++ b/functions/src/rollbackFunction/undoAddon.ts
@@ -1,0 +1,76 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { markActionAsRolledBack } from '../lib/actionLogger';
+
+export interface UndoAddonParams {
+  tournamentId: string;
+  actionLogId: string;
+  playerUid: string;
+  playerName: string;
+  tableId: string;
+  seatNumber: number;
+  addonAmount: number;
+  rollBackBy: string;
+}
+
+/**
+ * アドオン操作を巻き戻す
+ */
+export async function undoAddon(params: UndoAddonParams): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  try {
+    await db.runTransaction(async (transaction) => {
+      // 1. main view から addon を減算
+      const mainViewRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('main');
+        
+      const mainViewDoc = await transaction.get(mainViewRef);
+      if (!mainViewDoc.exists) {
+        throw new Error('Main view not found');
+      }
+      
+      const mainViewData = mainViewDoc.data()!;
+      const currentAddons = mainViewData.addons || 0;
+      
+      transaction.update(mainViewRef, {
+        addons: Math.max(0, currentAddons - 1), // 負の値にならないように
+        updatedAt: now,
+      });
+      
+      // 2. todaysBills から該当プレイヤーの addon 記録を削除または更新
+      const billsRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('todaysBills')
+        .doc(params.playerUid);
+        
+      const billsDoc = await transaction.get(billsRef);
+      if (billsDoc.exists) {
+        const billsData = billsDoc.data()!;
+        const currentAddons = billsData.addons || 0;
+        
+        transaction.update(billsRef, {
+          addons: Math.max(0, currentAddons - 1),
+          updatedAt: now,
+        });
+      }
+      
+      // 3. actionLog をロールバック済みとしてマーク
+      await markActionAsRolledBack(
+        params.tournamentId,
+        params.actionLogId,
+        params.rollBackBy
+      );
+    });
+    
+    console.log(`Addon operation undone for player ${params.playerName} in tournament ${params.tournamentId}`);
+    
+  } catch (error) {
+    console.error('Error undoing addon operation:', error);
+    throw error;
+  }
+}

--- a/functions/src/rollbackFunction/undoAssignSeatToPlayer.ts
+++ b/functions/src/rollbackFunction/undoAssignSeatToPlayer.ts
@@ -1,0 +1,109 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { markActionAsRolledBack } from '../lib/actionLogger';
+
+export interface UndoAssignSeatToPlayerParams {
+  tournamentId: string;
+  actionLogId: string;
+  playerUid: string;
+  playerName: string;
+  tableId: string;
+  seatNumber: number;
+  rollBackBy: string;
+}
+
+/**
+ * プレイヤーへのシート割当操作を巻き戻す
+ */
+export async function undoAssignSeatToPlayer(params: UndoAssignSeatToPlayerParams): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  try {
+    await db.runTransaction(async (transaction) => {
+      // 1. main view の統計を更新
+      const mainViewRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('main');
+        
+      const mainViewDoc = await transaction.get(mainViewRef);
+      if (!mainViewDoc.exists) {
+        throw new Error('Main view not found');
+      }
+      
+      const mainViewData = mainViewDoc.data()!;
+      const currentSeatedCount = mainViewData.seatedCount || 0;
+      const currentWaitingCount = mainViewData.waitingCount || 0;
+      
+      transaction.update(mainViewRef, {
+        seatedCount: Math.max(0, currentSeatedCount - 1),
+        waitingCount: currentWaitingCount + 1,
+        updatedAt: now,
+      });
+      
+      // 2. tablesSeat の該当シートを空にする
+      const seatRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('tablesSeat')
+        .doc(params.tableId);
+        
+      const seatDoc = await transaction.get(seatRef);
+      if (seatDoc.exists) {
+        const seatData = seatDoc.data()!;
+        const seats = seatData.seats || {};
+        
+        // 該当シートを空にする
+        if (seats[params.seatNumber]) {
+          delete seats[params.seatNumber];
+          
+          transaction.update(seatRef, {
+            seats,
+            updatedAt: now,
+          });
+        }
+      }
+      
+      // 3. waiting リストにプレイヤーを戻す
+      const waitingRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('tablesSeat')
+        .doc('waiting');
+        
+      const waitingDoc = await transaction.get(waitingRef);
+      if (waitingDoc.exists) {
+        const waitingData = waitingDoc.data()!;
+        const waiting = waitingData.waiting || {};
+        
+        // プレイヤーを待機リストに戻す
+        waiting[params.playerUid] = {
+          uid: params.playerUid,
+          name: params.playerName,
+          addedAt: now,
+          updatedAt: now,
+        };
+        
+        transaction.update(waitingRef, {
+          waiting,
+          count: Object.keys(waiting).length,
+          updatedAt: now,
+        });
+      }
+      
+      // 4. actionLog をロールバック済みとしてマーク
+      await markActionAsRolledBack(
+        params.tournamentId,
+        params.actionLogId,
+        params.rollBackBy
+      );
+    });
+    
+    console.log(`Assign seat to player operation undone for player ${params.playerName} in tournament ${params.tournamentId}`);
+    
+  } catch (error) {
+    console.error('Error undoing assign seat to player operation:', error);
+    throw error;
+  }
+}

--- a/functions/src/rollbackFunction/undoBulkAddon.ts
+++ b/functions/src/rollbackFunction/undoBulkAddon.ts
@@ -1,0 +1,77 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { markActionAsRolledBack } from '../lib/actionLogger';
+
+export interface UndoBulkAddonParams {
+  tournamentId: string;
+  actionLogId: string;
+  playerUids: string[];
+  playerNames: string[];
+  tableId: string;
+  rollBackBy: string;
+}
+
+/**
+ * 複数アドオン操作を巻き戻す
+ */
+export async function undoBulkAddon(params: UndoBulkAddonParams): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  try {
+    await db.runTransaction(async (transaction) => {
+      // 1. main view から addon を減算
+      const mainViewRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('main');
+        
+      const mainViewDoc = await transaction.get(mainViewRef);
+      if (!mainViewDoc.exists) {
+        throw new Error('Main view not found');
+      }
+      
+      const mainViewData = mainViewDoc.data()!;
+      const currentAddons = mainViewData.addons || 0;
+      const addonCount = params.playerUids.length;
+      
+      transaction.update(mainViewRef, {
+        addons: Math.max(0, currentAddons - addonCount),
+        updatedAt: now,
+      });
+      
+      // 2. todaysBills から各プレイヤーの addon 記録を更新
+      for (const playerUid of params.playerUids) {
+        const billsRef = db
+          .collection('scheduledTournaments')
+          .doc(params.tournamentId)
+          .collection('todaysBills')
+          .doc(playerUid);
+          
+        const billsDoc = await transaction.get(billsRef);
+        if (billsDoc.exists) {
+          const billsData = billsDoc.data()!;
+          const currentAddons = billsData.addons || 0;
+          
+          transaction.update(billsRef, {
+            addons: Math.max(0, currentAddons - 1),
+            updatedAt: now,
+          });
+        }
+      }
+      
+      // 3. actionLog をロールバック済みとしてマーク
+      await markActionAsRolledBack(
+        params.tournamentId,
+        params.actionLogId,
+        params.rollBackBy
+      );
+    });
+    
+    console.log(`Bulk addon operation undone for ${params.playerUids.length} players in tournament ${params.tournamentId}`);
+    
+  } catch (error) {
+    console.error('Error undoing bulk addon operation:', error);
+    throw error;
+  }
+}

--- a/functions/src/rollbackFunction/undoBustAndExit.ts
+++ b/functions/src/rollbackFunction/undoBustAndExit.ts
@@ -1,0 +1,103 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { markActionAsRolledBack } from '../lib/actionLogger';
+
+export interface UndoBustAndExitParams {
+  tournamentId: string;
+  actionLogId: string;
+  playerUid: string;
+  playerName: string;
+  tableId: string;
+  seatNumber: number;
+  rollBackBy: string;
+}
+
+/**
+ * バスト＆退場操作を巻き戻す
+ */
+export async function undoBustAndExit(params: UndoBustAndExitParams): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  try {
+    await db.runTransaction(async (transaction) => {
+      // 1. main view の統計を更新
+      const mainViewRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('main');
+        
+      const mainViewDoc = await transaction.get(mainViewRef);
+      if (!mainViewDoc.exists) {
+        throw new Error('Main view not found');
+      }
+      
+      const mainViewData = mainViewDoc.data()!;
+      const currentPlayersBusted = mainViewData.playersBusted || 0;
+      const currentPlayersIn = mainViewData.playersIn || 0;
+      
+      transaction.update(mainViewRef, {
+        playersBusted: Math.max(0, currentPlayersBusted - 1),
+        playersIn: currentPlayersIn + 1,
+        updatedAt: now,
+      });
+      
+      // 2. todaysBills の該当プレイヤーを復活
+      const billsRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('todaysBills')
+        .doc(params.playerUid);
+        
+      const billsDoc = await transaction.get(billsRef);
+      if (billsDoc.exists) {
+        transaction.update(billsRef, {
+          isBusted: false,
+          bustedAt: null,
+          updatedAt: now,
+        });
+      }
+      
+      // 3. tablesSeat の該当シートを復活
+      const seatRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('tablesSeat')
+        .doc(params.tableId);
+        
+      const seatDoc = await transaction.get(seatRef);
+      if (seatDoc.exists) {
+        const seatData = seatDoc.data()!;
+        const seats = seatData.seats || {};
+        
+        // 該当シートを復活
+        if (seats[params.seatNumber]) {
+          seats[params.seatNumber] = {
+            ...seats[params.seatNumber],
+            isBusted: false,
+            bustedAt: null,
+            updatedAt: now,
+          };
+          
+          transaction.update(seatRef, {
+            seats,
+            updatedAt: now,
+          });
+        }
+      }
+      
+      // 4. actionLog をロールバック済みとしてマーク
+      await markActionAsRolledBack(
+        params.tournamentId,
+        params.actionLogId,
+        params.rollBackBy
+      );
+    });
+    
+    console.log(`Bust and exit operation undone for player ${params.playerName} in tournament ${params.tournamentId}`);
+    
+  } catch (error) {
+    console.error('Error undoing bust and exit operation:', error);
+    throw error;
+  }
+}

--- a/functions/src/rollbackFunction/undoBustAndReentry.ts
+++ b/functions/src/rollbackFunction/undoBustAndReentry.ts
@@ -1,0 +1,106 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { markActionAsRolledBack } from '../lib/actionLogger';
+
+export interface UndoBustAndReentryParams {
+  tournamentId: string;
+  actionLogId: string;
+  playerUid: string;
+  playerName: string;
+  tableId: string;
+  seatNumber: number;
+  rollBackBy: string;
+}
+
+/**
+ * バスト＆リ・エントリー操作を巻き戻す
+ */
+export async function undoBustAndReentry(params: UndoBustAndReentryParams): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  try {
+    await db.runTransaction(async (transaction) => {
+      // 1. main view の統計を更新
+      const mainViewRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('main');
+        
+      const mainViewDoc = await transaction.get(mainViewRef);
+      if (!mainViewDoc.exists) {
+        throw new Error('Main view not found');
+      }
+      
+      const mainViewData = mainViewDoc.data()!;
+      const currentReentries = mainViewData.reentries || 0;
+      const currentPlayersIn = mainViewData.playersIn || 0;
+      
+      transaction.update(mainViewRef, {
+        reentries: Math.max(0, currentReentries - 1),
+        playersIn: Math.max(0, currentPlayersIn - 1),
+        updatedAt: now,
+      });
+      
+      // 2. todaysBills の該当プレイヤーをリ・エントリー前の状態に戻す
+      const billsRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('todaysBills')
+        .doc(params.playerUid);
+        
+      const billsDoc = await transaction.get(billsRef);
+      if (billsDoc.exists) {
+        const billsData = billsDoc.data()!;
+        const currentReentries = billsData.reentries || 0;
+        
+        transaction.update(billsRef, {
+          reentries: Math.max(0, currentReentries - 1),
+          isBusted: true, // リ・エントリー前はバスト状態
+          updatedAt: now,
+        });
+      }
+      
+      // 3. tablesSeat の該当シートをリ・エントリー前の状態に戻す
+      const seatRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('tablesSeat')
+        .doc(params.tableId);
+        
+      const seatDoc = await transaction.get(seatRef);
+      if (seatDoc.exists) {
+        const seatData = seatDoc.data()!;
+        const seats = seatData.seats || {};
+        
+        // 該当シートをリ・エントリー前の状態に戻す
+        if (seats[params.seatNumber]) {
+          seats[params.seatNumber] = {
+            ...seats[params.seatNumber],
+            isBusted: true,
+            reentryCount: (seats[params.seatNumber].reentryCount || 1) - 1,
+            updatedAt: now,
+          };
+          
+          transaction.update(seatRef, {
+            seats,
+            updatedAt: now,
+          });
+        }
+      }
+      
+      // 4. actionLog をロールバック済みとしてマーク
+      await markActionAsRolledBack(
+        params.tournamentId,
+        params.actionLogId,
+        params.rollBackBy
+      );
+    });
+    
+    console.log(`Bust and reentry operation undone for player ${params.playerName} in tournament ${params.tournamentId}`);
+    
+  } catch (error) {
+    console.error('Error undoing bust and reentry operation:', error);
+    throw error;
+  }
+}

--- a/functions/src/rollbackFunction/undoRegisterParticipants.ts
+++ b/functions/src/rollbackFunction/undoRegisterParticipants.ts
@@ -1,0 +1,92 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { markActionAsRolledBack } from '../lib/actionLogger';
+
+export interface UndoRegisterParticipantsParams {
+  tournamentId: string;
+  actionLogId: string;
+  playerUids: string[];
+  playerNames: string[];
+  rollBackBy: string;
+}
+
+/**
+ * プレイヤー登録操作を巻き戻す
+ */
+export async function undoRegisterParticipants(params: UndoRegisterParticipantsParams): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  try {
+    await db.runTransaction(async (transaction) => {
+      // 1. main view の統計を更新
+      const mainViewRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('main');
+        
+      const mainViewDoc = await transaction.get(mainViewRef);
+      if (!mainViewDoc.exists) {
+        throw new Error('Main view not found');
+      }
+      
+      const mainViewData = mainViewDoc.data()!;
+      const currentEntries = mainViewData.entries || 0;
+      const currentPlayersIn = mainViewData.playersIn || 0;
+      const playerCount = params.playerUids.length;
+      
+      transaction.update(mainViewRef, {
+        entries: Math.max(0, currentEntries - playerCount),
+        playersIn: Math.max(0, currentPlayersIn - playerCount),
+        updatedAt: now,
+      });
+      
+      // 2. todaysBills から該当プレイヤーを削除
+      for (const playerUid of params.playerUids) {
+        const billsRef = db
+          .collection('scheduledTournaments')
+          .doc(params.tournamentId)
+          .collection('todaysBills')
+          .doc(playerUid);
+          
+        transaction.delete(billsRef);
+      }
+      
+      // 3. usersList から該当プレイヤーを削除
+      const usersListRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('usersList');
+        
+      const usersListDoc = await transaction.get(usersListRef);
+      if (usersListDoc.exists) {
+        const usersListData = usersListDoc.data()!;
+        const users = usersListData.users || {};
+        
+        // 該当プレイヤーを削除
+        for (const playerUid of params.playerUids) {
+          delete users[playerUid];
+        }
+        
+        transaction.update(usersListRef, {
+          users,
+          updatedAt: now,
+        });
+      }
+      
+      // 4. actionLog をロールバック済みとしてマーク
+      await markActionAsRolledBack(
+        params.tournamentId,
+        params.actionLogId,
+        params.rollBackBy
+      );
+    });
+    
+    console.log(`Register participants operation undone for ${params.playerUids.length} players in tournament ${params.tournamentId}`);
+    
+  } catch (error) {
+    console.error('Error undoing register participants operation:', error);
+    throw error;
+  }
+}

--- a/functions/src/rollbackFunction/undoReseatAllPlayers.ts
+++ b/functions/src/rollbackFunction/undoReseatAllPlayers.ts
@@ -1,0 +1,92 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { markActionAsRolledBack } from '../lib/actionLogger';
+
+export interface UndoReseatAllPlayersParams {
+  tournamentId: string;
+  actionLogId: string;
+  previousSeatingData: Record<string, any>; // 前の座席配置データ
+  rollBackBy: string;
+}
+
+/**
+ * 全員再配置操作を巻き戻す
+ */
+export async function undoReseatAllPlayers(params: UndoReseatAllPlayersParams): Promise<void> {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  
+  try {
+    await db.runTransaction(async (transaction) => {
+      // 1. 前の座席配置データを復元
+      for (const [tableId, tableData] of Object.entries(params.previousSeatingData)) {
+        if (tableId === 'waiting') {
+          // waiting リストを復元
+          const waitingRef = db
+            .collection('scheduledTournaments')
+            .doc(params.tournamentId)
+            .collection('tablesSeat')
+            .doc('waiting');
+            
+          transaction.set(waitingRef, {
+            waiting: tableData.waiting || {},
+            count: Object.keys(tableData.waiting || {}).length,
+            updatedAt: now,
+          });
+        } else {
+          // 各テーブルの座席配置を復元
+          const seatRef = db
+            .collection('scheduledTournaments')
+            .doc(params.tournamentId)
+            .collection('tablesSeat')
+            .doc(tableId);
+            
+          transaction.set(seatRef, {
+            seats: tableData.seats || {},
+            updatedAt: now,
+          });
+        }
+      }
+      
+      // 2. main view の統計を復元
+      const mainViewRef = db
+        .collection('scheduledTournaments')
+        .doc(params.tournamentId)
+        .collection('views')
+        .doc('main');
+        
+      const mainViewDoc = await transaction.get(mainViewRef);
+      if (mainViewDoc.exists) {
+        // 前の座席配置から統計を計算
+        let seatedCount = 0;
+        let waitingCount = 0;
+        
+        for (const [tableId, tableData] of Object.entries(params.previousSeatingData)) {
+          if (tableId === 'waiting') {
+            waitingCount = Object.keys(tableData.waiting || {}).length;
+          } else {
+            seatedCount += Object.keys(tableData.seats || {}).length;
+          }
+        }
+        
+        transaction.update(mainViewRef, {
+          seatedCount,
+          waitingCount,
+          updatedAt: now,
+        });
+      }
+      
+      // 3. actionLog をロールバック済みとしてマーク
+      await markActionAsRolledBack(
+        params.tournamentId,
+        params.actionLogId,
+        params.rollBackBy
+      );
+    });
+    
+    console.log(`Reseat all players operation undone in tournament ${params.tournamentId}`);
+    
+  } catch (error) {
+    console.error('Error undoing reseat all players operation:', error);
+    throw error;
+  }
+}

--- a/functions/src/tournamentTemplate/createTournamentTemplate.ts
+++ b/functions/src/tournamentTemplate/createTournamentTemplate.ts
@@ -6,7 +6,7 @@ export const createTournamentTemplate = onCall(async (request) => {
     const {
       name, entryFee, isReentry, maxReentries, reentryFee, startStack,
       isAddon, addonFee, addonStack, blindStructure, prizeRatio,
-      tournamentCategory
+      tournamentCategory, pointType
     } = request.data;
 
     // 必須フィールドのバリデーション
@@ -56,6 +56,7 @@ export const createTournamentTemplate = onCall(async (request) => {
       blindStructure,
       prizeRatio,
       tournamentCategory,
+      pointType: pointType || 'pointA', // UIから送信されたpointTypeまたはデフォルト
       updatedAt: now,
       isArchived: false,
     };

--- a/functions/src/types/actionLog.ts
+++ b/functions/src/types/actionLog.ts
@@ -1,0 +1,30 @@
+import { Timestamp } from 'firebase-admin/firestore';
+
+export interface ActionLog {
+  action: string; // 操作の種類
+  deviceId: string; // 操作を行ったデバイスのID
+  deviceName: string; // 操作を行ったデバイスの名前
+  targetUid: string | null; // 対象プレイヤーのUID
+  targetPlayerName: string | null; // 対象プレイヤーの名前
+  tableId: string | null; // テーブルID
+  seatNumber: number | null; // シート番号
+  details: Record<string, any>; // 操作の詳細情報
+  createdAt: Timestamp; // 操作実行時刻
+  isRollBack: boolean; // ロールバック済みかどうか
+  rollBackBy: string | null; // ロールバック実行者のデバイスID
+  rollBackAt: Timestamp | null; // ロールバック実行時刻
+}
+
+// 操作の種類を定義
+export const ACTION_TYPES = {
+  CREATE_TOURNAMENT: 'create_tournament',
+  ADDON: 'addon',
+  BULK_ADDON: 'bulk_addon',
+  BUST_AND_EXIT: 'bust_and_exit',
+  BUST_AND_REENTRY: 'bust_and_reentry',
+  REGISTER_PARTICIPANTS: 'register_participants',
+  ASSIGN_SEAT_TO_PLAYER: 'assign_seat_to_player',
+  RESEAT_ALL_PLAYERS: 'reseat_all_players',
+} as const;
+
+export type ActionType = typeof ACTION_TYPES[keyof typeof ACTION_TYPES];

--- a/functions/src/user/createUserAccount.ts
+++ b/functions/src/user/createUserAccount.ts
@@ -85,9 +85,9 @@ export const createUserAccount = onCall(
           hashedPin: hashedPin,
           birthMonthDay: birthMonthDay,
           loginId: loginId,
-          pointA: 0,
-          pointB: 0,
-          sideGameTip: 0,
+          pointA: 0, // globalConstant.dart の pointTypes[0] フィールド
+          pointB: 0, // globalConstant.dart の pointTypes[1] フィールド
+          sideGameTip: 0, // globalConstant.dart の pointTypes[2] フィールド
           isStaying: false,
           lastLogin: null,
           role: "user",

--- a/functions/src/user/createUserByApp.ts
+++ b/functions/src/user/createUserByApp.ts
@@ -47,9 +47,9 @@ export const createUserByApp = onCall(async (request) => {
     hashedPin,
     role: "user",
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
-    pointA: 0,
-    pointB: 0,
-    sideGameTip: 0,
+    pointA: 0, // globalConstant.dart の pointTypes[0] フィールド
+    pointB: 0, // globalConstant.dart の pointTypes[1] フィールド
+    sideGameTip: 0, // globalConstant.dart の pointTypes[2] フィールド
     lastLogin: admin.firestore.FieldValue.serverTimestamp(),
     isStaying: false,
     currentTable: null,

--- a/lib/ActionHistory/tournamentActionsHistoryPage.dart
+++ b/lib/ActionHistory/tournamentActionsHistoryPage.dart
@@ -1,0 +1,525 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import '../../services/device_service.dart';
+
+class TournamentActionsHistoryPage extends StatefulWidget {
+  final String tournamentId;
+
+  const TournamentActionsHistoryPage({
+    super.key,
+    required this.tournamentId,
+  });
+
+  @override
+  State<TournamentActionsHistoryPage> createState() => _TournamentActionsHistoryPageState();
+}
+
+class _TournamentActionsHistoryPageState extends State<TournamentActionsHistoryPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  List<Map<String, dynamic>> _actionLogs = [];
+  bool _isLoading = false;
+  String? _currentDeviceId;
+  String? _currentDeviceName;
+  int _currentTabIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    _tabController.addListener(() {
+      if (_tabController.index != _currentTabIndex) {
+        setState(() {
+          _currentTabIndex = _tabController.index;
+        });
+        _loadActionLogs();
+      }
+    });
+    _initializeDeviceInfo();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _initializeDeviceInfo() async {
+    try {
+      final deviceService = DeviceService();
+      final device = await deviceService.getCurrentDevice();
+      if (device != null) {
+        setState(() {
+          _currentDeviceId = device.id;
+          _currentDeviceName = device.name;
+        });
+      }
+    } catch (e) {
+      print('デバイス情報の取得に失敗: $e');
+    }
+  }
+
+  Future<void> _loadActionLogs() async {
+    if (_isLoading) return;
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final functions = FirebaseFunctions.instance;
+      
+      // タブに応じてクエリパラメータを設定
+      Map<String, dynamic> params = {
+        'tournamentId': widget.tournamentId,
+        'limit': 100,
+      };
+
+      if (_currentTabIndex == 0 && _currentDeviceId != null) {
+        // この端末の操作のみ
+        params['deviceId'] = _currentDeviceId;
+      }
+
+      final result = await functions
+          .httpsCallable('getActionLogs')
+          .call(params);
+
+      if (result.data['success'] == true) {
+        // デバッグ用ログ
+        print('=== ActionLogs Debug ===');
+        print('result.data type: ${result.data.runtimeType}');
+        print('result.data keys: ${(result.data as Map).keys.toList()}');
+        print('actionLogs type: ${result.data['actionLogs'].runtimeType}');
+        print('actionLogs length: ${(result.data['actionLogs'] as List).length}');
+        
+        // 最初のログの詳細を確認
+        if ((result.data['actionLogs'] as List).isNotEmpty) {
+          final firstLog = (result.data['actionLogs'] as List).first;
+          print('First log type: ${firstLog.runtimeType}');
+          if (firstLog is Map) {
+            print('First log keys: ${firstLog.keys.toList()}');
+            print('First log createdAt: ${firstLog['createdAt']}');
+            print('First log createdAt type: ${firstLog['createdAt']?.runtimeType}');
+          }
+        }
+        
+        // 型安全な変換を行う
+        final rawLogs = result.data['actionLogs'] as List<dynamic>;
+        print('rawLogs type: ${rawLogs.runtimeType}');
+        
+        final logs = rawLogs.map((log) {
+          print('log type: ${log.runtimeType}');
+          if (log is Map) {
+            // Map<Object?, Object?> を Map<String, dynamic> に変換
+            final converted = Map<String, dynamic>.from(log.map((key, value) => 
+              MapEntry(key.toString(), value)
+            ));
+            print('converted log: $converted');
+            
+            // createdAtの詳細をデバッグ出力
+            if (converted.containsKey('createdAt')) {
+              print('=== createdAt Debug ===');
+              print('createdAt value: ${converted['createdAt']}');
+              print('createdAt type: ${converted['createdAt'].runtimeType}');
+              
+              // createdAtがMapの場合、Firestore Timestampの可能性
+              if (converted['createdAt'] is Map) {
+                final timestampMap = converted['createdAt'] as Map;
+                print('Timestamp Map keys: ${timestampMap.keys.toList()}');
+                print('Timestamp Map values: ${timestampMap.values.toList()}');
+                
+                if (timestampMap.containsKey('_seconds')) {
+                  final seconds = timestampMap['_seconds'] as int;
+                  final nanoseconds = timestampMap['_nanoseconds'] as int? ?? 0;
+                  final dateTime = DateTime.fromMillisecondsSinceEpoch(
+                    (seconds * 1000) + (nanoseconds ~/ 1000000),
+                    isUtc: true,
+                  );
+                  print('Converted DateTime: $dateTime');
+                  // 変換されたDateTimeで置き換え
+                  converted['createdAt'] = dateTime;
+                } else if (timestampMap.isEmpty) {
+                  print('WARNING: createdAt is an empty Map! This should not happen.');
+                }
+              }
+              print('=== End createdAt Debug ===');
+            }
+            
+            return converted;
+          }
+          print('log is not a Map: $log');
+          return <String, dynamic>{};
+        }).where((log) => log.isNotEmpty).toList();
+        
+        print('final logs length: ${logs.length}');
+        print('=== End Debug ===');
+        
+        // タブに応じてフィルタリング
+        List<Map<String, dynamic>> filteredLogs = logs;
+        
+        if (_currentTabIndex == 1) {
+          // 全ての端末の操作（フィルタリングなし）
+          print('全ての端末の操作: ${logs.length}件');
+        } else if (_currentTabIndex == 2) {
+          // 他端末の操作のみ
+          filteredLogs = logs.where((log) => 
+            log['deviceId'] != _currentDeviceId
+          ).toList();
+          print('他端末の操作: ${filteredLogs.length}件 (全体: ${logs.length}件)');
+        } else {
+          print('この端末の操作: ${logs.length}件');
+        }
+
+        setState(() {
+          _actionLogs = filteredLogs;
+        });
+        
+        print('フィルタリング後のログ数: ${filteredLogs.length}');
+      } else {
+        throw Exception('アクションログの取得に失敗しました');
+      }
+    } catch (e, stackTrace) {
+      print('アクションログ取得エラー: $e');
+      print('スタックトレース: $stackTrace');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('アクションログの取得に失敗しました: $e'),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 5),
+            action: SnackBarAction(
+              label: '詳細',
+              textColor: Colors.white,
+              onPressed: () {
+                print('詳細エラー: $e');
+                print('スタックトレース: $stackTrace');
+              },
+            ),
+          ),
+        );
+      }
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _rollbackAction(Map<String, dynamic> actionLog) async {
+    // 確認ダイアログを表示
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('操作の取り消し'),
+        content: Text('この操作を本当に取り消しますか？\n\n'
+            '操作: ${_getActionDisplayName(actionLog['action'])}\n'
+            '対象: ${actionLog['targetPlayerName'] ?? 'なし'}\n'
+            '実行時刻: ${_formatDateTime(actionLog['createdAt'])}'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('取り消し', style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      final functions = FirebaseFunctions.instance;
+      
+      // ロールバックに必要なパラメータを構築
+      final params = <String, dynamic>{
+        'tournamentId': widget.tournamentId,
+        'actionLogId': actionLog['id'],
+        'action': actionLog['action'],
+        'rollBackBy': _currentDeviceId ?? 'unknown',
+      };
+
+      // 操作タイプに応じて必要なパラメータを追加
+      final action = actionLog['action'] as String;
+      switch (action) {
+        case 'addon':
+        case 'bust_and_exit':
+        case 'bust_and_reentry':
+        case 'assign_seat_to_player':
+          if (actionLog['targetUid'] != null) params['playerUid'] = actionLog['targetUid'];
+          if (actionLog['targetPlayerName'] != null) params['playerName'] = actionLog['targetPlayerName'];
+          if (actionLog['tableId'] != null) params['tableId'] = actionLog['tableId'];
+          if (actionLog['seatNumber'] != null) params['seatNumber'] = actionLog['seatNumber'];
+          break;
+        case 'bulk_addon':
+          if (actionLog['tableId'] != null) params['tableId'] = actionLog['tableId'];
+          // bulk_addonの場合は、detailsからplayerUidsとplayerNamesを取得
+          if (actionLog['details'] is Map) {
+            final details = actionLog['details'] as Map;
+            if (details['playerUids'] != null) params['playerUids'] = details['playerUids'];
+            if (details['playerNames'] != null) params['playerNames'] = details['playerNames'];
+          }
+          break;
+        case 'register_participants':
+          // register_participantsの場合は、detailsからplayerUidsとplayerNamesを取得
+          if (actionLog['details'] is Map) {
+            final details = actionLog['details'] as Map;
+            if (details['playerUids'] != null) params['playerUids'] = details['playerUids'];
+            if (details['playerNames'] != null) params['playerNames'] = details['playerNames'];
+          }
+          break;
+        case 'reseat_all_players':
+          // reseat_all_playersの場合は、detailsからpreviousSeatingDataを取得
+          if (actionLog['details'] is Map) {
+            final details = actionLog['details'] as Map;
+            if (details['previousSeatingData'] != null) params['previousSeatingData'] = details['previousSeatingData'];
+          }
+          break;
+      }
+
+      print('=== Rollback Params Debug ===');
+      print('Action: $action');
+      print('ActionLog: $actionLog');
+      print('Params: $params');
+      print('=== End Rollback Params Debug ===');
+
+      final result = await functions
+          .httpsCallable('rollbackAction')
+          .call(params);
+
+      if (result.data['success'] == true) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('操作の取り消しが完了しました'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
+        // ログを再読み込み
+        _loadActionLogs();
+      } else {
+        throw Exception('ロールバックに失敗しました');
+      }
+    } catch (e) {
+      print('ロールバックエラー: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('操作の取り消しに失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  String _getActionDisplayName(String action) {
+    switch (action) {
+      case 'addon':
+        return 'アドオン';
+      case 'bulk_addon':
+        return '複数アドオン';
+      case 'bust_and_exit':
+        return 'バースト＆退場';
+      case 'bust_and_reentry':
+        return 'バースト＆リエントリー';
+      case 'register_participants':
+        return 'エントリー';
+      case 'assign_seat_to_player':
+        return 'シート割当';
+      case 'reseat_all_players':
+        return '全員リシート';
+      case 'create_tournament':
+        return 'トーナメント作成';
+      default:
+        return action;
+    }
+  }
+
+  String _formatDateTime(dynamic dateTime) {
+    if (dateTime == null) return '不明';
+    
+    // 空のオブジェクトや無効なデータのチェック
+    if (dateTime is Map && dateTime.isEmpty) {
+      print('時刻データが空のオブジェクトです: $dateTime');
+      return '時刻不明';
+    }
+    
+    print('=== _formatDateTime Debug ===');
+    print('入力値: $dateTime');
+    print('入力値の型: ${dateTime.runtimeType}');
+    
+    DateTime? parsedDateTime;
+    
+    if (dateTime is DateTime) {
+      parsedDateTime = dateTime;
+      print('DateTime型として処理');
+    } else if (dateTime is String) {
+      // ISO文字列の場合
+      try {
+        parsedDateTime = DateTime.parse(dateTime);
+        print('ISO文字列としてパース成功: $parsedDateTime');
+      } catch (e) {
+        print('日時文字列のパースエラー: $dateTime, $e');
+        return 'パースエラー';
+      }
+    } else if (dateTime is Map) {
+      // Firestore Timestampの場合
+      print('Map型として処理: $dateTime');
+      print('Mapのキー: ${dateTime.keys.toList()}');
+      
+      try {
+        if (dateTime['_seconds'] != null) {
+          final seconds = dateTime['_seconds'] as int;
+          final nanoseconds = dateTime['_nanoseconds'] as int? ?? 0;
+          parsedDateTime = DateTime.fromMillisecondsSinceEpoch(
+            (seconds * 1000) + (nanoseconds ~/ 1000000),
+            isUtc: true,
+          );
+          print('Timestamp変換成功: $parsedDateTime');
+        } else {
+          print('_secondsフィールドが見つかりません');
+        }
+      } catch (e) {
+        print('Timestamp変換エラー: $dateTime, $e');
+        return '変換エラー';
+      }
+    }
+    
+    if (parsedDateTime != null) {
+      // UTCからJSTに変換（+9時間）
+      final jstDateTime = parsedDateTime.toUtc().add(const Duration(hours: 9));
+      final result = '${jstDateTime.year}/${jstDateTime.month.toString().padLeft(2, '0')}/${jstDateTime.day.toString().padLeft(2, '0')} '
+          '${jstDateTime.hour.toString().padLeft(2, '0')}:'
+          '${jstDateTime.minute.toString().padLeft(2, '0')}:'
+          '${jstDateTime.second.toString().padLeft(2, '0')}';
+      print('最終結果: $result');
+      print('=== End _formatDateTime Debug ===');
+      return result;
+    }
+    
+    print('パース失敗、元の値を返却: ${dateTime.toString()}');
+    print('=== End _formatDateTime Debug ===');
+    return dateTime.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('操作履歴'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loadActionLogs,
+            tooltip: '更新',
+          ),
+        ],
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'この端末'),
+            Tab(text: '全て'),
+            Tab(text: '他端末'),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          // 初回データ取得ボタン
+          if (_actionLogs.isEmpty && !_isLoading)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(16),
+              child: ElevatedButton(
+                onPressed: _loadActionLogs,
+                child: const Text('データを取得'),
+              ),
+            ),
+          
+          // ログ一覧
+          Expanded(
+            child: _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _actionLogs.isEmpty
+                    ? const Center(
+                        child: Text('操作履歴がありません'),
+                      )
+                    : ListView.builder(
+                        itemCount: _actionLogs.length,
+                        itemBuilder: (context, index) {
+                          final log = _actionLogs[index];
+                          return _buildActionLogItem(log);
+                        },
+                      ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionLogItem(Map<String, dynamic> log) {
+    final isRolledBack = log['isRollBack'] == true;
+    
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: ListTile(
+        title: Row(
+          children: [
+            Text(
+              _getActionDisplayName(log['action']),
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: isRolledBack ? Colors.grey : Colors.black,
+              ),
+            ),
+            if (isRolledBack) ...[
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade300,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: const Text(
+                  '取り消し済み',
+                  style: TextStyle(fontSize: 12, color: Colors.grey),
+                ),
+              ),
+            ],
+          ],
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (log['targetPlayerName'] != null)
+              Text('対象: ${log['targetPlayerName']}'),
+            if (log['tableId'] != null)
+              Text('テーブル: ${log['tableId']}'),
+            if (log['seatNumber'] != null)
+              Text('シート: ${log['seatNumber']}'),
+            Text('実行者: ${log['deviceName']} (${log['deviceId']})'),
+            Text('時刻: ${_formatDateTime(log['createdAt'])}'),
+            // デバッグ用：生データも表示
+            Text('生データ: ${log['createdAt']}', style: TextStyle(fontSize: 10, color: Colors.grey)),
+            if (isRolledBack && log['rollBackBy'] != null)
+              Text('取り消し者: ${log['rollBackBy']}'),
+          ],
+        ),
+        trailing: isRolledBack
+            ? null
+            : IconButton(
+                icon: const Icon(Icons.undo, color: Colors.orange),
+                onPressed: () => _rollbackAction(log),
+                tooltip: '取り消し',
+              ),
+      ),
+    );
+  }
+}

--- a/lib/Tournament/createTournamentTemplatePage.dart
+++ b/lib/Tournament/createTournamentTemplatePage.dart
@@ -41,6 +41,9 @@ class _CreateTournamentTemplatePageState extends State<CreateTournamentTemplateP
   // トーナメントカテゴリ
   String _tournamentCategory = 'regular';
   
+  // ポイントタイプ
+  String _selectedPointType = 'pointA';
+  
   // 状態管理
   bool _isLoading = false;
   bool _isSaving = false;
@@ -228,6 +231,7 @@ class _CreateTournamentTemplatePageState extends State<CreateTournamentTemplateP
         'blindStructure': _selectedBlindTemplateId,
         'prizeRatio': _prizeRatio,
         'tournamentCategory': _tournamentCategory,
+        'pointType': _selectedPointType,
       };
 
       final result = await callable.call(tournamentTemplateData);
@@ -409,9 +413,28 @@ class _CreateTournamentTemplatePageState extends State<CreateTournamentTemplateP
                             ),
                             const SizedBox(height: 16),
 
-
-
-
+                            // ポイントタイプ選択
+                            DropdownButtonFormField<String>(
+                              value: _selectedPointType,
+                              decoration: const InputDecoration(
+                                labelText: 'ポイントタイプ *',
+                                border: OutlineInputBorder(),
+                              ),
+                              items: GlobalConstants.pointTypes.map((String pointType) {
+                                return DropdownMenuItem<String>(
+                                  value: pointType,
+                                  child: Text(pointType),
+                                );
+                              }).toList(),
+                              onChanged: (value) {
+                                if (value != null) {
+                                  setState(() {
+                                    _selectedPointType = value;
+                                  });
+                                }
+                              },
+                            ),
+                            const SizedBox(height: 16),
 
                             // トーナメントカテゴリ
                             DropdownButtonFormField<String>(

--- a/lib/globalConstant.dart
+++ b/lib/globalConstant.dart
@@ -14,6 +14,24 @@ class GlobalConstants {
 
   // トーナメント設定
   static const double defaultPrizeRatio = 0.7; // デフォルトプライズ割合（70%）
+  
+  // プライズ設定
+  static const int prizeReceiverPercentage = 10; // プライズ受け取り人数の割合（10%）
+  static const String prizeRoundingMethod = 'floor'; // プライズ計算の丸め方法（floor: 切り捨て, ceil: 切り上げ, round: 四捨五入）
+  
+  // プライズ配分比率（人数別）
+  static const Map<int, List<double>> prizeDistribution = {
+    1: [100.0], // 1人入賞（Winner Take All）
+    2: [65.0, 35.0], // 2人入賞
+    3: [50.0, 30.0, 20.0], // 3人入賞
+    4: [45.0, 25.0, 18.0, 12.0], // 4人入賞
+    5: [40.0, 25.0, 15.0, 12.0, 8.0], // 5人入賞
+    6: [38.0, 23.0, 15.0, 10.0, 8.0, 6.0], // 6人入賞
+    7: [36.0, 22.0, 14.0, 9.0, 7.0, 6.0, 6.0], // 7人入賞
+    8: [35.0, 21.0, 13.0, 9.0, 7.0, 6.0, 5.0, 4.0], // 8人入賞
+    9: [34.0, 20.0, 12.0, 8.0, 7.0, 6.0, 5.0, 4.0, 4.0], // 9人入賞
+    10: [32.0, 19.0, 12.0, 8.0, 7.0, 6.0, 5.0, 4.0, 4.0, 3.0], // 10人入賞
+  };
 
   // 給与計算期間設定
   static const int PAYROLL_START_DAY = 25; // 給与計算期間の開始日（25日から開始）
@@ -21,4 +39,7 @@ class GlobalConstants {
   
   // 給与計算期間の説明
   static const String PAYROLL_PERIOD_DESCRIPTION = "給与計算期間は25日〜翌月24日です。変更する場合は、このファイルの数値を変更してアプリを再起動してください。";
+  
+  // ポイントタイプ選択肢（フィールド名のみ）
+  static const List<String> pointTypes = ['pointA', 'pointB', 'sideGameTip'];//createUserAccount.tsやcreateUserByApp.tsについては直接コード内で修正する必要がある
 }

--- a/lib/scheduledTournament/pages/prize_setup_page.dart
+++ b/lib/scheduledTournament/pages/prize_setup_page.dart
@@ -1,0 +1,590 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import '../../globalConstant.dart';
+
+class PrizeSetupPage extends StatefulWidget {
+  final String tournamentId;
+  
+  const PrizeSetupPage({
+    super.key,
+    required this.tournamentId,
+  });
+
+  @override
+  State<PrizeSetupPage> createState() => _PrizeSetupPageState();
+}
+
+class _PrizeSetupPageState extends State<PrizeSetupPage> {
+  final _functions = FirebaseFunctions.instance;
+  
+  // データ
+  Map<String, dynamic>? _tournamentData;
+  Map<String, dynamic>? _mainViewData;
+  bool _isLoading = true;
+  String? _errorMessage;
+  
+  // 入力値
+  double _prizeRatio = 0.0; // プライズに回す比率
+  int _prizeReceiverCount = 0; // プライズ受け取り人数
+  List<double> _prizePercentages = []; // 各順位の配分比率
+  List<int> _prizeAmounts = []; // 各順位の金額
+  String _selectedPointType = 'pointA'; // 選択されたポイントタイプ
+  
+  // 計算結果
+  int _totalRevenue = 0; // 売上合計
+  int _totalPrizePool = 0; // プライズプール合計
+  
+  @override
+  void initState() {
+    super.initState();
+    _loadTournamentData();
+  }
+  
+  Future<void> _loadTournamentData() async {
+    try {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+      
+      final callable = _functions.httpsCallable('getPrizeData');
+      final result = await callable.call({
+        'tournamentId': widget.tournamentId,
+      });
+      
+      if (result.data['success'] == true) {
+        // デバッグログ: 取得されたデータの型を確認
+        print('=== PrizeSetup データ型デバッグ ===');
+        print('result.data type: ${result.data.runtimeType}');
+        print('result.data keys: ${result.data.keys.toList()}');
+        
+        // tournamentData の型確認
+        final tournamentDataRaw = result.data['tournamentData'];
+        print('tournamentDataRaw type: ${tournamentDataRaw.runtimeType}');
+        print('tournamentDataRaw: $tournamentDataRaw');
+        
+        // mainViewData の型確認
+        final mainViewDataRaw = result.data['mainViewData'];
+        print('mainViewDataRaw type: ${mainViewDataRaw.runtimeType}');
+        print('mainViewDataRaw: $mainViewDataRaw');
+        
+        setState(() {
+          try {
+            _tournamentData = tournamentDataRaw != null 
+                ? Map<String, dynamic>.from(tournamentDataRaw as Map)
+                : <String, dynamic>{};
+            print('tournamentData 変換成功: ${_tournamentData.runtimeType}');
+          } catch (e) {
+            print('tournamentData 変換エラー: $e');
+            _tournamentData = <String, dynamic>{};
+          }
+          
+          try {
+            _mainViewData = mainViewDataRaw != null 
+                ? Map<String, dynamic>.from(mainViewDataRaw as Map)
+                : <String, dynamic>{};
+            print('mainViewData 変換成功: ${_mainViewData.runtimeType}');
+          } catch (e) {
+            print('mainViewData 変換エラー: $e');
+            _mainViewData = <String, dynamic>{};
+          }
+          
+          _calculateInitialValues();
+        });
+        print('=== End PrizeSetup データ型デバッグ ===');
+      } else {
+        setState(() {
+          _errorMessage = result.data['error'] ?? 'データの取得に失敗しました';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'エラーが発生しました: $e';
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+  
+  // 安全な型変換ヘルパーメソッド
+  int _getIntValue(Map<String, dynamic>? data, String key, {int defaultValue = 0}) {
+    if (data == null) {
+      print('_getIntValue: data is null for key: $key');
+      return defaultValue;
+    }
+    final value = data[key];
+    print('_getIntValue: key=$key, value=$value, type=${value.runtimeType}');
+    if (value is int) return value;
+    if (value is double) return value.toInt();
+    if (value is String) return int.tryParse(value) ?? defaultValue;
+    print('_getIntValue: 未対応の型 ${value.runtimeType} for key: $key');
+    return defaultValue;
+  }
+  
+  void _calculateInitialValues() {
+    if (_tournamentData == null || _mainViewData == null) {
+      print('=== PrizeSetup データ不足エラー ===');
+      print('tournamentData: $_tournamentData');
+      print('mainViewData: $_mainViewData');
+      print('=== End データ不足エラー ===');
+      return;
+    }
+    
+    // デバッグログ: 取得されたデータを確認
+    print('=== PrizeSetup Debug ===');
+    print('tournamentData: $_tournamentData');
+    print('mainViewData: $_mainViewData');
+    
+    // 売上合計を計算
+    final entryFee = _getIntValue(_mainViewData, 'entryFee');
+    final reentryFee = _getIntValue(_mainViewData, 'reentryFee');
+    final addonFee = _getIntValue(_mainViewData, 'addonFee');
+    final entries = _getIntValue(_mainViewData, 'entries');
+    final reentries = _getIntValue(_mainViewData, 'reentries');
+    final addons = _getIntValue(_mainViewData, 'addons');
+    
+    // デバッグログ: 計算に使用する値を確認
+    print('entryFee: $entryFee, reentryFee: $reentryFee, addonFee: $addonFee');
+    print('entries: $entries, reentries: $reentries, addons: $addons');
+    
+    _totalRevenue = (entryFee * entries) + (reentryFee * reentries) + (addonFee * addons);
+    
+    // デバッグログ: 計算結果を確認
+    print('totalRevenue: $_totalRevenue');
+    print('=== End Debug ===');
+    
+    // デバッグログ: snapshot取得の詳細確認
+    print('=== Snapshot デバッグ ===');
+    final snapshotRaw = _tournamentData?['snapshot'];
+    print('snapshotRaw type: ${snapshotRaw.runtimeType}');
+    print('snapshotRaw: $snapshotRaw');
+    
+    Map<String, dynamic>? snapshot;
+    try {
+      if (snapshotRaw is Map) {
+        snapshot = Map<String, dynamic>.from(snapshotRaw);
+        print('snapshot 変換成功: ${snapshot.runtimeType}');
+      } else {
+        print('snapshotRaw がMapではありません: ${snapshotRaw.runtimeType}');
+        snapshot = null;
+      }
+    } catch (e) {
+      print('snapshot 変換エラー: $e');
+      snapshot = null;
+    }
+    
+    // デフォルトのプライズ比率を設定（snapshotから取得）
+    try {
+      final prizeRateBps = _getIntValue(snapshot, 'prizeRateBps', defaultValue: 7000);
+      print('prizeRateBps 取得成功: $prizeRateBps');
+      _prizeRatio = prizeRateBps / 10000.0;
+      print('_prizeRatio 設定成功: $_prizeRatio');
+    } catch (e) {
+      print('prizeRateBps 取得エラー: $e');
+      _prizeRatio = 0.7; // デフォルト値
+    }
+    
+    // デフォルトのポイントタイプを設定（snapshotから取得）
+    try {
+      _selectedPointType = snapshot?['pointType'] as String? ?? 'pointA';
+      print('_selectedPointType 設定成功: $_selectedPointType');
+    } catch (e) {
+      print('_selectedPointType 設定エラー: $e');
+      _selectedPointType = 'pointA';
+    }
+    
+    print('=== End Snapshot デバッグ ===');
+    
+    // デフォルトのプライズ受け取り人数を計算
+    final totalParticipants = entries + reentries;
+    _prizeReceiverCount = ((totalParticipants * GlobalConstants.prizeReceiverPercentage) / 100).round();
+    if (_prizeReceiverCount < 1) _prizeReceiverCount = 1;
+    if (_prizeReceiverCount > 10) _prizeReceiverCount = 10;
+    
+    _updatePrizeDistribution();
+  }
+  
+  void _updatePrizeDistribution() {
+    print('=== _updatePrizeDistribution デバッグ ===');
+    print('_totalRevenue: $_totalRevenue');
+    print('_prizeRatio: $_prizeRatio');
+    
+    _totalPrizePool = (_totalRevenue * _prizeRatio).round();
+    print('_totalPrizePool 計算結果: $_totalPrizePool');
+    
+    // 配分比率を取得
+    _prizePercentages = List.from(GlobalConstants.prizeDistribution[_prizeReceiverCount] ?? [100.0]);
+    
+    // 各順位の金額を計算
+    _prizeAmounts.clear();
+    for (int i = 0; i < _prizeReceiverCount; i++) {
+      double percentage = _prizePercentages[i];
+      double amount = (_totalPrizePool * percentage / 100);
+      
+      int finalAmount;
+      switch (GlobalConstants.prizeRoundingMethod) {
+        case 'ceil':
+          finalAmount = amount.ceil();
+          break;
+        case 'round':
+          finalAmount = amount.round();
+          break;
+        case 'floor':
+        default:
+          finalAmount = amount.floor();
+          break;
+      }
+      
+      // 100の位で丸める
+      finalAmount = (finalAmount ~/ 100) * 100;
+      _prizeAmounts.add(finalAmount);
+    }
+  }
+  
+  Future<void> _savePrizeData() async {
+    try {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+      
+      // プライズデータを準備
+      Map<String, dynamic> prizeData = {
+        'prizePool': _totalPrizePool,
+        'prizeReceiverCount': _prizeReceiverCount,
+        'pointType': _selectedPointType,
+      };
+      
+      // 各順位のプライズを追加
+      for (int i = 0; i < _prizeReceiverCount; i++) {
+        prizeData['${i + 1}stPrize'] = _prizeAmounts[i];
+        // プレイヤー名とUIDをnullで初期化
+        prizeData['${i + 1}stPlayerName'] = null;
+        prizeData['${i + 1}stPlayerUid'] = null;
+      }
+      
+      final callable = _functions.httpsCallable('setPrizeData');
+      final result = await callable.call({
+        'tournamentId': widget.tournamentId,
+        'prizeData': prizeData,
+      });
+      
+      if (result.data['success'] == true) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('プライズデータを保存しました')),
+          );
+          Navigator.of(context).pop();
+        }
+      } else {
+        setState(() {
+          _errorMessage = result.data['error'] ?? 'データの保存に失敗しました';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'エラーが発生しました: $e';
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    print('=== build メソッド開始 ===');
+    print('_isLoading: $_isLoading');
+    print('_errorMessage: $_errorMessage');
+    print('_tournamentData: $_tournamentData');
+    print('_mainViewData: $_mainViewData');
+    print('=== build メソッド開始 ===');
+    
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('プライズ確定'),
+        backgroundColor: Colors.blue.shade700,
+        foregroundColor: Colors.white,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _errorMessage != null
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.error, color: Colors.red, size: 48),
+                      const SizedBox(height: 16),
+                      Text(_errorMessage!, style: const TextStyle(color: Colors.red)),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: _loadTournamentData,
+                        child: const Text('再試行'),
+                      ),
+                    ],
+                  ),
+                )
+              : SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // 売上情報
+                      _buildRevenueSection(),
+                      const SizedBox(height: 24),
+                      
+                      // プライズ比率設定
+                      _buildPrizeRatioSection(),
+                      const SizedBox(height: 24),
+                      
+                      // プライズ受け取り人数設定
+                      _buildPrizeReceiverCountSection(),
+                      const SizedBox(height: 24),
+                      
+                      // ポイントタイプ選択
+                      _buildPointTypeSection(),
+                      const SizedBox(height: 24),
+                      
+                      // プライズ配分表示
+                      _buildPrizeDistributionSection(),
+                      const SizedBox(height: 32),
+                      
+                      // 確定ボタン
+                      SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: _savePrizeData,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.green,
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                          ),
+                          child: const Text(
+                            'プライズ確定',
+                            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+    );
+  }
+  
+  Widget _buildRevenueSection() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '売上情報',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            Text('売上合計: ¥${_totalRevenue.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}'),
+            const SizedBox(height: 8),
+            Text('プライズプール: ¥${_totalPrizePool.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}'),
+          ],
+        ),
+      ),
+    );
+  }
+  
+  Widget _buildPrizeRatioSection() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'プライズ比率設定',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: Slider(
+                    value: _prizeRatio,
+                    min: 0.0,
+                    max: 1.0,
+                    divisions: 100,
+                    label: '${(_prizeRatio * 100).toStringAsFixed(1)}%',
+                    onChanged: (value) {
+                      setState(() {
+                        _prizeRatio = value;
+                        _updatePrizeDistribution();
+                      });
+                    },
+                  ),
+                ),
+                SizedBox(
+                  width: 80,
+                  child: Text(
+                    '${(_prizeRatio * 100).toStringAsFixed(1)}%',
+                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+  
+  Widget _buildPrizeReceiverCountSection() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'プライズ受け取り人数',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: Slider(
+                    value: _prizeReceiverCount.toDouble(),
+                    min: 1.0,
+                    max: 10.0,
+                    divisions: 9,
+                    label: '$_prizeReceiverCount人',
+                    onChanged: (value) {
+                      setState(() {
+                        _prizeReceiverCount = value.round();
+                        _updatePrizeDistribution();
+                      });
+                    },
+                  ),
+                ),
+                SizedBox(
+                  width: 80,
+                  child: Text(
+                    '$_prizeReceiverCount人',
+                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+  
+  Widget _buildPrizeDistributionSection() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'プライズ配分',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            ...List.generate(_prizeReceiverCount, (index) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 60,
+                      child: Text(
+                        '${index + 1}位:',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    Expanded(
+                      child: Slider(
+                        value: _prizePercentages[index],
+                        min: 0.0,
+                        max: 100.0,
+                        divisions: 1000,
+                        label: '${_prizePercentages[index].toStringAsFixed(1)}%',
+                        onChanged: (value) {
+                          setState(() {
+                            _prizePercentages[index] = value;
+                            _updatePrizeDistribution();
+                          });
+                        },
+                      ),
+                    ),
+                    SizedBox(
+                      width: 80,
+                      child: Text(
+                        '${_prizePercentages[index].toStringAsFixed(1)}%',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    SizedBox(
+                      width: 100,
+                      child: Text(
+                        '¥${_prizeAmounts[index].toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                        style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.green),
+                        textAlign: TextAlign.right,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+  
+  Widget _buildPointTypeSection() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'ポイントタイプ',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              value: _selectedPointType,
+              decoration: const InputDecoration(
+                labelText: 'ポイントタイプを選択',
+                border: OutlineInputBorder(),
+              ),
+              items: GlobalConstants.pointTypes.map((String pointType) {
+                return DropdownMenuItem<String>(
+                  value: pointType,
+                  child: Text(pointType),
+                );
+              }).toList(),
+              onChanged: (String? newValue) {
+                if (newValue != null) {
+                  setState(() {
+                    _selectedPointType = newValue;
+                  });
+                }
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/scheduledTournament/pages/ranking_setup_page.dart
+++ b/lib/scheduledTournament/pages/ranking_setup_page.dart
@@ -1,0 +1,486 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import '../../globalConstant.dart';
+
+class RankingSetupPage extends StatefulWidget {
+  final String tournamentId;
+  
+  const RankingSetupPage({
+    super.key,
+    required this.tournamentId,
+  });
+
+  @override
+  State<RankingSetupPage> createState() => _RankingSetupPageState();
+}
+
+class _RankingSetupPageState extends State<RankingSetupPage> {
+  final _functions = FirebaseFunctions.instance;
+  
+  // データ
+  Map<String, dynamic>? _mainViewData;
+  List<Map<String, dynamic>> _bustedPlayers = [];
+  bool _isLoading = true;
+  String? _errorMessage;
+  
+  // 選択されたプレイヤー
+  Map<int, String?> _selectedPlayers = {}; // 順位 -> playerId
+  Map<String, Map<String, dynamic>> _playerData = {}; // playerId -> playerData
+  
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+  
+  Future<void> _loadData() async {
+    try {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+      
+      // メインビューデータとバストプレイヤーデータを取得
+      final callable = _functions.httpsCallable('getRankingData');
+      final result = await callable.call({
+        'tournamentId': widget.tournamentId,
+      });
+      
+      if (result.data['success'] == true) {
+        setState(() {
+          _mainViewData = Map<String, dynamic>.from(result.data['mainViewData']);
+          _bustedPlayers = List<Map<String, dynamic>>.from(
+            result.data['bustedPlayers'].map((player) => Map<String, dynamic>.from(player))
+          );
+          _initializeSelectedPlayers();
+        });
+      } else {
+        setState(() {
+          _errorMessage = result.data['error'] ?? 'データの取得に失敗しました';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'エラーが発生しました: $e';
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+  
+  void _initializeSelectedPlayers() {
+    if (_mainViewData == null) return;
+    
+    final prizeReceiverCount = _mainViewData!['prizeReceiverCount'] as int? ?? 0;
+    _selectedPlayers = {};
+    
+    // 既に登録されているプレイヤーを設定
+    for (int i = 1; i <= prizeReceiverCount; i++) {
+      final playerName = _mainViewData!['${i}stPlayerName'] as String?;
+      final playerUid = _mainViewData!['${i}stPlayerUid'] as String?;
+      
+      if (playerName != null && playerUid != null) {
+        _selectedPlayers[i] = playerUid;
+        _playerData[playerUid] = {
+          'pokerName': playerName,
+          'uid': playerUid,
+        };
+      }
+    }
+  }
+  
+  int _getPrizeAmount(int rank) {
+    if (_mainViewData == null) return 0;
+    return _mainViewData!['${rank}stPrize'] as int? ?? 0;
+  }
+  
+  bool _isPlayerSelected(int rank) {
+    return _selectedPlayers[rank] != null;
+  }
+  
+  bool _isPlayerDisabled(String playerId) {
+    return _selectedPlayers.values.contains(playerId);
+  }
+  
+  void _selectPlayer(int rank, String playerId) {
+    setState(() {
+      _selectedPlayers[rank] = playerId;
+      final player = _bustedPlayers.firstWhere((p) => p['uid'] == playerId);
+      _playerData[playerId] = {
+        'pokerName': player['pokerName'],
+        'uid': playerId,
+      };
+    });
+  }
+  
+  void _clearPlayer(int rank) {
+    setState(() {
+      final playerId = _selectedPlayers[rank];
+      if (playerId != null) {
+        _playerData.remove(playerId);
+      }
+      _selectedPlayers[rank] = null;
+    });
+  }
+  
+  Future<void> _confirmRanking() async {
+    final selectedCount = _selectedPlayers.values.where((id) => id != null).length;
+    if (selectedCount == 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('最低1名のプレイヤーを選択してください')),
+      );
+      return;
+    }
+    
+    // 確認ダイアログを表示
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('順位確定'),
+        content: Text('${selectedCount}位に${_playerData[_selectedPlayers[selectedCount]]?['pokerName']}様を登録します。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('確定'),
+          ),
+        ],
+      ),
+    );
+    
+    if (confirmed != true) return;
+    
+    try {
+      setState(() {
+        _isLoading = true;
+      });
+      
+      // 順位データを準備
+      final rankingData = <String, dynamic>{};
+      for (int rank = 1; rank <= _selectedPlayers.length; rank++) {
+        final playerId = _selectedPlayers[rank];
+        if (playerId != null) {
+          final player = _playerData[playerId]!;
+          rankingData['${rank}stPlayerName'] = player['pokerName'];
+          rankingData['${rank}stPlayerUid'] = playerId;
+        }
+      }
+      
+      final callable = _functions.httpsCallable('setRankingData');
+      final result = await callable.call({
+        'tournamentId': widget.tournamentId,
+        'rankingData': rankingData,
+      });
+      
+      if (result.data['success'] == true) {
+        // 全ての順位が埋まっているかチェック
+        final allRanksFilled = _checkAllRanksFilled();
+        
+        if (allRanksFilled) {
+          // トーナメント終了処理の確認
+          final endTournament = await showDialog<bool>(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('トーナメント終了'),
+              content: const Text('トーナメントの終了処理を行いますか？'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('キャンセル'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(true),
+                  child: const Text('終了処理を行う'),
+                ),
+              ],
+            ),
+          );
+          
+          if (endTournament == true) {
+            await _endTournament();
+          }
+        }
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('順位を確定しました')),
+        );
+        Navigator.of(context).pop();
+      } else {
+        setState(() {
+          _errorMessage = result.data['error'] ?? '順位の確定に失敗しました';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'エラーが発生しました: $e';
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+  
+  bool _checkAllRanksFilled() {
+    if (_mainViewData == null) return false;
+    final prizeReceiverCount = _mainViewData!['prizeReceiverCount'] as int? ?? 0;
+    
+    for (int i = 1; i <= prizeReceiverCount; i++) {
+      if (_selectedPlayers[i] == null) return false;
+    }
+    return true;
+  }
+  
+  Future<void> _endTournament() async {
+    try {
+      final callable = _functions.httpsCallable('endTournament');
+      final result = await callable.call({
+        'tournamentId': widget.tournamentId,
+      });
+      
+      if (result.data['success'] == true) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('トーナメントを終了しました')),
+        );
+        Navigator.of(context).pop();
+      } else {
+        setState(() {
+          _errorMessage = result.data['error'] ?? 'トーナメントの終了に失敗しました';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'エラーが発生しました: $e';
+      });
+    }
+  }
+  
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    
+    if (_errorMessage != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('順位確定')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(_errorMessage!),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _loadData,
+                child: const Text('再試行'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    
+    final prizeReceiverCount = _mainViewData?['prizeReceiverCount'] as int? ?? 0;
+    
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('順位確定'),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // プライズ情報
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'プライズ情報',
+                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    Text('プライズプール: ¥${(_mainViewData?['prizePool'] as int? ?? 0).toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}'),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            
+            // 順位選択
+            ...List.generate(prizeReceiverCount, (index) {
+              final rank = index + 1;
+              final prizeAmount = _getPrizeAmount(rank);
+              final isSelected = _isPlayerSelected(rank);
+              final selectedPlayerId = _selectedPlayers[rank];
+              final selectedPlayer = selectedPlayerId != null ? _playerData[selectedPlayerId] : null;
+              
+              return Card(
+                margin: const EdgeInsets.only(bottom: 16),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            '${rank}位',
+                            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                          const SizedBox(width: 16),
+                          Text(
+                            '¥${prizeAmount.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                            style: const TextStyle(fontSize: 16, color: Colors.green, fontWeight: FontWeight.bold),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      
+                      if (isSelected && selectedPlayer != null)
+                        // 選択済みプレイヤー表示
+                        Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Colors.green[50],
+                            border: Border.all(color: Colors.green),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            children: [
+                              Icon(Icons.person, color: Colors.green[700]),
+                              const SizedBox(width: 8),
+                              Text(
+                                selectedPlayer['pokerName'],
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.green[700],
+                                ),
+                              ),
+                              const Spacer(),
+                              if (!_isPlayerDisabled(selectedPlayerId!))
+                                IconButton(
+                                  onPressed: () => _clearPlayer(rank),
+                                  icon: const Icon(Icons.clear, color: Colors.red),
+                                ),
+                            ],
+                          ),
+                        )
+                      else
+                        // プレイヤー選択ボタン
+                        ElevatedButton.icon(
+                          onPressed: () => _showPlayerSelector(rank),
+                          icon: const Icon(Icons.person_add),
+                          label: const Text('プレイヤーを選択'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.blue,
+                            foregroundColor: Colors.white,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              );
+            }),
+            
+            const SizedBox(height: 32),
+            
+            // 確定ボタン
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _confirmRanking,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.green,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child: const Text(
+                  'プライズ付与',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+  
+  void _showPlayerSelector(int rank) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('${rank}位のプレイヤーを選択'),
+        content: SizedBox(
+          width: double.maxFinite,
+          height: 400,
+          child: ListView.builder(
+            itemCount: _bustedPlayers.length,
+            itemBuilder: (context, index) {
+              final player = _bustedPlayers[index];
+              final isDisabled = _isPlayerDisabled(player['uid']);
+              
+              return Card(
+                margin: const EdgeInsets.symmetric(vertical: 4),
+                child: ListTile(
+                  title: Text(
+                    player['pokerName'] ?? '不明なプレイヤー',
+                    style: TextStyle(
+                      color: isDisabled ? Colors.grey : null,
+                    ),
+                  ),
+                  subtitle: Text(
+                    '退席時刻: ${_formatDateTime(player['bustAt'])}',
+                    style: TextStyle(
+                      color: isDisabled ? Colors.grey : null,
+                    ),
+                  ),
+                  enabled: !isDisabled,
+                  onTap: isDisabled ? null : () {
+                    _selectPlayer(rank, player['uid']);
+                    Navigator.of(context).pop();
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('キャンセル'),
+          ),
+        ],
+      ),
+    );
+  }
+  
+  String _formatDateTime(dynamic timestamp) {
+    if (timestamp == null) return '不明';
+    
+    try {
+      if (timestamp is Map && timestamp.containsKey('_seconds')) {
+        final seconds = timestamp['_seconds'] as int;
+        final date = DateTime.fromMillisecondsSinceEpoch(seconds * 1000);
+        return '${date.year}/${date.month}/${date.day} ${date.hour}:${date.minute.toString().padLeft(2, '0')}';
+      }
+      return timestamp.toString();
+    } catch (e) {
+      return '不明';
+    }
+  }
+}

--- a/lib/scheduledTournament/pages/scheduled_tournament_home_page.dart
+++ b/lib/scheduledTournament/pages/scheduled_tournament_home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 
 import '../widgets/add_table_dialog.dart';
 import '../widgets/assign_seat_dialog.dart';
@@ -9,6 +10,8 @@ import '../models/table_and_users.dart';
 import '../services/tournament_data_service.dart';
 import '../scheduled_tournament_service.dart';
 import 'tableHomeInScheduledTournament.dart';
+import 'prize_setup_page.dart';
+import 'ranking_setup_page.dart';
 
 class ScheduledTournamentHomePage extends StatefulWidget {
   final String tournamentId;
@@ -212,9 +215,102 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
   }
 
   void _confirmPrizes() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('プライズを確定する機能が実装されました')),
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => PrizeSetupPage(
+          tournamentId: widget.tournamentId,
+        ),
+      ),
     );
+  }
+
+  void _confirmRankings() async {
+    try {
+      // プライズプールの存在確認
+      final mainViewDoc = await FirebaseFirestore.instance
+          .collection('scheduledTournaments')
+          .doc(widget.tournamentId)
+          .collection('views')
+          .doc('main')
+          .get();
+      
+      if (!mainViewDoc.exists) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('トーナメントデータが見つかりません')),
+        );
+        return;
+      }
+      
+      final mainViewData = Map<String, dynamic>.from(mainViewDoc.data()!);
+      final prizePool = mainViewData['prizePool'];
+      
+      if (prizePool == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('プライズの確定が行われていないため、先にプライズ確定を行ってください')),
+        );
+        return;
+      }
+      
+      // 順位確定画面に遷移
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => RankingSetupPage(
+            tournamentId: widget.tournamentId,
+          ),
+        ),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('エラーが発生しました: $e')),
+      );
+    }
+  }
+
+  void _endTournament() async {
+    // 確認ダイアログを表示
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('トーナメント終了'),
+        content: const Text('トーナメントの終了処理を行いますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('終了処理を行う'),
+          ),
+        ],
+      ),
+    );
+    
+    if (confirmed != true) return;
+    
+    try {
+      // 終了処理を実行
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('endTournament');
+      final result = await callable.call({
+        'tournamentId': widget.tournamentId,
+      });
+      
+      if (result.data['success'] == true) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('トーナメントを終了しました')),
+        );
+        Navigator.of(context).pop();
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(result.data['error'] ?? '終了処理に失敗しました')),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('エラーが発生しました: $e')),
+      );
+    }
   }
 
   /// 統計アイテムを構築
@@ -269,18 +365,24 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
 
   /// 下部アクションバーを構築
   Widget _buildBottomActionBar() {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Colors.grey[50],
-        border: Border(
-          top: BorderSide(color: Colors.grey[300]!),
+    return ExpansionTile(
+      title: const Text(
+        'トーナメント操作',
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
         ),
       ),
-      child: Row(
+      leading: const Icon(Icons.settings),
+      backgroundColor: Colors.grey[50],
+      collapsedBackgroundColor: Colors.grey[100],
+      childrenPadding: const EdgeInsets.all(16),
+      children: [
+        Row(
         children: [
-          // 左側: トーナメント状況表示
-          Expanded(
+          // 左側: トーナメント状況表示（画面幅の2/3に固定）
+          SizedBox(
+            width: MediaQuery.of(context).size.width * 0.67,
             child: Container(
               padding: const EdgeInsets.all(10),
               decoration: BoxDecoration(
@@ -304,7 +406,9 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
                     return const Center(child: CircularProgressIndicator());
                   }
                   
-                  final data = snapshot.data?.data() as Map<String, dynamic>?;
+                  final data = snapshot.data?.data() != null 
+                      ? Map<String, dynamic>.from(snapshot.data!.data()! as Map)
+                      : null;
                   
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -481,46 +585,81 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
           
           const SizedBox(width: 16),
           
-          // 右側: アクションボタン（縦並び）
-          Column(
-            mainAxisSize: MainAxisSize.min,
+          // 右側: アクションボタン（2列縦並びレイアウト）
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              ElevatedButton.icon(
-                onPressed: () => _registerParticipant(),
-                icon: const Icon(Icons.person_add),
-                label: const Text('参加者登録'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.green,
-                  foregroundColor: Colors.white,
-                  minimumSize: const Size(120, 40),
-                ),
+              // 左列: 参加者登録、全員リシート、プライズ確定
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ElevatedButton.icon(
+                    onPressed: () => _registerParticipant(),
+                    icon: const Icon(Icons.person_add),
+                    label: const Text('参加者登録'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      foregroundColor: Colors.white,
+                      minimumSize: Size(MediaQuery.of(context).size.width * 0.11, 40),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton.icon(
+                    onPressed: () => _reseatAllPlayers(),
+                    icon: const Icon(Icons.shuffle),
+                    label: const Text('全員リシート'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orange,
+                      foregroundColor: Colors.white,
+                      minimumSize: Size(MediaQuery.of(context).size.width * 0.11, 40),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton.icon(
+                    onPressed: () => _confirmPrizes(),
+                    icon: const Icon(Icons.emoji_events),
+                    label: const Text('プライズ確定'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.purple,
+                      foregroundColor: Colors.white,
+                      minimumSize: Size(MediaQuery.of(context).size.width * 0.11, 40),
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(height: 8),
-              ElevatedButton.icon(
-                onPressed: () => _reseatAllPlayers(),
-                icon: const Icon(Icons.shuffle),
-                label: const Text('全員リシート'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.orange,
-                  foregroundColor: Colors.white,
-                  minimumSize: const Size(120, 40),
-                ),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton.icon(
-                onPressed: () => _confirmPrizes(),
-                icon: const Icon(Icons.emoji_events),
-                label: const Text('プライズ確定'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.purple,
-                  foregroundColor: Colors.white,
-                  minimumSize: const Size(120, 40),
-                ),
+              const SizedBox(width: 16),
+              // 右列: 順位確定、終了処理
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ElevatedButton.icon(
+                    onPressed: () => _confirmRankings(),
+                    icon: const Icon(Icons.leaderboard),
+                    label: const Text('順位確定'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.indigo,
+                      foregroundColor: Colors.white,
+                      minimumSize: Size(MediaQuery.of(context).size.width * 0.11, 40),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton.icon(
+                    onPressed: () => _endTournament(),
+                    icon: const Icon(Icons.stop),
+                    label: const Text('終了処理'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                      foregroundColor: Colors.white,
+                      minimumSize: Size(MediaQuery.of(context).size.width * 0.11, 40),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
         ],
-      ),
+        ),
+      ],
     );
   }
 
@@ -596,7 +735,9 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
           }
 
           // データ取得成功
-          final data = snapshot.data!.data() as Map<String, dynamic>?;
+          final data = snapshot.data!.data() != null 
+              ? Map<String, dynamic>.from(snapshot.data!.data()! as Map)
+              : null;
           debugPrint('=== views/main データ取得成功 ===');
           debugPrint('データ: $data');
 
@@ -685,7 +826,9 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
                                     return const Center(child: CircularProgressIndicator());
                                   }
 
-                                  final waitingData = waitingSnapshot.data?.data() as Map<String, dynamic>?;
+                                  final waitingData = waitingSnapshot.data?.data() != null 
+                                      ? Map<String, dynamic>.from(waitingSnapshot.data!.data()! as Map)
+                                      : null;
                                   final waitingList = waitingData?['waiting'] as Map<String, dynamic>? ?? {};
                                   final waitingCount = waitingList.length;
 
@@ -834,7 +977,9 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
                                       
                                       int totalOccupiedSeats = 0;
                                       for (final tableDoc in tables) {
-                                        final tableData = tableDoc.data() as Map<String, dynamic>?;
+                                        final tableData = tableDoc.data() != null 
+                                            ? Map<String, dynamic>.from(tableDoc.data()! as Map)
+                                            : null;
                                         final seats = tableData?['seats'] as Map<String, dynamic>? ?? {};
                                         
                                         // nullでないseatXXUserIdフィールドの数をカウント
@@ -906,7 +1051,9 @@ class _ScheduledTournamentHomePageState extends State<ScheduledTournamentHomePag
                                     itemBuilder: (context, index) {
                                       final tableDoc = tables[index];
                                       final tableId = tableDoc.id;
-                                      final tableData = tableDoc.data() as Map<String, dynamic>?;
+                                      final tableData = tableDoc.data() != null 
+                                          ? Map<String, dynamic>.from(tableDoc.data()! as Map)
+                                          : null;
                                       final seats = tableData?['seats'] as Map<String, dynamic>? ?? {};
                                       // seatXXUserIdフィールドの数をカウント
                                       final userIdFields = seats.keys.where((key) => key.endsWith('UserId')).length;


### PR DESCRIPTION
- プライズ確定画面での型キャストエラーを修正
- getPrizeData Cloud FunctionでmainViewDataに料金情報を追加
- bustAndExitとendTournamentのFirestoreトランザクションエラーを修正
- 読み取り操作を書き込み操作より前に移動してトランザクション制約を遵守
- デバッグログを追加してエラー診断を改善

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implement prize/ranking management, action log + rollback system, busted tracking, and tournament end flow across Cloud Functions and Flutter UI.
> 
> - **Backend (Cloud Functions)**
>   - **Prize/Ranking Workflow**:
>     - Add `getPrizeData`, `setPrizeData`, `getRankingData`, `setRankingData`, and `endTournament` callables.
>     - Extend `createScheduledTournament` snapshot with `pointType`; create `tablesSeat/busted` doc on init.
>     - Update `bustAndExit` to read/write busted info; `registerParticipants` removes user from `tablesSeat/busted` on reentry.
>   - **Action Logs & Rollback**:
>     - Add `types/actionLog`, logger (`lib/actionLogger.ts`), `getActionLogs`, and `rollbackAction` with undo handlers: `undoAddon`, `undoBulkAddon`, `undoBustAndExit`, `undoBustAndReentry`, `undoRegisterParticipants`, `undoAssignSeatToPlayer`, `undoReseatAllPlayers`.
>     - Export new callables in `callables/index.ts`.
> - **Frontend (Flutter)**
>   - **Prize/Ranking UI**:
>     - New pages: `scheduledTournament/pages/prize_setup_page.dart` and `ranking_setup_page.dart` (compute/save prize pool, assign winners, optional end tournament).
>     - Update `scheduled_tournament_home_page.dart`: add actions (Prize confirm, Ranking confirm, End tournament), UI refactor (ExpansionTile panel), safer Firestore map parsing.
>   - **Action History UI**:
>     - New `ActionHistory/tournamentActionsHistoryPage.dart` to view/filter logs and trigger rollbacks.
>   - **Template & Constants**:
>     - `Tournament/createTournamentTemplatePage.dart`: add point type selector; Functions `createTournamentTemplate`/`createScheduledTournament` mirror point type.
>     - `globalConstant.dart`: add prize config, distribution map, and `pointTypes`.
>   - **Misc**:
>     - Initialize users with point fields (comments clarifying mapping).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b727f4afb02287ba12a2c781223452c307b19f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->