### PR TITLE
スタッフの銀行口座情報管理機能を実装

### DIFF
--- a/functions/src/callables/index.ts
+++ b/functions/src/callables/index.ts
@@ -4,6 +4,7 @@ export { getTodayTournaments } from './getTodayTournaments';
 export { getUpcomingTournaments } from './getUpcomingTournaments';
 export { registerForTournament } from './registerForTournament';
 export { updateStaffHourlyWage } from './updateStaffHourlyWage';
+export { updateStaffBankInfo } from './updateStaffBankInfo';
 export { getPayrollData } from './getPayrollData';
 export { addTableToTournament } from './addTableToTournament';
 export { assignSeatToPlayer } from './assignSeatToPlayer';

--- a/functions/src/callables/updateStaffBankInfo.ts
+++ b/functions/src/callables/updateStaffBankInfo.ts
@@ -1,0 +1,101 @@
+import * as admin from 'firebase-admin';
+import {HttpsError, onCall} from 'firebase-functions/v2/https';
+import {z} from 'zod';
+
+// バリデーションスキーマ
+const bankInfoSchema = z.object({
+  staffId: z.string().min(1, 'スタッフIDが必要です'),
+  bankInfo: z.object({
+    bankName: z.string().min(1, '銀行名が必要です'),
+    branchName: z.string().min(1, '支店名が必要です'),
+    accountType: z.enum(['普通', '当座']),
+    accountNumber: z.string().regex(/^\d{7}$/, '口座番号は7桁の数字である必要があります'),
+    accountHolder: z.string().min(1, '口座名義が必要です'),
+  }),
+});
+
+/**
+ * スタッフの銀行口座情報を更新するCloud Function
+ * 
+ * @param data - スタッフIDと銀行口座情報
+ * @returns 成功メッセージ
+ */
+export const updateStaffBankInfo = onCall(async (request) => {
+  const db = admin.firestore();
+
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const adminId = request.auth.uid;
+
+  try {
+    // リクエストデータのバリデーション
+    const validatedData = bankInfoSchema.parse(request.data);
+    const {staffId, bankInfo} = validatedData;
+
+    console.log(`銀行口座情報更新開始: staffId=${staffId}, adminId=${adminId}`);
+
+    // デバイス権限の確認（role: adminのみ）
+    const deviceQuery = await db.collection('devices')
+      .where('uid', '==', adminId)
+      .where('role', '==', 'admin')
+      .limit(1)
+      .get();
+
+    console.log(`デバイスクエリ結果: ${deviceQuery.size}件`);
+    if (deviceQuery.size > 0) {
+      const deviceData = deviceQuery.docs[0].data();
+      console.log(`デバイス情報:`, deviceData);
+    }
+
+    if (deviceQuery.empty) {
+      // デバッグ用：全デバイスを確認
+      const allDevicesQuery = await db.collection('devices')
+        .where('uid', '==', adminId)
+        .get();
+      console.log(`ユーザー ${adminId} の全デバイス:`, allDevicesQuery.docs.map((doc) => doc.data()));
+      throw new HttpsError('permission-denied', '管理者権限がありません');
+    }
+
+    // スタッフドキュメントの存在確認
+    const staffDoc = await db.collection('staffs').doc(staffId).get();
+    if (!staffDoc.exists) {
+      throw new HttpsError('not-found', 'スタッフが見つかりません');
+    }
+
+    // 銀行口座情報を更新
+    // 注意: 本番環境では銀行口座情報を暗号化して保存することを推奨
+    await db.collection('staffs').doc(staffId).update({
+      bankInfo: {
+        ...bankInfo,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedBy: adminId,
+      },
+    });
+
+    console.log(`銀行口座情報更新成功: staffId=${staffId}`);
+
+    return {
+      success: true,
+      message: '銀行口座情報を更新しました',
+    };
+  } catch (error) {
+    console.error('銀行口座情報更新エラー:', error);
+
+    if (error instanceof z.ZodError) {
+      throw new HttpsError(
+        'invalid-argument',
+        `入力データが無効です: ${error.errors.map((e) => e.message).join(', ')}`
+      );
+    }
+
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    throw new HttpsError('internal', `予期しないエラーが発生しました: ${error}`);
+  }
+});
+

--- a/lib/AttendanceManagement/allStaffAttendancePage.dart
+++ b/lib/AttendanceManagement/allStaffAttendancePage.dart
@@ -13,7 +13,7 @@ class AllStaffAttendancePage extends StatefulWidget {
 }
 
 class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
-  DateTime selectedDate = DateTime.now();
+  late DateTime selectedDate;
   String? selectedStaffId;
   List<String> staffNames = [];
   bool isLoading = false;
@@ -25,10 +25,20 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
   @override
   void initState() {
     super.initState();
+    // 今日の日付から給与計算期間の開始日を計算して初期化
+    selectedDate = _calculatePayrollPeriodStart(DateTime.now());
+    print('=== initState 開始 ===');
+    print('今日の日付: ${DateTime.now()}');
+    print('計算後のselectedDate: $selectedDate');
+    print('selectedDate.month: ${selectedDate.month}');
+    print('selectedDate.year: ${selectedDate.year}');
     _loadAttendanceData();
   }
 
   Future<void> _loadAttendanceData() async {
+    print('=== _loadAttendanceData 開始 ===');
+    print('selectedDate: $selectedDate');
+    
     setState(() {
       isLoading = true;
     });
@@ -40,16 +50,21 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
       final payrollYear = payrollMonth > 12 ? selectedDate.year + 1 : selectedDate.year;
       final adjustedPayrollMonth = payrollMonth > 12 ? 1 : payrollMonth;
       
+      print('給与データ取得パラメータ: month=$adjustedPayrollMonth, year=$payrollYear');
+      
       // 勤怠データと給与データを個別に取得
       Map<String, dynamic> result;
       try {
+        print('勤怠データ取得開始: month=${selectedDate.month}, year=${selectedDate.year}');
         result = await AttendanceService.getAllStaffAttendance(
           month: selectedDate.month,
           year: selectedDate.year,
           startDay: GlobalConstants.PAYROLL_START_DAY,
           endDay: GlobalConstants.PAYROLL_END_DAY,
         );
+        print('勤怠データ取得成功: ${result['attendances']?.length ?? 0}件');
       } catch (e) {
+        print('勤怠データ取得エラー: $e');
         result = {'success': false, 'attendances': [], 'shifts': []};
       }
       
@@ -68,13 +83,19 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
         payrollResult = [];
       }
 
+      print('result["success"]: ${result['success']}');
+      
       if (result['success'] == true) {
+        print('=== 勤怠データ変換開始 ===');
         // 勤怠データの型安全な変換
         final attendancesList = <Map<String, dynamic>>[];
         try {
           final rawAttendances = result['attendances'];
+          print('rawAttendances.length: ${rawAttendances?.length ?? 0}');
+          
           if (rawAttendances is List) {
-            for (final item in rawAttendances) {
+            for (int i = 0; i < rawAttendances.length; i++) {
+              final item = rawAttendances[i];
               if (item is Map) {
                 try {
                   // 各フィールドを明示的に変換
@@ -94,14 +115,16 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
                     'totalMinutes': (item['totalMinutes'] is num) ? (item['totalMinutes'] as num).toInt() : 0,
                   };
                   attendancesList.add(convertedItem);
+                  print('✅ 勤怠データ[$i]変換成功: ${convertedItem['date']}');
                 } catch (e) {
-                  // 個別アイテムの変換エラーは無視
+                  print('❌ 勤怠データ[$i]変換エラー: $e');
                 }
               }
             }
           }
+          print('変換後のattendancesList.length: ${attendancesList.length}');
         } catch (e) {
-          // 勤怠データの変換エラーは無視
+          print('❌ 勤怠データ変換エラー: $e');
         }
         
         // シフトデータの型安全な変換
@@ -138,6 +161,11 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
           // シフトデータの変換エラーは無視
         }
         
+        print('=== setState 前 ===');
+        print('attendancesList.length: ${attendancesList.length}');
+        print('shiftsList.length: ${shiftsList.length}');
+        print('payrollResult.length: ${payrollResult.length}');
+        
         setState(() {
           attendances = attendancesList;
           shifts = shiftsList;
@@ -145,8 +173,14 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
           _updateSummaryData();
           _updateStaffNames();
         });
+        
+        print('=== setState 後 ===');
+        print('attendances.length: ${attendances.length}');
+        print('shifts.length: ${shifts.length}');
+        print('payrollData.length: ${payrollData.length}');
       }
     } catch (e) {
+      print('❌ _loadAttendanceData エラー: $e');
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('勤怠データの取得に失敗しました: $e')),
       );
@@ -225,9 +259,8 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
     final startDay = GlobalConstants.PAYROLL_START_DAY;
     final endDay = GlobalConstants.PAYROLL_END_DAY;
     
-    // selectedDateから給与計算期間を計算
-    final currentMonth = selectedDate.month;
-    final currentYear = selectedDate.year;
+    // _calculatePayrollPeriodStartを使って正しい期間開始日を取得
+    final periodStart = _calculatePayrollPeriodStart(selectedDate);
     
     // 終了日の表示テキストを取得
     String getEndDayText(int year, int month, int day) {
@@ -243,21 +276,16 @@ class _AllStaffAttendancePageState extends State<AllStaffAttendancePage> {
     // 現在の給与計算期間を計算
     String periodText;
     
-    // 給与計算期間の開始日を計算
-    DateTime periodStart;
+    // 給与計算期間の終了日を計算
     DateTime periodEnd;
     
     if (endDay == 0) {
       // 終了日が0の場合：今月開始日〜今月終了日（月を跨がない）
-      // selectedDateから給与計算期間を計算
-      periodStart = DateTime(currentYear, currentMonth, startDay);
-      periodEnd = DateTime(currentYear, currentMonth, DateTime(currentYear, currentMonth + 1, 0).day);
+      periodEnd = DateTime(periodStart.year, periodStart.month, DateTime(periodStart.year, periodStart.month + 1, 0).day);
     } else {
       // 終了日が0以外の場合：月を跨ぐ期間
-      // selectedDateから給与計算期間を計算
-      periodStart = DateTime(currentYear, currentMonth, startDay);
-      final nextMonth = currentMonth == 12 ? 1 : currentMonth + 1;
-      final nextYear = currentMonth == 12 ? currentYear + 1 : currentYear;
+      final nextMonth = periodStart.month == 12 ? 1 : periodStart.month + 1;
+      final nextYear = periodStart.month == 12 ? periodStart.year + 1 : periodStart.year;
       periodEnd = DateTime(nextYear, nextMonth, endDay);
     }
     

--- a/lib/Home/staffDetailPage.dart
+++ b/lib/Home/staffDetailPage.dart
@@ -20,19 +20,109 @@ class _StaffDetailPageState extends State<StaffDetailPage> {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseFunctions _functions = FirebaseFunctions.instance;
   final TextEditingController _hourlyWageController = TextEditingController();
+  
+  // 銀行口座情報用のコントローラー
+  final TextEditingController _bankNameController = TextEditingController();
+  final TextEditingController _branchNameController = TextEditingController();
+  final TextEditingController _accountNumberController = TextEditingController();
+  final TextEditingController _accountHolderController = TextEditingController();
+  String _accountType = '普通'; // 普通 or 当座
+  
   bool _isEditing = false;
+  bool _isEditingBankInfo = false;
   bool _isLoading = false;
 
   @override
   void initState() {
     super.initState();
     _hourlyWageController.text = widget.staffData['hourlyWage']?.toString() ?? '';
+    
+    // 銀行口座情報の初期化
+    final bankInfo = widget.staffData['bankInfo'] as Map<String, dynamic>?;
+    if (bankInfo != null) {
+      _bankNameController.text = bankInfo['bankName']?.toString() ?? '';
+      _branchNameController.text = bankInfo['branchName']?.toString() ?? '';
+      _accountNumberController.text = bankInfo['accountNumber']?.toString() ?? '';
+      _accountHolderController.text = bankInfo['accountHolder']?.toString() ?? '';
+      _accountType = bankInfo['accountType']?.toString() ?? '普通';
+    }
   }
 
   @override
   void dispose() {
     _hourlyWageController.dispose();
+    _bankNameController.dispose();
+    _branchNameController.dispose();
+    _accountNumberController.dispose();
+    _accountHolderController.dispose();
     super.dispose();
+  }
+
+  // 銀行口座情報を更新する関数（Cloud Function経由）
+  Future<void> _updateBankInfo() async {
+    if (_bankNameController.text.isEmpty ||
+        _branchNameController.text.isEmpty ||
+        _accountNumberController.text.isEmpty ||
+        _accountHolderController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('すべての項目を入力してください')),
+      );
+      return;
+    }
+
+    // 口座番号のバリデーション（7桁の数字）
+    if (_accountNumberController.text.length != 7 || 
+        int.tryParse(_accountNumberController.text) == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('口座番号は7桁の数字で入力してください')),
+      );
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      // Cloud Functionを呼び出して銀行口座情報を更新
+      final result = await _functions.httpsCallable('updateStaffBankInfo').call({
+        'staffId': widget.staffId,
+        'bankInfo': {
+          'bankName': _bankNameController.text,
+          'branchName': _branchNameController.text,
+          'accountNumber': _accountNumberController.text,
+          'accountHolder': _accountHolderController.text,
+          'accountType': _accountType,
+        },
+      });
+
+      if (mounted) {
+        if (result.data['success'] == true) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(result.data['message'] ?? '銀行口座情報を更新しました')),
+          );
+          setState(() {
+            _isEditingBankInfo = false;
+          });
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('更新に失敗しました')),
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('更新に失敗しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
   }
 
   Future<void> _updateHourlyWage() async {
@@ -272,9 +362,195 @@ class _StaffDetailPageState extends State<StaffDetailPage> {
             
             const SizedBox(height: 16),
             
+            // 銀行口座情報カード
+            Card(
+              elevation: 4,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        const Text(
+                          '銀行口座情報',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        IconButton(
+                          onPressed: _isLoading ? null : () {
+                            setState(() {
+                              _isEditingBankInfo = !_isEditingBankInfo;
+                              if (!_isEditingBankInfo) {
+                                // キャンセル時に元の値に戻す
+                                final bankInfo = widget.staffData['bankInfo'] as Map<String, dynamic>?;
+                                if (bankInfo != null) {
+                                  _bankNameController.text = bankInfo['bankName']?.toString() ?? '';
+                                  _branchNameController.text = bankInfo['branchName']?.toString() ?? '';
+                                  _accountNumberController.text = bankInfo['accountNumber']?.toString() ?? '';
+                                  _accountHolderController.text = bankInfo['accountHolder']?.toString() ?? '';
+                                  _accountType = bankInfo['accountType']?.toString() ?? '普通';
+                                }
+                              }
+                            });
+                          },
+                          icon: Icon(_isEditingBankInfo ? Icons.close : Icons.edit),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    if (_isEditingBankInfo)
+                      Column(
+                        children: [
+                          TextField(
+                            controller: _bankNameController,
+                            decoration: const InputDecoration(
+                              labelText: '銀行名',
+                              border: OutlineInputBorder(),
+                              hintText: '例: ○○銀行',
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          TextField(
+                            controller: _branchNameController,
+                            decoration: const InputDecoration(
+                              labelText: '支店名',
+                              border: OutlineInputBorder(),
+                              hintText: '例: ○○支店',
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          DropdownButtonFormField<String>(
+                            value: _accountType,
+                            decoration: const InputDecoration(
+                              labelText: '口座種別',
+                              border: OutlineInputBorder(),
+                            ),
+                            items: const [
+                              DropdownMenuItem(value: '普通', child: Text('普通')),
+                              DropdownMenuItem(value: '当座', child: Text('当座')),
+                            ],
+                            onChanged: (value) {
+                              setState(() {
+                                _accountType = value ?? '普通';
+                              });
+                            },
+                          ),
+                          const SizedBox(height: 12),
+                          TextField(
+                            controller: _accountNumberController,
+                            keyboardType: TextInputType.number,
+                            decoration: const InputDecoration(
+                              labelText: '口座番号',
+                              border: OutlineInputBorder(),
+                              hintText: '7桁の数字',
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          TextField(
+                            controller: _accountHolderController,
+                            decoration: const InputDecoration(
+                              labelText: '口座名義（カタカナ）',
+                              border: OutlineInputBorder(),
+                              hintText: '例: ヤマダタロウ',
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: ElevatedButton.icon(
+                                  onPressed: _isLoading ? null : _updateBankInfo,
+                                  icon: _isLoading
+                                      ? const SizedBox(
+                                          width: 16,
+                                          height: 16,
+                                          child: CircularProgressIndicator(strokeWidth: 2),
+                                        )
+                                      : const Icon(Icons.save),
+                                  label: Text(_isLoading ? '保存中...' : '保存'),
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: Colors.green,
+                                    foregroundColor: Colors.white,
+                                    padding: const EdgeInsets.symmetric(vertical: 12),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: OutlinedButton.icon(
+                                  onPressed: _isLoading ? null : () {
+                                    setState(() {
+                                      _isEditingBankInfo = false;
+                                      final bankInfo = widget.staffData['bankInfo'] as Map<String, dynamic>?;
+                                      if (bankInfo != null) {
+                                        _bankNameController.text = bankInfo['bankName']?.toString() ?? '';
+                                        _branchNameController.text = bankInfo['branchName']?.toString() ?? '';
+                                        _accountNumberController.text = bankInfo['accountNumber']?.toString() ?? '';
+                                        _accountHolderController.text = bankInfo['accountHolder']?.toString() ?? '';
+                                        _accountType = bankInfo['accountType']?.toString() ?? '普通';
+                                      }
+                                    });
+                                  },
+                                  icon: const Icon(Icons.cancel),
+                                  label: const Text('キャンセル'),
+                                  style: OutlinedButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(vertical: 12),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      )
+                    else
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _buildBankInfoRow('銀行名', _bankNameController.text.isEmpty ? '未設定' : _bankNameController.text),
+                          const SizedBox(height: 8),
+                          _buildBankInfoRow('支店名', _branchNameController.text.isEmpty ? '未設定' : _branchNameController.text),
+                          const SizedBox(height: 8),
+                          _buildBankInfoRow('口座種別', _accountType),
+                          const SizedBox(height: 8),
+                          _buildBankInfoRow('口座番号', _accountNumberController.text.isEmpty ? '未設定' : _accountNumberController.text),
+                          const SizedBox(height: 8),
+                          _buildBankInfoRow('口座名義', _accountHolderController.text.isEmpty ? '未設定' : _accountHolderController.text),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildBankInfoRow(String label, String value) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 100,
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontWeight: FontWeight.w500,
+              color: Colors.grey,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(fontSize: 16),
+          ),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
- staffDetailPage.dartに銀行口座情報UIを追加
- バリデーション付きupdateStaffBankInfo Cloud Functionを作成
- 銀行口座フィールド追加: 銀行名、支店名、口座種別、口座番号、口座名義
- 管理者権限チェックによる適切なセキュリティ実装
- 口座番号のクライアント側バリデーション（7桁数字）
- セキュリティのためCloud Function経由でFirestore書き込み
- 包括的なエラーハンドリングとユーザーフィードバック
- 将来の銀行振込機能の基盤を準備