### PR TITLE
feat: ログ機能とChip購入処理の実装

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -79,10 +79,16 @@ service cloud.firestore {
       allow write: if false; // 書き込みはCloud Functions経由のみ
     }
 
-    // tables の読み取り（開発用：全許可）
+    // tables の読み取り・書き込み（開発用：全許可）
     match /tables/{tableId} {
-      allow read: if true;
-      allow write: if false; // 書き込みはCloud Functions経由のみ
+      allow read: if true; // 開発用：全許可
+      allow write: if true; // 開発用：全許可
+    }
+
+    // sideGame の読み取り・書き込み（開発用：全許可）
+    match /sideGame/{tableId} {
+      allow read: if true; // 開発用：全許可
+      allow write: if true; // 開発用：全許可
     }
 
     // デバイスコレクション（開発用：読み取り全許可）

--- a/functions/src/callables/createTemporaryTable.ts
+++ b/functions/src/callables/createTemporaryTable.ts
@@ -52,16 +52,17 @@ export const createTemporaryTable = functions.https.onCall(async (data, context)
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       });
       
-      // 4. temporaryTablesコレクションにドキュメント作成（ドキュメントID = テーブル名）
-      const temporaryTableSeatRef = db
-        .collection('temporaryTables')
+      // 4. sideGameコレクションにドキュメント作成（ドキュメントID = テーブル名）
+      const sideGameTableRef = db
+        .collection('sideGame')
         .doc(tableName);
       
-      transaction.set(temporaryTableSeatRef, {
+      transaction.set(sideGameTableRef, {
         tableId: tableName, // テーブル名をtableIdとして使用
         name: tableName,
         maxSeats: maxSeats,
         seats: seats,
+        active: false, // 初期値はfalse
         isEnabled: true,
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),

--- a/functions/src/callables/debugSideGame.ts
+++ b/functions/src/callables/debugSideGame.ts
@@ -1,0 +1,65 @@
+import { onCall } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const debugSideGame = onCall(async (request) => {
+  const db = getFirestore();
+  const { tableId } = request.data;
+
+  try {
+    console.log(`=== debugSideGame開始: ${tableId} ===`);
+    
+    // 1. tablesコレクションの確認
+    const tableDoc = await db.collection('tables').doc(tableId).get();
+    console.log('tablesドキュメント存在:', tableDoc.exists);
+    if (tableDoc.exists) {
+      console.log('tablesデータ:', tableDoc.data());
+    }
+    
+    // 2. sideGameコレクションの確認
+    const sideGameDoc = await db.collection('sideGame').doc(tableId).get();
+    console.log('sideGameドキュメント存在:', sideGameDoc.exists);
+    if (sideGameDoc.exists) {
+      console.log('sideGameデータ:', sideGameDoc.data());
+    }
+    
+    // 3. sideGameコレクションが存在しない場合は作成
+    if (!sideGameDoc.exists) {
+      console.log('sideGameドキュメントを作成中...');
+      
+      const tableData = tableDoc.data();
+      const maxSeats = tableData?.maxSeats || 6;
+      
+      // 座席情報を生成
+      const seats: { [key: string]: any } = {};
+      for (let i = 1; i <= maxSeats; i++) {
+        const seatNumber = i.toString().padStart(2, '0');
+        seats[`seat${seatNumber}UserId`] = null;
+        seats[`seat${seatNumber}PokerName`] = null;
+      }
+      
+      await db.collection('sideGame').doc(tableId).set({
+        tableId: tableId,
+        name: tableId,
+        maxSeats: maxSeats,
+        seats: seats,
+        active: false,
+        isEnabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      
+      console.log('sideGameドキュメント作成完了');
+    }
+    
+    return {
+      success: true,
+      message: 'デバッグ完了',
+      tableExists: tableDoc.exists,
+      sideGameExists: sideGameDoc.exists,
+    };
+    
+  } catch (error) {
+    console.error('debugSideGameエラー:', error);
+    throw new Error(`デバッグエラー: ${error}`);
+  }
+});

--- a/functions/src/callables/index.ts
+++ b/functions/src/callables/index.ts
@@ -35,4 +35,9 @@ export { updateTournamentRecurrence } from './updateTournamentRecurrence';
 export { updateTournamentTemplate } from './updateTournamentTemplate';
 export { getScheduledTournamentsForEdit } from './getScheduledTournamentsForEdit';
 export { getBlindTemplates } from '../tournamentBlind/getBlindTemplates';
+export { debugSideGame } from './debugSideGame';
+export { registerForSideGame } from '../sideGame/registerForSideGame';
+export { leaveSeat } from '../sideGame/leaveSeat';
+export { withdrawTip } from '../sideGame/withdrawTip';
+export { depositTip } from '../sideGame/depositTip';
 

--- a/functions/src/callables/setRankingData.ts
+++ b/functions/src/callables/setRankingData.ts
@@ -1,5 +1,6 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
+import { addLogEntry } from '../utils/logUtils';
 
 export const setRankingData = onCall(async (request) => {
   try {
@@ -123,6 +124,16 @@ async function _awardPrizes(db: any, tournamentId: string, rankingData: Record<s
         await userRef.update({
           [pointType]: newPoints,
           updatedAt: new Date()
+        });
+        
+        // ログ記録を追加
+        const logType = pointType === 'pointA' ? 'pointALogs' : 'pointBLogs';
+        await addLogEntry(award.playerUid, logType, {
+          appliedAt: new Date(),
+          category: 'income',
+          amountDelta: award.prizeAmount,
+          reasonType: 'tournamentId',
+          actor: 'tablet_front', // 実際の端末IDに置き換え可能
         });
         
         console.log(`プレイヤー ${award.playerUid} に ${award.prizeAmount} ポイント付与 (${pointType}: ${currentPoints} -> ${newPoints})`);

--- a/functions/src/itemOrder/placeOrder.ts
+++ b/functions/src/itemOrder/placeOrder.ts
@@ -1,5 +1,26 @@
 import { onCall } from "firebase-functions/v2/https";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { addLogEntry } from "../utils/logUtils";
+
+/**
+ * Chip名から数値部分を抽出する
+ * 例: "side game chip ：1000" -> 1000
+ * 例: "チップ 500" -> 500
+ */
+function extractChipAmount(chipName: string): number {
+  console.log(`extractChipAmount: 入力="${chipName}"`);
+  
+  // 文字列から数値部分を抽出（最後の数値部分を取得）
+  const match = chipName.match(/(\d+)(?!.*\d)/);
+  if (match) {
+    const amount = parseInt(match[1], 10);
+    console.log(`extractChipAmount: 抽出結果=${amount}`);
+    return amount;
+  }
+  
+  console.log(`extractChipAmount: 数値が見つかりません`);
+  return 0;
+}
 
 /**
  * When: スタッフが注文確定ボタンを押下したとき
@@ -87,15 +108,41 @@ export const placeOrder = onCall(async (request) => {
         orderedAt,
       };
 
-      const existingItems: any[] = Array.isArray(billsData?.items) ? billsData.items : [];
-      const updatedItems = [...existingItems, newEntry];
-      const updatedTotal = (Number(billsData?.totalPrice) || 0) + itemTotal;
+      // Chipカテゴリーの場合はsideGameChipフィールドに保存、それ以外はitemsフィールドに保存
+      if (item.category === 'Chip') {
+        const existingSideGameChips: any[] = Array.isArray(billsData?.sideGameChip) ? billsData.sideGameChip : [];
+        const updatedSideGameChips = [...existingSideGameChips, newEntry];
+        
+        tx.update(billsRef, {
+          sideGameChip: updatedSideGameChips,
+          totalPrice: (Number(billsData?.totalPrice) || 0) + itemTotal,
+          updatedAt: now,
+        });
 
-      tx.update(billsRef, {
-        items: updatedItems,
-        totalPrice: updatedTotal,
-        updatedAt: now,
-      });
+        // Chip購入の場合はusersコレクションのsideGameTipも更新
+        const chipAmount = extractChipAmount(item.name);
+        const totalChipAmount = chipAmount * Number(item.quantity);
+        
+        console.log(`Chip購入処理: name=${item.name}, chipAmount=${chipAmount}, quantity=${item.quantity}, totalChipAmount=${totalChipAmount}`);
+        
+        if (totalChipAmount > 0) {
+          const userRef = db.collection('users').doc(userId);
+          tx.update(userRef, {
+            sideGameTip: FieldValue.increment(totalChipAmount),
+            updatedAt: now,
+          });
+          console.log(`sideGameTip更新予定: userId=${userId}, 加算量=${totalChipAmount}`);
+        }
+      } else {
+        const existingItems: any[] = Array.isArray(billsData?.items) ? billsData.items : [];
+        const updatedItems = [...existingItems, newEntry];
+        
+        tx.update(billsRef, {
+          items: updatedItems,
+          totalPrice: (Number(billsData?.totalPrice) || 0) + itemTotal,
+          updatedAt: now,
+        });
+      }
 
       // 2) orders/{YYYYMMDD} と _TodaysOrders の作成/更新
 
@@ -136,9 +183,38 @@ export const placeOrder = onCall(async (request) => {
         todaysBillsId: billsRef.id,
         ordersDocId: orderDocId,
         todaysOrderId: todaysOrderRef.id,
-        totalPrice: updatedTotal,
+        totalPrice: (Number(billsData?.totalPrice) || 0) + itemTotal,
       };
     });
+
+    // Chip購入の場合はログ記録を追加（トランザクション外で実行）
+    if (item.category === 'Chip') {
+      try {
+        // Chip名から数値部分を抽出
+        const chipAmount = extractChipAmount(item.name);
+        const totalChipAmount = chipAmount * Number(item.quantity);
+        
+        console.log(`Chip購入ログ記録: name=${item.name}, chipAmount=${chipAmount}, quantity=${item.quantity}, totalChipAmount=${totalChipAmount}`);
+        
+        if (totalChipAmount > 0) {
+          // ログ記録を追加（amountDeltaはChip量を使用）
+          await addLogEntry(userId, 'sideGameChipLogs', {
+            appliedAt: new Date(),
+            category: 'purchase',
+            amountDelta: totalChipAmount, // Chip量を使用（価格ではない）
+            reasonType: 'sideGame',
+            actor: 'tablet_front', // 実際の端末IDに置き換え可能
+          });
+          console.log(`Chip購入ログ記録完了: userId=${userId}, chipAmount=${totalChipAmount}`);
+        } else {
+          console.warn(`Chip量が0のためログ記録をスキップ: name=${item.name}`);
+        }
+      } catch (logError) {
+        console.error('Chip購入ログ記録エラー:', logError);
+        // ログ記録の失敗は注文処理を止めないが、エラーを記録
+        throw new Error(`Chip購入ログ記録に失敗しました: ${logError instanceof Error ? logError.message : String(logError)}`);
+      }
+    }
 
     return { success: true, data: result };
   } catch (error) {

--- a/functions/src/sideGame/depositTip.ts
+++ b/functions/src/sideGame/depositTip.ts
@@ -1,0 +1,74 @@
+import { onCall } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+import { addLogEntry } from '../utils/logUtils';
+
+export const depositTip = onCall(async (request) => {
+  const db = getFirestore();
+  const { userId, amount } = request.data;
+
+  try {
+    console.log(`=== depositTip開始 ===`);
+    console.log(`userId: ${userId}`);
+    console.log(`amount: ${amount}`);
+
+    // パラメータの検証
+    if (!userId || !amount) {
+      throw new Error('必須パラメータが不足しています: userId, amount');
+    }
+
+    if (typeof amount !== 'number' || amount <= 0) {
+      throw new Error('amountは正の数値である必要があります');
+    }
+
+    // usersコレクションから対象ユーザーのドキュメントを取得
+    const userDoc = await db.collection('users').doc(userId).get();
+    if (!userDoc.exists) {
+      throw new Error(`ユーザー ${userId} が見つかりません`);
+    }
+
+    const userData = userDoc.data();
+    const currentTip = userData?.sideGameTip as number || 0;
+
+    console.log(`現在のTip残高: ${currentTip}`);
+    console.log(`預入予定額: ${amount}`);
+
+    // Tipを預入
+    const newTipAmount = currentTip + amount;
+    await db.collection('users').doc(userId).update({
+      sideGameTip: newTipAmount,
+      updatedAt: new Date(),
+    });
+
+    // ログ記録を追加
+    await addLogEntry(userId, 'sideGameChipLogs', {
+      appliedAt: new Date(),
+      category: 'income',
+      amountDelta: amount,
+      reasonType: 'sideGame',
+      actor: 'tablet_front', // 実際の端末IDに置き換え可能
+    });
+
+    console.log(`預入完了: ${amount}`);
+    console.log(`新しい残高: ${newTipAmount}`);
+
+    return {
+      success: true,
+      message: `Tipの預入処理が完了しました`,
+      data: {
+        userId,
+        depositAmount: amount,
+        previousBalance: currentTip,
+        newBalance: newTipAmount,
+      },
+    };
+
+  } catch (error) {
+    console.error('depositTipエラー:', error);
+    console.error('エラー詳細:', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      name: error instanceof Error ? error.name : undefined,
+    });
+    throw new Error(`Tipの預入に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+  }
+});

--- a/functions/src/sideGame/leaveSeat.ts
+++ b/functions/src/sideGame/leaveSeat.ts
@@ -1,0 +1,57 @@
+import { onCall } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const leaveSeat = onCall(async (request) => {
+  const db = getFirestore();
+  const { tableId, seatNumber, userId } = request.data;
+
+  try {
+    console.log(`=== leaveSeat開始 ===`);
+    console.log(`tableId: ${tableId}`);
+    console.log(`seatNumber: ${seatNumber}`);
+    console.log(`userId: ${userId}`);
+
+    // 1. sideGameコレクションの座席情報をクリア（seatsマップ内から削除）
+    const seatNumberStr = seatNumber.toString().padStart(2, '0');
+    const sideGameUpdateData = {
+      [`seats.seat${seatNumberStr}UserId`]: null,
+      [`seats.seat${seatNumberStr}PokerName`]: null,
+      updatedAt: new Date(),
+    };
+
+    await db.collection('sideGame').doc(tableId).update(sideGameUpdateData);
+    console.log(`sideGame座席クリア完了: seat${seatNumberStr}`);
+
+    // 2. todaysBillsの参加者情報をクリア（userIdフィールドで検索）
+    const todaysBillsQuery = await db.collection('todaysBills')
+      .where('userId', '==', userId)
+      .limit(1)
+      .get();
+    
+    if (!todaysBillsQuery.empty) {
+      const todaysBillsDoc = todaysBillsQuery.docs[0];
+      const todaysBillsUpdateData = {
+        currentSeat: null,
+        currentTable: null,
+        updatedAt: new Date(),
+      };
+
+      await todaysBillsDoc.ref.update(todaysBillsUpdateData);
+      console.log(`todaysBillsクリア完了: ${userId}`);
+    }
+
+    return {
+      success: true,
+      message: '退席処理が完了しました',
+      data: {
+        tableId,
+        seatNumber,
+        userId,
+      },
+    };
+
+  } catch (error) {
+    console.error('leaveSeatエラー:', error);
+    throw new Error(`退席処理に失敗しました: ${error}`);
+  }
+});

--- a/functions/src/sideGame/registerForSideGame.ts
+++ b/functions/src/sideGame/registerForSideGame.ts
@@ -1,0 +1,90 @@
+import { onCall } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const registerForSideGame = onCall(async (request) => {
+  const db = getFirestore();
+  const { tableId, seatNumber, userId } = request.data;
+
+  try {
+    console.log(`=== registerParticipant開始 ===`);
+    console.log(`tableId: ${tableId}`);
+    console.log(`seatNumber: ${seatNumber}`);
+    console.log(`userId: ${userId}`);
+
+    // パラメータの検証
+    if (!tableId || !seatNumber || !userId) {
+      throw new Error('必須パラメータが不足しています: tableId, seatNumber, userId');
+    }
+
+    if (typeof seatNumber !== 'number') {
+      throw new Error('seatNumberは数値である必要があります');
+    }
+
+    // 1. todaysBillsから参加者情報を取得（userIdフィールドで検索）
+    const todaysBillsQuery = await db.collection('todaysBills')
+      .where('userId', '==', userId)
+      .limit(1)
+      .get();
+    
+    if (todaysBillsQuery.empty) {
+      throw new Error(`参加者 ${userId} がtodaysBillsに見つかりません`);
+    }
+
+    const todaysBillsDoc = todaysBillsQuery.docs[0];
+    const todaysBillsData = todaysBillsDoc.data();
+    const pokerName = todaysBillsData?.pokerName as string;
+    
+    if (!pokerName) {
+      throw new Error(`参加者 ${userId} のpokerNameが見つかりません`);
+    }
+
+    console.log(`参加者情報取得完了: ${pokerName}`);
+
+    // 2. sideGameドキュメントの存在確認
+    const sideGameDoc = await db.collection('sideGame').doc(tableId).get();
+    if (!sideGameDoc.exists) {
+      throw new Error(`テーブル ${tableId} がsideGameコレクションに見つかりません`);
+    }
+
+    // 3. sideGameコレクションの座席情報を更新（seatsマップ内に格納）
+    const seatNumberStr = seatNumber.toString().padStart(2, '0');
+    const sideGameUpdateData = {
+      [`seats.seat${seatNumberStr}UserId`]: userId,
+      [`seats.seat${seatNumberStr}PokerName`]: pokerName,
+      updatedAt: new Date(),
+    };
+
+    await db.collection('sideGame').doc(tableId).update(sideGameUpdateData);
+    console.log(`sideGame座席更新完了: seat${seatNumberStr}`);
+
+    // 4. todaysBillsの参加者情報を更新
+    const todaysBillsUpdateData = {
+      currentSeat: seatNumber,
+      currentTable: tableId,
+      updatedAt: new Date(),
+    };
+
+    await todaysBillsDoc.ref.update(todaysBillsUpdateData);
+    console.log(`todaysBills更新完了: ${userId}`);
+
+    return {
+      success: true,
+      message: '参加登録が完了しました',
+      data: {
+        tableId,
+        seatNumber,
+        userId,
+        pokerName,
+      },
+    };
+
+  } catch (error) {
+    console.error('registerParticipantエラー:', error);
+    console.error('エラー詳細:', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      name: error instanceof Error ? error.name : undefined,
+    });
+    throw new Error(`参加登録に失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+  }
+});

--- a/functions/src/sideGame/withdrawTip.ts
+++ b/functions/src/sideGame/withdrawTip.ts
@@ -1,0 +1,79 @@
+import { onCall } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+import { addLogEntry } from '../utils/logUtils';
+
+export const withdrawTip = onCall(async (request) => {
+  const db = getFirestore();
+  const { userId, amount } = request.data;
+
+  try {
+    console.log(`=== withdrawTip開始 ===`);
+    console.log(`userId: ${userId}`);
+    console.log(`amount: ${amount}`);
+
+    // パラメータの検証
+    if (!userId || !amount) {
+      throw new Error('必須パラメータが不足しています: userId, amount');
+    }
+
+    if (typeof amount !== 'number' || amount <= 0) {
+      throw new Error('amountは正の数値である必要があります');
+    }
+
+    // usersコレクションから対象ユーザーのドキュメントを取得
+    const userDoc = await db.collection('users').doc(userId).get();
+    if (!userDoc.exists) {
+      throw new Error(`ユーザー ${userId} が見つかりません`);
+    }
+
+    const userData = userDoc.data();
+    const currentTip = userData?.sideGameTip as number || 0;
+
+    console.log(`現在のTip残高: ${currentTip}`);
+    console.log(`引き出し予定額: ${amount}`);
+
+    // 残高チェック
+    if (amount > currentTip) {
+      throw new Error('残高が不足しています');
+    }
+
+    // Tipを引き出し
+    const newTipAmount = currentTip - amount;
+    await db.collection('users').doc(userId).update({
+      sideGameTip: newTipAmount,
+      updatedAt: new Date(),
+    });
+
+    // ログ記録を追加
+    await addLogEntry(userId, 'sideGameChipLogs', {
+      appliedAt: new Date(),
+      category: 'expense',
+      amountDelta: -amount, // 負の値
+      reasonType: 'sideGame',
+      actor: 'tablet_front', // 実際の端末IDに置き換え可能
+    });
+
+    console.log(`引き出し完了: ${amount}`);
+    console.log(`新しい残高: ${newTipAmount}`);
+
+    return {
+      success: true,
+      message: `Tipの引き出し処理が完了しました`,
+      data: {
+        userId,
+        withdrawAmount: amount,
+        previousBalance: currentTip,
+        newBalance: newTipAmount,
+      },
+    };
+
+  } catch (error) {
+    console.error('withdrawTipエラー:', error);
+    console.error('エラー詳細:', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      name: error instanceof Error ? error.name : undefined,
+    });
+    throw new Error(`Tipの引き出しに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+  }
+});

--- a/functions/src/user/createUserAccount.ts
+++ b/functions/src/user/createUserAccount.ts
@@ -2,6 +2,7 @@ import {onCall} from "firebase-functions/v2/https";
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as bcrypt from "bcryptjs";
+import { initializeUserLogs } from "../utils/logUtils";
 
 /**
  * ユーザーアカウント作成関数
@@ -98,6 +99,9 @@ export const createUserAccount = onCall(
           qrCodeUrl: qrCodeUrl,
           qrExpiresAt: admin.firestore.Timestamp.fromDate(new Date(expiresAt)),
         });
+
+      // ログサブコレクションを初期化
+      await initializeUserLogs(uid);
 
       return {
         success: true,

--- a/functions/src/user/createUserByApp.ts
+++ b/functions/src/user/createUserByApp.ts
@@ -3,6 +3,7 @@ import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as bcrypt from "bcryptjs";
 import * as QRCode from "qrcode";
+import { initializeUserLogs } from "../utils/logUtils";
 
 export const createUserByApp = onCall(async (request) => {
   const {pokerName, email, pin, birthMonthDay} = request.data;
@@ -77,6 +78,9 @@ export const createUserByApp = onCall(async (request) => {
   await admin.firestore().collection("users").doc(uid).update({
     qrCodeUrl: url,
   });
+
+  // ログサブコレクションを初期化
+  await initializeUserLogs(uid);
 
   return {success: true, uid, qrUrl: url};
 }); 

--- a/functions/src/userLogin/manualCheckIn.ts
+++ b/functions/src/userLogin/manualCheckIn.ts
@@ -104,7 +104,6 @@ export const manualCheckIn = onCall(async (request) => {
       status: 'open',
       userId: uid,
       items: [],
-      sideGameTip: [],
       tournaments: [],
       extraCost: extraCost,
       totalPrice: entranceFee > 0 ? entranceFee : 0, // 入店料を初期値として設定（0円の場合は0）

--- a/functions/src/userLogin/processVisitByQR.ts
+++ b/functions/src/userLogin/processVisitByQR.ts
@@ -131,7 +131,6 @@ export const processVisitByQR = onCall(async (request) => {
                status: 'open',
                userId: parsed.uid,
                items: [],
-               sideGameTip: [],
                tournaments: [],
                extraCost: extraCost, // 入店料を含む
                totalPrice: entranceFee > 0 ? entranceFee : 0, // 入店料を初期値として設定

--- a/functions/src/utils/logUtils.ts
+++ b/functions/src/utils/logUtils.ts
@@ -1,0 +1,94 @@
+import { getFirestore } from 'firebase-admin/firestore';
+
+export interface LogEntry {
+  entryId: string;
+  appliedAt: Date;
+  category: 'income' | 'expense' | 'purchase';
+  amountDelta: number;
+  reasonType: 'accounting' | 'tournamentId' | 'sideGame' | 'manual' | 'adjustment';
+  actor?: string;
+  isReversal?: boolean;
+  reversesEntryId?: string;
+}
+
+/**
+ * ユーザーのログサブコレクションにエントリを追加する
+ * @param userId ユーザーID
+ * @param logType ログタイプ（sideGameChipLogs, pointALogs, pointBLogs）
+ * @param entry ログエントリ（entryIdは自動生成）
+ */
+export async function addLogEntry(
+  userId: string,
+  logType: 'sideGameChipLogs' | 'pointALogs' | 'pointBLogs',
+  entry: Omit<LogEntry, 'entryId'>
+): Promise<void> {
+  const db = getFirestore();
+  const today = new Date().toISOString().split('T')[0];
+  
+  // 8文字の一意IDを生成（英数字）
+  const entryId = Math.random().toString(36).substring(2, 10);
+  
+  const logEntry: LogEntry = {
+    ...entry,
+    entryId,
+  };
+  
+  const logRef = db
+    .collection('users')
+    .doc(userId)
+    .collection(logType)
+    .doc(today);
+  
+  // ドキュメントが存在しない場合は作成、存在する場合は更新
+  const logDoc = await logRef.get();
+  
+  if (!logDoc.exists) {
+    await logRef.set({
+      logs: {
+        [entryId]: logEntry,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  } else {
+    await logRef.update({
+      [`logs.${entryId}`]: logEntry,
+      updatedAt: new Date(),
+    });
+  }
+  
+  console.log(`ログエントリ追加完了: ${logType}/${today}/${entryId}`);
+}
+
+/**
+ * ユーザー作成時にログサブコレクションを初期化する
+ * @param userId ユーザーID
+ */
+export async function initializeUserLogs(userId: string): Promise<void> {
+  const db = getFirestore();
+  const today = new Date().toISOString().split('T')[0];
+  const userRef = db.collection('users').doc(userId);
+  
+  // 3つのサブコレクションに当日のドキュメントを作成
+  const logTypes: ('sideGameChipLogs' | 'pointALogs' | 'pointBLogs')[] = [
+    'sideGameChipLogs',
+    'pointALogs', 
+    'pointBLogs'
+  ];
+  
+  const initPromises = logTypes.map(async (logType) => {
+    const logRef = userRef.collection(logType).doc(today);
+    const logDoc = await logRef.get();
+    
+    if (!logDoc.exists) {
+      await logRef.set({
+        logs: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      console.log(`ログサブコレクション初期化: ${logType}/${today}`);
+    }
+  });
+  
+  await Promise.all(initPromises);
+}

--- a/lib/Home/terminalHomePage.dart
+++ b/lib/Home/terminalHomePage.dart
@@ -8,6 +8,7 @@ import 'package:amuse_app_template/tournament/scheduling/pages/scheduled_tournam
 import 'package:amuse_app_template/Home/systemSettingsPage.dart';
 import 'package:amuse_app_template/tournament/scheduling/pages/tournament_creation_menu_page.dart';
 import 'package:amuse_app_template/Accounting/accountingPage.dart';
+import 'package:amuse_app_template/sideGame/pages/side_game_table_list.dart';
 import 'package:flutter/material.dart';
 
 class terminalHomePage extends StatefulWidget {
@@ -31,7 +32,7 @@ class _terminalHomePageState extends State<terminalHomePage> {
       (label: '入店中user一覧', destination: const StayingUsersListPage()),
       (label: 'Tournament 作成', destination: const TournamentCreationMenuPage()),
       (label: 'Tournament Home', destination: const ScheduledTournamentListPage()),
-      (label: 'デモ1', destination: const PlaceholderPage(title: 'demo1')),
+      (label: 'sideGame', destination: const SideGameTableListPage()),
       (label: 'デモ2', destination: const PlaceholderPage(title: 'demo2')),
       (label: 'スタッフ打刻', destination: const StaffAttendancePage()),
       (label: '会計管理', destination: const AccountingPage()),

--- a/lib/OrderView/MenuView/categorySelectPage.dart
+++ b/lib/OrderView/MenuView/categorySelectPage.dart
@@ -85,6 +85,8 @@ class _CategorySelectPageState extends State<CategorySelectPage> {
         return const Icon(Icons.local_drink, color: Colors.blue);
       case 'アルコール':
         return const Icon(Icons.local_bar, color: Colors.amber);
+      case 'Chip':
+        return const Icon(Icons.account_balance_wallet, color: Colors.orange);
       case 'その他':
         return const Icon(Icons.category, color: Colors.grey);
       default:

--- a/lib/OrderView/MenuView/createMenuPage.dart
+++ b/lib/OrderView/MenuView/createMenuPage.dart
@@ -50,6 +50,50 @@ class _CreateMenuPageState extends State<CreateMenuPage> {
     }
   }
 
+  void _onCategoryChanged(String? value) {
+    if (value != null) {
+      setState(() {
+        _selectedCategory = value;
+        
+        // Chipカテゴリーが選択された場合、商品名を自動設定
+        if (value == 'Chip') {
+          _nameController.text = 'side game chip ：';
+        }
+      });
+    }
+  }
+
+  void _onChipNameChanged(String value) {
+    // Chipカテゴリーの場合のみ、数値部分のみを抽出して更新
+    if (_selectedCategory == 'Chip') {
+      // 'side game chip ：'の後の数値部分のみを抽出
+      final prefix = 'side game chip ：';
+      if (value.startsWith(prefix)) {
+        final numberPart = value.substring(prefix.length);
+        // 数値のみを許可（空文字も許可）
+        if (numberPart.isEmpty || RegExp(r'^\d+$').hasMatch(numberPart)) {
+          _nameController.text = value;
+        } else {
+          // 数値以外が入力された場合は、前の有効な値に戻す
+          final currentText = _nameController.text;
+          if (currentText.startsWith(prefix)) {
+            final currentNumber = currentText.substring(prefix.length);
+            if (RegExp(r'^\d+$').hasMatch(currentNumber)) {
+              _nameController.text = currentText;
+            } else {
+              _nameController.text = prefix;
+            }
+          } else {
+            _nameController.text = prefix;
+          }
+        }
+      } else {
+        // プレフィックスが変更された場合は元に戻す
+        _nameController.text = prefix;
+      }
+    }
+  }
+
   Future<void> _pickImage() async {
     final picked = await _picker.pickImage(source: ImageSource.gallery);
     if (picked != null) {
@@ -76,11 +120,31 @@ class _CreateMenuPageState extends State<CreateMenuPage> {
     final price = int.tryParse(_priceController.text.trim()) ?? 0;
     final description = _descriptionController.text.trim();
 
+    // 基本バリデーション
     if (name.isEmpty || price <= 0) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('有効な名前と金額を入力してください')),
       );
       return;
+    }
+
+    // Chipカテゴリーの場合、数値が入力されているかチェック
+    if (_selectedCategory == 'Chip') {
+      final prefix = 'side game chip ：';
+      if (!name.startsWith(prefix)) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Chip商品の名前が正しくありません')),
+        );
+        return;
+      }
+      
+      final numberPart = name.substring(prefix.length);
+      if (numberPart.isEmpty || !RegExp(r'^\d+$').hasMatch(numberPart)) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Chip商品には数値を入力してください')),
+        );
+        return;
+      }
     }
 
     try {
@@ -200,13 +264,30 @@ class _CreateMenuPageState extends State<CreateMenuPage> {
                   flex: 1,
                   child: Column(
                     children: [
+                      // カテゴリー選択
+                      DropdownButtonFormField<String>(
+                        value: _selectedCategory,
+                        decoration: const InputDecoration(
+                          labelText: 'カテゴリー',
+                          border: OutlineInputBorder(),
+                        ),
+                        onChanged: _onCategoryChanged,
+                        items: _categories.map((cat) {
+                          return DropdownMenuItem(value: cat, child: Text(cat));
+                        }).toList(),
+                      ),
+                      const SizedBox(height: 12),
+
                       // 商品名入力
                       TextField(
                         controller: _nameController,
-                        decoration: const InputDecoration(
+                        decoration: InputDecoration(
                           labelText: '商品名',
-                          border: OutlineInputBorder(),
+                          border: const OutlineInputBorder(),
+                          hintText: _selectedCategory == 'Chip' ? '数値を入力してください' : null,
                         ),
+                        onChanged: _onChipNameChanged,
+                        keyboardType: _selectedCategory == 'Chip' ? TextInputType.number : TextInputType.text,
                       ),
                       const SizedBox(height: 12),
 
@@ -218,26 +299,6 @@ class _CreateMenuPageState extends State<CreateMenuPage> {
                           border: OutlineInputBorder(),
                         ),
                         keyboardType: TextInputType.number,
-                      ),
-                      const SizedBox(height: 12),
-
-                      // カテゴリー選択
-                      DropdownButtonFormField<String>(
-                        value: _selectedCategory,
-                        decoration: const InputDecoration(
-                          labelText: 'カテゴリー',
-                          border: OutlineInputBorder(),
-                        ),
-                        onChanged: (value) {
-                          if (value != null) {
-                            setState(() {
-                              _selectedCategory = value;
-                            });
-                          }
-                        },
-                        items: _categories.map((cat) {
-                          return DropdownMenuItem(value: cat, child: Text(cat));
-                        }).toList(),
                       ),
                     ],
                   ),

--- a/lib/globalConstant.dart
+++ b/lib/globalConstant.dart
@@ -5,6 +5,7 @@ class GlobalConstants {
     'フード',
     'ノンアルコール',
     'アルコール',
+    'Chip',
     'その他',
   ];
 
@@ -47,5 +48,13 @@ class GlobalConstants {
   
   // ポイントタイプ選択肢（フィールド名のみ）
   static const List<String> pointTypes = ['pointA', 'pointB', 'sideGameTip'];//createUserAccount.tsやcreateUserByApp.tsについては直接コード内で修正する必要がある
+  
+  // サイドゲーム選択肢
+  static const List<String> sideGameTypes = [
+    'ブラックジャック',
+    'ルーレット',
+    'バカラ',
+    'アルティメットポーカー',
+  ];
 }
 

--- a/lib/sideGame/pages/side_game_table_home.dart
+++ b/lib/sideGame/pages/side_game_table_home.dart
@@ -1,0 +1,767 @@
+import 'dart:math' as Math;
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:amuse_app_template/globalConstant.dart';
+import 'package:amuse_app_template/user_actions/user_action_home.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+class SideGameTableHomePage extends StatefulWidget {
+  final String tableId;
+  final String gameName;
+
+  const SideGameTableHomePage({
+    super.key,
+    required this.tableId,
+    required this.gameName,
+  });
+
+  @override
+  State<SideGameTableHomePage> createState() => _SideGameTableHomePageState();
+}
+
+class _SideGameTableHomePageState extends State<SideGameTableHomePage> {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  String _currentGameName = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _currentGameName = widget.gameName;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.tableId),
+        centerTitle: true,
+        backgroundColor: Colors.grey,
+        foregroundColor: Colors.white,
+        actions: [
+          // ゲーム名表示と変更ボタン
+          PopupMenuButton<String>(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.2),
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(color: Colors.white.withOpacity(0.3)),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _currentGameName,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  const Icon(
+                    Icons.arrow_drop_down, 
+                    color: Colors.white,
+                    size: 20,
+                  ),
+                ],
+              ),
+            ),
+            onSelected: (String gameName) {
+              setState(() {
+                _currentGameName = gameName;
+              });
+              _updateGameName(gameName);
+            },
+            itemBuilder: (BuildContext context) {
+              return GlobalConstants.sideGameTypes.map((String gameName) {
+                return PopupMenuItem<String>(
+                  value: gameName,
+                  child: Text(gameName),
+                );
+              }).toList();
+            },
+          ),
+        ],
+      ),
+      body: StreamBuilder<DocumentSnapshot>(
+        stream: _firestore.collection('sideGame').doc(widget.tableId).snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error, size: 64, color: Colors.red),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'エラーが発生しました',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  Text('エラー: ${snapshot.error}'),
+                  const SizedBox(height: 8),
+                  Text('テーブルID: ${widget.tableId}'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      _createSideGameDocument();
+                    },
+                    child: const Text('ドキュメントを作成'),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: () {
+                      _debugSideGame();
+                    },
+                    child: const Text('デバッグ実行'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (!snapshot.hasData || !snapshot.data!.exists) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.table_chart, size: 64, color: Colors.grey),
+                  const SizedBox(height: 16),
+                  const Text(
+                    'テーブルデータが見つかりません',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  Text('テーブルID: ${widget.tableId}'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () {
+                      _createSideGameDocument();
+                    },
+                    child: const Text('ドキュメントを作成'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final data = snapshot.data!.data() as Map<String, dynamic>;
+          final maxSeats = data['maxSeats'] as int? ?? 6;
+          final seats = data['seats'] as Map<String, dynamic>? ?? {};
+
+          return Column(
+            children: [
+              // テーブル表示
+              Expanded(
+                child: _buildTableDisplay(maxSeats, seats),
+              ),
+              
+              // 終了処理ボタン
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Align(
+                  alignment: Alignment.bottomRight,
+                  child: ElevatedButton.icon(
+                    onPressed: _showEndGameDialog,
+                    icon: const Icon(Icons.stop),
+                    label: const Text('終了処理'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildTableDisplay(int maxSeats, Map<String, dynamic> seats) {
+    return Container(
+      width: double.infinity,
+      height: double.infinity,
+      child: Stack(
+        children: [
+            // ポーカーテーブル（横長楕円形）
+            Positioned(
+              left: 0,
+              right: 0,
+              top: 0,
+              bottom: 0,
+              child: Center(
+                child: Container(
+                  width: MediaQuery.of(context).size.width * 0.6, // 画面幅の60%
+                  height: MediaQuery.of(context).size.width * 0.4, // 画面幅の40%（3:2の比率）
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(MediaQuery.of(context).size.width * 0.2), // 楕円形（画面幅の20%）
+                    color: Colors.green.shade800,
+                    border: Border.all(color: Colors.green.shade900, width: 3),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.3),
+                        blurRadius: 10,
+                        offset: const Offset(0, 5),
+                      ),
+                    ],
+                  ),
+                  child: Stack(
+                    children: [
+                      // ゲーム名称（テーブル内中央上部）
+                      Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              _currentGameName,
+                              style: const TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            const Text(
+                              'SIDE GAME',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white70,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      
+                      // ディーラーポジション（中央下部）
+                      Positioned(
+                        bottom: 20,
+                        left: 0,
+                        right: 0,
+                        child: Center(
+                          child: Container(
+                            width: 60,
+                            height: 30,
+                            decoration: BoxDecoration(
+                              color: Colors.red.shade700,
+                              borderRadius: BorderRadius.circular(15),
+                            ),
+                            child: const Center(
+                              child: Text(
+                                'DEALER',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            
+            // 座席配置（テーブル周囲）
+            ..._buildSeatPositions(seats, maxSeats),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildSeatPositions(Map<String, dynamic> seats, int maxSeats) {
+    final widgets = <Widget>[];
+    
+    // テーブルの中心位置を画面中央に設定
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final tableCenterX = screenWidth * 0.5; // 画面中央
+    final tableCenterY = screenHeight * 0.5; // 画面中央
+    
+    // 座席数 + 1（ディーラーポジション含む）で等間隔配置
+    final totalPositions = maxSeats + 1;
+    
+    for (int i = 1; i <= maxSeats; i++) {
+      final seatNoStr = i.toString().padLeft(2, '0');
+      final userId = seats['seat${seatNoStr}UserId'] as String?;
+      final pokerName = seats['seat${seatNoStr}PokerName'] as String?;
+      final isOccupied = userId != null && userId.isNotEmpty;
+      
+      // 座席の位置を計算（左右反転）
+      // 左右反転: -cos(angle) を使用
+      final angle = i * (2 * 3.14159 / totalPositions) - (3.14159 / 2); // 12時方向から開始
+      
+      // 楕円の配置（画面サイズに応じた楕円周上に配置）
+      final ellipseWidth = MediaQuery.of(context).size.width * 0.64; // 画面幅の64%
+      final ellipseHeight = MediaQuery.of(context).size.width * 0.44; // 画面幅の44%（3:2の比率）
+      final a = ellipseWidth / 2; // 楕円の横半径
+      final b = ellipseHeight / 2; // 楕円の縦半径
+      
+      final x = tableCenterX - a * Math.cos(angle); // 左右反転
+      final y = tableCenterY - b * Math.sin(angle); // 上下反転
+      
+      widgets.add(
+        Positioned(
+          left: x - 60, // 120pxの座席サイズの半分
+          top: y - 100,  // 60pxの座席サイズの半分
+          child: _buildSeatWidget(
+            seatNumber: i,
+            userId: userId,
+            pokerName: pokerName,
+            isOccupied: isOccupied,
+          ),
+        ),
+      );
+    }
+    
+    return widgets;
+  }
+
+  Widget _buildSeatWidget({
+    required int seatNumber,
+    required String? userId,
+    required String? pokerName,
+    required bool isOccupied,
+  }) {
+    return GestureDetector(
+      onTap: () => _handleSeatTap(seatNumber, userId, pokerName),
+      child: Container(
+        width: 120, // 横幅を2倍に変更（60 * 2）
+        height: 60, // 縦幅はそのまま
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(30), // 楕円形にする（height/2）
+          color: isOccupied ? Colors.white : Colors.grey.shade300,
+          border: Border.all(
+            color: isOccupied ? Colors.blue : Colors.grey.shade400,
+            width: 2,
+          ),
+          boxShadow: isOccupied ? [
+            BoxShadow(
+              color: Colors.blue.withValues(alpha: 0.3),
+              blurRadius: 5,
+              offset: const Offset(0, 2),
+            ),
+          ] : null,
+        ),
+        child: Center(
+          child: isOccupied
+              ? Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.person,
+                      size: 20,
+                      color: Colors.blue.shade700,
+                    ),
+                    Text(
+                      pokerName ?? 'Unknown',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Colors.blue.shade700,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                )
+              : Text(
+                  seatNumber.toString(),
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.grey.shade600,
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+
+  void _handleSeatTap(int seatNumber, String? userId, String? pokerName) {
+    if (userId != null && userId.isNotEmpty) {
+      // 着席済みの場合はユーザーアクションポップを表示
+      _showUserActionPop(seatNumber, userId, pokerName ?? '');
+    } else {
+      // 空席の場合は参加者登録ダイアログを表示
+      _showParticipantRegistrationDialog(seatNumber);
+    }
+  }
+
+  void _showUserActionPop(int seatNumber, String userId, String pokerName) {
+    showUserActionHome(
+      context: context,
+      sourcePage: 'sideGameTableHome',
+      user: {
+        'userId': userId,
+        'pokerName': pokerName,
+        'tableId': widget.tableId,
+        'seatNumber': seatNumber,
+      },
+    );
+  }
+
+  void _showParticipantRegistrationDialog(int seatNumber) {
+    showDialog(
+      context: context,
+      builder: (context) => _ParticipantRegistrationDialog(
+        tableId: widget.tableId,
+        seatNumber: seatNumber,
+        onParticipantRegistered: () {
+          // 参加者が登録された時の処理（自動的にStreamBuilderで更新される）
+        },
+      ),
+    );
+  }
+
+  void _showEndGameDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('ゲーム終了'),
+        content: const Text('サイドゲームを終了しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              _endGame();
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('終了'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _endGame() async {
+    try {
+      // sideGameコレクションの座席を全てnullに設定（seatsマップ内）
+      final seatsUpdate = <String, dynamic>{};
+      for (int i = 1; i <= 10; i++) { // 最大10席まで対応
+        final seatNumber = i.toString().padLeft(2, '0');
+        seatsUpdate['seats.seat${seatNumber}UserId'] = null;
+        seatsUpdate['seats.seat${seatNumber}PokerName'] = null;
+      }
+
+      await _firestore.collection('sideGame').doc(widget.tableId).update({
+        ...seatsUpdate,
+        'active': false,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+
+      // tablesコレクションのstatusを'open'に変更
+      await _firestore.collection('tables').doc(widget.tableId).update({
+        'status': 'open',
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('ゲームを終了しました'),
+            backgroundColor: Colors.green,
+          ),
+        );
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('終了処理に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _updateGameName(String gameName) async {
+    try {
+      await _firestore.collection('sideGame').doc(widget.tableId).update({
+        'gameName': gameName,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('ゲーム名の更新に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  /// sideGameドキュメントを手動作成するメソッド
+  Future<void> _createSideGameDocument() async {
+    try {
+      // テーブル情報を取得
+      final tableDoc = await _firestore.collection('tables').doc(widget.tableId).get();
+      if (!tableDoc.exists) {
+        throw Exception('テーブル ${widget.tableId} が見つかりません');
+      }
+      
+      final tableData = tableDoc.data()!;
+      final maxSeats = tableData['maxSeats'] as int? ?? 6;
+      
+      // 座席情報を生成
+      final seats = <String, dynamic>{};
+      for (int i = 1; i <= maxSeats; i++) {
+        final seatNumber = i.toString().padLeft(2, '0');
+        seats['seat${seatNumber}UserId'] = null;
+        seats['seat${seatNumber}PokerName'] = null;
+      }
+      
+      // sideGameドキュメントを作成
+      await _firestore.collection('sideGame').doc(widget.tableId).set({
+        'tableId': widget.tableId,
+        'name': widget.tableId,
+        'maxSeats': maxSeats,
+        'seats': seats,
+        'active': false,
+        'isEnabled': true,
+        'createdAt': FieldValue.serverTimestamp(),
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('sideGameドキュメントを作成しました'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('ドキュメント作成に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  /// デバッグ用Cloud Functionを呼び出すメソッド
+  Future<void> _debugSideGame() async {
+    try {
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('debugSideGame');
+      
+      final result = await callable.call({
+        'tableId': widget.tableId,
+      });
+      
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('デバッグ完了: ${result.data['message']}'),
+            backgroundColor: Colors.blue,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('デバッグ実行に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+}
+
+class _ParticipantRegistrationDialog extends StatefulWidget {
+  final String tableId;
+  final int seatNumber;
+  final VoidCallback onParticipantRegistered;
+
+  const _ParticipantRegistrationDialog({
+    required this.tableId,
+    required this.seatNumber,
+    required this.onParticipantRegistered,
+  });
+
+  @override
+  State<_ParticipantRegistrationDialog> createState() => _ParticipantRegistrationDialogState();
+}
+
+class _ParticipantRegistrationDialogState extends State<_ParticipantRegistrationDialog> {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  List<Map<String, dynamic>> _availableParticipants = [];
+  bool _isLoading = true;
+  String? _selectedUserId;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAvailableParticipants();
+  }
+
+  Future<void> _loadAvailableParticipants() async {
+    try {
+      final snapshot = await _firestore.collection('todaysBills').get();
+      final participants = <Map<String, dynamic>>[];
+      
+      for (final doc in snapshot.docs) {
+        final data = doc.data();
+        final pokerName = data['pokerName'] as String?;
+        final userId = data['userId'] as String?;
+        
+        if (pokerName != null && userId != null) {
+          participants.add({
+            'userId': userId,
+            'pokerName': pokerName,
+          });
+        }
+      }
+      
+      setState(() {
+        _availableParticipants = participants;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+      });
+      
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('参加者リストの読み込みに失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('座席${widget.seatNumber} 参加者登録'),
+      content: SizedBox(
+        width: double.maxFinite,
+        height: 400,
+        child: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : _availableParticipants.isEmpty
+                ? const Center(
+                    child: Text('利用可能な参加者がいません'),
+                  )
+                : ListView.builder(
+                    itemCount: _availableParticipants.length,
+                    itemBuilder: (context, index) {
+                      final participant = _availableParticipants[index];
+                      final isSelected = _selectedUserId == participant['userId'];
+                      
+                      return ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: isSelected ? Colors.blue : Colors.grey,
+                          child: Text(
+                            participant['pokerName'].toString().substring(0, 1).toUpperCase(),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        title: Text(participant['pokerName']),
+                        subtitle: Text('ID: ${participant['userId']}'),
+                        selected: isSelected,
+                        onTap: () {
+                          setState(() {
+                            _selectedUserId = participant['userId'];
+                          });
+                        },
+                      );
+                    },
+                  ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        ElevatedButton(
+          onPressed: _selectedUserId != null ? _registerParticipant : null,
+          child: const Text('登録'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _registerParticipant() async {
+    if (_selectedUserId == null) return;
+
+    try {
+      print('=== 参加登録開始 ===');
+      print('tableId: ${widget.tableId}');
+      print('seatNumber: ${widget.seatNumber}');
+      print('userId: $_selectedUserId');
+
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('registerForSideGame');
+      
+      final result = await callable.call({
+        'tableId': widget.tableId,
+        'seatNumber': widget.seatNumber,
+        'userId': _selectedUserId,
+      });
+
+      print('=== 参加登録結果 ===');
+      print('success: ${result.data['success']}');
+      print('message: ${result.data['message']}');
+      print('data: ${result.data['data']}');
+
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${result.data['data']['pokerName']}さんを座席${widget.seatNumber}に登録しました'),
+            backgroundColor: Colors.green,
+          ),
+        );
+        widget.onParticipantRegistered();
+      }
+    } catch (e) {
+      print('=== 参加登録エラー ===');
+      print('エラー: $e');
+      print('エラータイプ: ${e.runtimeType}');
+      
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('登録に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/lib/sideGame/pages/side_game_table_list.dart
+++ b/lib/sideGame/pages/side_game_table_list.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:amuse_app_template/globalConstant.dart';
+import 'package:amuse_app_template/sideGame/pages/side_game_table_home.dart';
+
+class SideGameTableListPage extends StatefulWidget {
+  const SideGameTableListPage({super.key});
+
+  @override
+  State<SideGameTableListPage> createState() => _SideGameTableListPageState();
+}
+
+class _SideGameTableListPageState extends State<SideGameTableListPage> {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('サイドゲーム テーブル選択'),
+        centerTitle: true,
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: _firestore.collection('tables').snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Text('エラーが発生しました: ${snapshot.error}'),
+            );
+          }
+
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final tables = snapshot.data!.docs
+              .where((doc) {
+                final data = doc.data() as Map<String, dynamic>;
+                return data['isEnabled'] == true;
+              })
+              .toList();
+
+          return _buildTableGrid(tables);
+        },
+      ),
+    );
+  }
+
+  Widget _buildTableGrid(List<QueryDocumentSnapshot> tables) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 5,
+          childAspectRatio: 0.8,
+          crossAxisSpacing: 16,
+          mainAxisSpacing: 16,
+        ),
+        itemCount: tables.length,
+        itemBuilder: (context, index) {
+          final table = tables[index];
+          final data = table.data() as Map<String, dynamic>;
+          return _buildTableCard(table.id, data);
+        },
+      ),
+    );
+  }
+
+  Widget _buildTableCard(String tableId, Map<String, dynamic> data) {
+    final name = data['name'] as String? ?? tableId;
+    final status = data['status'] as String? ?? 'open';
+    final maxSeats = data['maxSeats'] as int? ?? 6;
+
+    final isAvailable = status == 'open';
+    final isSideGame = GlobalConstants.sideGameTypes.contains(status);
+
+    return Card(
+      elevation: 4,
+      color: isAvailable ? Colors.white : Colors.grey[300],
+      child: InkWell(
+        onTap: () => _handleTableSelection(tableId, status),
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.table_restaurant,
+                size: 40,
+                color: isAvailable ? Colors.green : Colors.grey,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                name,
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: isAvailable ? Colors.black : Colors.grey[600],
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '$maxSeats席',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: isAvailable ? Colors.black87 : Colors.grey[600],
+                ),
+              ),
+              const SizedBox(height: 4),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: isAvailable
+                      ? Colors.green[100]
+                      : isSideGame
+                          ? Colors.blue[100]
+                          : Colors.orange[100],
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  _getStatusText(status),
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: isAvailable
+                        ? Colors.green[800]
+                        : isSideGame
+                            ? Colors.blue[800]
+                            : Colors.orange[800],
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _getStatusText(String status) {
+    if (status == 'open') {
+      return '使用可能';
+    } else if (GlobalConstants.sideGameTypes.contains(status)) {
+      return status;
+    } else {
+      return '$status使用中';
+    }
+  }
+
+  void _handleTableSelection(String tableId, String status) async {
+    final isAvailable = status == 'open';
+    final isSideGame = GlobalConstants.sideGameTypes.contains(status);
+    final isInUse = !isAvailable && !isSideGame;
+
+    if (isInUse) {
+      // 他のゲームで使用中の場合は確認ダイアログを表示
+      final confirmed = await _showWarningDialog(status);
+      if (!confirmed) return;
+    }
+
+    if (isSideGame) {
+      // サイドゲーム中の場合は直接テーブルホームに遷移
+      _navigateToTableHome(tableId, status);
+    } else {
+      // 使用可能または他のゲーム使用中の場合はゲーム選択ダイアログを表示
+      final selectedGame = await _showGameSelectionDialog();
+      if (selectedGame != null) {
+        await _updateTableStatus(tableId, selectedGame);
+        _navigateToTableHome(tableId, selectedGame);
+      }
+    }
+  }
+
+  Future<bool> _showWarningDialog(String currentStatus) async {
+    return await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        icon: const Icon(
+          Icons.warning,
+          color: Colors.orange,
+          size: 48,
+        ),
+        title: const Text('確認'),
+        content: Text('他ゲームで使用中となっていますが、上書きを行って問題ないですか？\n\n現在の状態: $currentStatus使用中'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.orange,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('確認'),
+          ),
+        ],
+      ),
+    ) ?? false;
+  }
+
+  Future<String?> _showGameSelectionDialog() async {
+    return await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('ゲームを選択してください'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: GlobalConstants.sideGameTypes.length,
+            itemBuilder: (context, index) {
+              final game = GlobalConstants.sideGameTypes[index];
+              return ListTile(
+                leading: const Icon(Icons.casino),
+                title: Text(game),
+                onTap: () => Navigator.of(context).pop(game),
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('キャンセル'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _updateTableStatus(String tableId, String gameName) async {
+    try {
+      // tablesコレクションのstatusを更新
+      await _firestore.collection('tables').doc(tableId).update({
+        'status': gameName,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+
+      // sideGameコレクションのactiveフィールドをtrueに更新
+      await _firestore.collection('sideGame').doc(tableId).update({
+        'active': true,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('$gameName でテーブルを開始しました'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラーが発生しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  void _navigateToTableHome(String tableId, String gameName) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => SideGameTableHomePage(
+          tableId: tableId,
+          gameName: gameName,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/user_actions/side_game_chip_purchase_popup.dart
+++ b/lib/user_actions/side_game_chip_purchase_popup.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import '../../Utils/menuItemsManager.dart';
+
+/// SideGame用Chip購入ポップアップ
+Future<void> showSideGameChipPurchaseDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+}) async {
+  // 外側（ページ側）のコンテキストを退避。以降のUI操作は必ずこれを使う
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _SideGameChipPurchaseDialog(
+      userId: userId,
+      pokerName: pokerName,
+    ),
+  );
+}
+
+class _SideGameChipPurchaseDialog extends StatefulWidget {
+  final String userId;
+  final String pokerName;
+
+  const _SideGameChipPurchaseDialog({
+    required this.userId,
+    required this.pokerName,
+  });
+
+  @override
+  State<_SideGameChipPurchaseDialog> createState() => _SideGameChipPurchaseDialogState();
+}
+
+class _SideGameChipPurchaseDialogState extends State<_SideGameChipPurchaseDialog> {
+  bool _isLoading = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: [
+          const Icon(Icons.shopping_cart, color: Colors.teal),
+          const SizedBox(width: 8),
+          const Text('Chip購入'),
+        ],
+      ),
+      content: SizedBox(
+        width: 350,
+        height: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // ユーザー情報表示
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.blue.shade50,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.blue.shade200),
+              ),
+              child: Column(
+                children: [
+                  const Icon(
+                    Icons.person,
+                    color: Colors.blue,
+                    size: 32,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    widget.pokerName,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.blue,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Chipメニュー一覧
+            Expanded(
+              child: _buildChipMenuList(),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChipMenuList() {
+    // MenuItemsManagerからChipカテゴリーのメニューを取得
+    final chipMenus = MenuItemsManager.getMenuItemsByCategory('Chip');
+
+    if (chipMenus.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.shopping_cart_outlined, size: 48, color: Colors.grey),
+            SizedBox(height: 16),
+            Text(
+              'Chipメニューがありません',
+              style: TextStyle(
+                fontSize: 16,
+                color: Colors.grey,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: chipMenus.length,
+      itemBuilder: (context, index) {
+        final menu = chipMenus[index];
+        return Card(
+          margin: const EdgeInsets.symmetric(vertical: 4),
+          child: ListTile(
+            leading: Container(
+              width: 50,
+              height: 50,
+              decoration: BoxDecoration(
+                color: Colors.teal.shade50,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.teal.shade200),
+              ),
+              child: const Icon(
+                Icons.casino,
+                color: Colors.teal,
+                size: 24,
+              ),
+            ),
+            title: Text(
+              menu.name,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            subtitle: Text(
+              '¥${menu.price}',
+              style: const TextStyle(
+                fontSize: 14,
+                color: Colors.grey,
+              ),
+            ),
+            trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            onTap: _isLoading ? null : () => _showConfirmDialog(menu),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showConfirmDialog(MenuItem menu) async {
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('購入確認'),
+        content: Text(
+          '${widget.pokerName}様の${menu.name}の購入でお間違い無いですか？',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              _processPurchase(menu);
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.teal,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('購入'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _processPurchase(MenuItem menu) async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    // 処理中ダイアログを表示
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => const AlertDialog(
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(width: 16),
+            Text('Chip購入処理中...'),
+          ],
+        ),
+      ),
+    );
+
+    try {
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('placeOrder');
+
+      final result = await callable.call({
+        'userId': widget.userId,
+        'item': {
+          'menuItemId': menu.id,
+          'category': menu.category,
+          'name': menu.name,
+          'price': menu.price,
+          'quantity': 1,
+        }
+      });
+
+      // 処理中ダイアログを閉じる
+      Navigator.of(context).pop();
+
+      if (mounted) {
+        // Chip購入ポップアップを閉じる
+        Navigator.of(context).pop();
+        
+        // 成功メッセージを表示
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              '${widget.pokerName}様の${menu.name}の購入処理が完了しました。chipをお渡しください。',
+            ),
+            backgroundColor: Colors.green,
+            duration: const Duration(seconds: 5),
+          ),
+        );
+      }
+    } catch (e) {
+      // 処理中ダイアログを閉じる
+      if (mounted) {
+        Navigator.of(context).pop();
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Chip購入処理に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+}

--- a/lib/user_actions/side_game_tip_deposit_popup.dart
+++ b/lib/user_actions/side_game_tip_deposit_popup.dart
@@ -1,0 +1,357 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+/// SideGame用Tip預入ポップアップ
+Future<void> showSideGameTipDepositDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+  String? tableId,
+  int? seatNumber,
+}) async {
+  // 外側（ページ側）のコンテキストを退避。以降のUI操作は必ずこれを使う
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _SideGameTipDepositDialog(
+      userId: userId,
+      pokerName: pokerName,
+      tableId: tableId,
+      seatNumber: seatNumber,
+    ),
+  );
+}
+
+class _SideGameTipDepositDialog extends StatefulWidget {
+  final String userId;
+  final String pokerName;
+  final String? tableId;
+  final int? seatNumber;
+
+  const _SideGameTipDepositDialog({
+    required this.userId,
+    required this.pokerName,
+    this.tableId,
+    this.seatNumber,
+  });
+
+  @override
+  State<_SideGameTipDepositDialog> createState() => _SideGameTipDepositDialogState();
+}
+
+class _SideGameTipDepositDialogState extends State<_SideGameTipDepositDialog> {
+  final TextEditingController _amountController = TextEditingController();
+  bool _isLoading = false;
+  num _currentTip = 0;
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: [
+          const Icon(Icons.account_balance, color: Colors.green),
+          const SizedBox(width: 8),
+          const Text('Tip預入'),
+        ],
+      ),
+      content: SizedBox(
+        width: 300,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // ユーザー情報と残高表示（StreamBuilderで分離）
+            StreamBuilder<DocumentSnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('users')
+                  .doc(widget.userId)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+
+                if (snapshot.hasError || !snapshot.hasData || !snapshot.data!.exists) {
+                  return Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.red.shade50,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: Colors.red.shade200),
+                    ),
+                    child: const Column(
+                      children: [
+                        Icon(Icons.error, color: Colors.red, size: 32),
+                        SizedBox(height: 8),
+                        Text(
+                          'ユーザー情報の取得に失敗しました',
+                          style: TextStyle(
+                            fontSize: 16,
+                            color: Colors.red,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+
+                final userData = snapshot.data!.data() as Map<String, dynamic>;
+                _currentTip = userData['sideGameTip'] as num? ?? 0;
+
+                return Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: Colors.blue.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.blue.shade200),
+                  ),
+                  child: Column(
+                    children: [
+                      const Icon(
+                        Icons.person,
+                        color: Colors.blue,
+                        size: 32,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        widget.pokerName,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.blue,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '現在の残高: ${_currentTip.toString().replaceAllMapped(
+                          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+                          (Match m) => '${m[1]},',
+                        )} Tip',
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 20),
+
+            // 預入額入力（StreamBuilderの外に移動）
+            TextField(
+              controller: _amountController,
+              keyboardType: TextInputType.number,
+              enabled: !_isLoading,
+              decoration: const InputDecoration(
+                labelText: '預入額',
+                hintText: '預入するTip額を入力',
+                suffixText: 'Tip',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.money),
+              ),
+              onChanged: (value) {
+                setState(() {}); // ボタンの有効/無効を更新
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isLoading ? null : () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        ElevatedButton(
+          onPressed: _isLoading ? null : _canDeposit() ? () => _showConfirmDialog(false) : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
+          child: _isLoading
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : const Text('預入のみ'),
+        ),
+        ElevatedButton(
+          onPressed: _isLoading ? null : _canDeposit() ? () => _showConfirmDialog(true) : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.orange,
+            foregroundColor: Colors.white,
+          ),
+          child: _isLoading
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : const Text('預入と退席'),
+        ),
+      ],
+    );
+  }
+
+  bool _canDeposit() {
+    final amount = int.tryParse(_amountController.text);
+    return amount != null && amount > 0;
+  }
+
+  Future<void> _showConfirmDialog(bool shouldLeaveSeat) async {
+    final amount = int.parse(_amountController.text);
+    
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('預入確認'),
+        content: Text(
+          '${widget.pokerName}様の${amount.toString().replaceAllMapped(
+            RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+            (Match m) => '${m[1]},',
+          )} Tipの預入${shouldLeaveSeat ? 'と退席' : ''}で確定してよろしいですか？',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              _processDeposit(amount, shouldLeaveSeat);
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: shouldLeaveSeat ? Colors.orange : Colors.green,
+              foregroundColor: Colors.white,
+            ),
+            child: Text(shouldLeaveSeat ? '預入と退席' : '預入のみ'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _processDeposit(int amount, bool shouldLeaveSeat) async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    // 処理中ダイアログを表示
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(width: 16),
+            Text(shouldLeaveSeat ? '預入と退席処理中...' : '預入処理中...'),
+          ],
+        ),
+      ),
+    );
+
+    try {
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('depositTip');
+
+      // 1. Tip預入処理
+      await callable.call({
+        'userId': widget.userId,
+        'amount': amount,
+      });
+
+      // 2. 退席処理が必要な場合
+      if (shouldLeaveSeat) {
+        if (widget.tableId != null && widget.seatNumber != null) {
+          final leaveSeatCallable = functions.httpsCallable('leaveSeat');
+          await leaveSeatCallable.call({
+            'tableId': widget.tableId,
+            'seatNumber': widget.seatNumber,
+            'userId': widget.userId,
+          });
+        } else {
+          throw Exception('退席処理に必要な情報が不足しています（tableId, seatNumber）');
+        }
+      }
+
+      // 処理中ダイアログを閉じる
+      Navigator.of(context).pop();
+
+      if (mounted) {
+        // 預入ポップアップを閉じる
+        Navigator.of(context).pop();
+        
+        // 成功メッセージを表示
+        await showDialog(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('処理完了'),
+            content: Text(
+              '${widget.pokerName}様の${amount.toString().replaceAllMapped(
+                RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+                (Match m) => '${m[1]},',
+              )} Tipの預入処理${shouldLeaveSeat ? 'と退席処理' : ''}が完了しました。',
+            ),
+            actions: [
+              ElevatedButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+      }
+    } catch (e) {
+      // 処理中ダイアログを閉じる
+      if (mounted) {
+        Navigator.of(context).pop();
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('預入処理に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+}

--- a/lib/user_actions/side_game_tip_view_popup.dart
+++ b/lib/user_actions/side_game_tip_view_popup.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// SideGame用Tip参照ポップアップ
+Future<void> showSideGameTipViewDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+}) async {
+  // 外側（ページ側）のコンテキストを退避。以降のUI操作は必ずこれを使う
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _SideGameTipViewDialog(
+      userId: userId,
+      pokerName: pokerName,
+    ),
+  );
+}
+
+class _SideGameTipViewDialog extends StatelessWidget {
+  final String userId;
+  final String pokerName;
+
+  const _SideGameTipViewDialog({
+    required this.userId,
+    required this.pokerName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: [
+          const Icon(Icons.account_balance_wallet, color: Colors.orange),
+          const SizedBox(width: 8),
+          const Text('Tip残高'),
+        ],
+      ),
+      content: StreamBuilder<DocumentSnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('users')
+            .doc(userId)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+
+          if (snapshot.hasError) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error, color: Colors.red, size: 48),
+                const SizedBox(height: 16),
+                Text(
+                  'エラーが発生しました',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.red[700],
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  snapshot.error.toString(),
+                  style: const TextStyle(fontSize: 14),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            );
+          }
+
+          if (!snapshot.hasData || !snapshot.data!.exists) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.person_off, color: Colors.grey, size: 48),
+                const SizedBox(height: 16),
+                Text(
+                  'ユーザー情報が見つかりません',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.grey[700],
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            );
+          }
+
+          final userData = snapshot.data!.data() as Map<String, dynamic>;
+          final sideGameTip = userData['sideGameTip'] as num? ?? 0;
+
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // ユーザー名表示
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                decoration: BoxDecoration(
+                  color: Colors.blue.shade50,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.blue.shade200),
+                ),
+                child: Column(
+                  children: [
+                    const Icon(
+                      Icons.person,
+                      color: Colors.blue,
+                      size: 32,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      pokerName,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.blue,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 20),
+              
+              // Tip残高表示
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+                decoration: BoxDecoration(
+                  color: Colors.orange.shade50,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: Colors.orange.shade200, width: 2),
+                ),
+                child: Column(
+                  children: [
+                    const Icon(
+                      Icons.account_balance_wallet,
+                      color: Colors.orange,
+                      size: 40,
+                    ),
+                    const SizedBox(height: 12),
+                    const Text(
+                      '現在のTip残高',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${sideGameTip.toString().replaceAllMapped(
+                        RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+                        (Match m) => '${m[1]},',
+                      )}',
+                      style: const TextStyle(
+                        fontSize: 32,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.orange,
+                      ),
+                    ),
+                    const Text(
+                      'Tip',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Colors.orange,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('閉じる'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/user_actions/side_game_tip_withdraw_popup.dart
+++ b/lib/user_actions/side_game_tip_withdraw_popup.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+
+/// SideGame用Tip引き出しポップアップ
+Future<void> showSideGameTipWithdrawDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+}) async {
+  // 外側（ページ側）のコンテキストを退避。以降のUI操作は必ずこれを使う
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _SideGameTipWithdrawDialog(
+      userId: userId,
+      pokerName: pokerName,
+    ),
+  );
+}
+
+class _SideGameTipWithdrawDialog extends StatefulWidget {
+  final String userId;
+  final String pokerName;
+
+  const _SideGameTipWithdrawDialog({
+    required this.userId,
+    required this.pokerName,
+  });
+
+  @override
+  State<_SideGameTipWithdrawDialog> createState() => _SideGameTipWithdrawDialogState();
+}
+
+class _SideGameTipWithdrawDialogState extends State<_SideGameTipWithdrawDialog> {
+  final TextEditingController _amountController = TextEditingController();
+  bool _isLoading = false;
+  num _currentTip = 0;
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: [
+          const Icon(Icons.account_balance_wallet, color: Colors.red),
+          const SizedBox(width: 8),
+          const Text('Tip引き出し'),
+        ],
+      ),
+      content: SizedBox(
+        width: 300,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // ユーザー情報と残高表示（StreamBuilderで分離）
+            StreamBuilder<DocumentSnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('users')
+                  .doc(widget.userId)
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(
+                    child: CircularProgressIndicator(),
+                  );
+                }
+
+                if (snapshot.hasError || !snapshot.hasData || !snapshot.data!.exists) {
+                  return Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.red.shade50,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: Colors.red.shade200),
+                    ),
+                    child: const Column(
+                      children: [
+                        Icon(Icons.error, color: Colors.red, size: 32),
+                        SizedBox(height: 8),
+                        Text(
+                          'ユーザー情報の取得に失敗しました',
+                          style: TextStyle(
+                            fontSize: 16,
+                            color: Colors.red,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+
+                final userData = snapshot.data!.data() as Map<String, dynamic>;
+                _currentTip = userData['sideGameTip'] as num? ?? 0;
+
+                return Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: Colors.blue.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.blue.shade200),
+                  ),
+                  child: Column(
+                    children: [
+                      const Icon(
+                        Icons.person,
+                        color: Colors.blue,
+                        size: 32,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        widget.pokerName,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.blue,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '現在の残高: ${_currentTip.toString().replaceAllMapped(
+                          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+                          (Match m) => '${m[1]},',
+                        )} Tip',
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Colors.grey,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 20),
+
+            // 引き出し額入力（StreamBuilderの外に移動）
+            TextField(
+              controller: _amountController,
+              keyboardType: TextInputType.number,
+              enabled: !_isLoading,
+              decoration: const InputDecoration(
+                labelText: '引き出し額',
+                hintText: '引き出しするTip額を入力',
+                suffixText: 'Tip',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.money),
+              ),
+              onChanged: (value) {
+                setState(() {}); // ボタンの有効/無効を更新
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isLoading ? null : () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        ElevatedButton(
+          onPressed: _isLoading ? null : _canWithdraw() ? _showConfirmDialog : null,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.red,
+            foregroundColor: Colors.white,
+          ),
+          child: _isLoading
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+              : const Text('引き出し確定'),
+        ),
+      ],
+    );
+  }
+
+  bool _canWithdraw() {
+    final amount = int.tryParse(_amountController.text);
+    return amount != null && amount > 0;
+  }
+
+  Future<void> _showConfirmDialog() async {
+    final amount = int.parse(_amountController.text);
+    
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('引き出し確認'),
+        content: Text(
+          '${widget.pokerName}様の${amount.toString().replaceAllMapped(
+            RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+            (Match m) => '${m[1]},',
+          )} Tipの引き出し処理を開始してよろしいですか？',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              _processWithdraw(amount);
+            },
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('確定'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _processWithdraw(int amount) async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    // 処理中ダイアログを表示
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => const AlertDialog(
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(width: 16),
+            Text('引き出し処理中...'),
+          ],
+        ),
+      ),
+    );
+
+    try {
+      final functions = FirebaseFunctions.instance;
+      final callable = functions.httpsCallable('withdrawTip');
+
+      final result = await callable.call({
+        'userId': widget.userId,
+        'amount': amount,
+      });
+
+      // 処理中ダイアログを閉じる
+      Navigator.of(context).pop();
+
+      if (mounted) {
+        // 引き出しポップアップを閉じる
+        Navigator.of(context).pop();
+        
+        // 成功メッセージを表示
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              '引き出し処理が完了しました${widget.pokerName}様に${amount.toString().replaceAllMapped(
+                RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+                (Match m) => '${m[1]},',
+              )}のTipをお渡しください。',
+            ),
+            backgroundColor: Colors.green,
+            duration: const Duration(seconds: 5),
+          ),
+        );
+      }
+    } catch (e) {
+      // 処理中ダイアログを閉じる
+      if (mounted) {
+        Navigator.of(context).pop();
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('引き出し処理に失敗しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+}

--- a/lib/user_actions/user_action_home.dart
+++ b/lib/user_actions/user_action_home.dart
@@ -3,6 +3,11 @@ import 'order_from_user_action_popup.dart';
 import 'bust_and_reentry_popup.dart';
 import 'bust_and_exit_popup.dart';
 import 'addon_popup.dart';
+import 'side_game_tip_view_popup.dart';
+import 'side_game_tip_withdraw_popup.dart';
+import 'side_game_tip_deposit_popup.dart';
+import 'side_game_chip_purchase_popup.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 
 /// When: ユーザー行をタップしてアクションを選択したいとき
 /// Where: StayingUsersListPage などユーザー一覧系の画面
@@ -120,6 +125,11 @@ List<_UserActionItem> _buildActionsForSource({
   // tableHomeInScheduledTournament からの呼び出し時は 4 ブロックを表示
   if (sourcePage == 'tableHomeInScheduledTournament') {
     return _buildActionsFromBlocks(blockIds: const ['A', 'I', 'J', 'K'], user: user);
+  }
+
+  // sideGameTableHome からの呼び出し時は 6 ブロックを表示
+  if (sourcePage == 'sideGameTableHome') {
+    return _buildActionsFromBlocks(blockIds: const ['L', 'M', 'N', 'O', 'P', 'Q'], user: user);
   }
 
   // 将来: 他の呼び出し元ごとのメニュー構成はここに追加する
@@ -329,6 +339,200 @@ _UserActionItem _buildBlockK(Map<String, dynamic> user) => _UserActionItem(
       },
     );
 
+// 塊L: SideGame注文
+_UserActionItem _buildBlockL(Map<String, dynamic> user) => _UserActionItem(
+      label: '注文',
+      icon: Icons.shopping_bag_outlined,
+      color: Colors.blue,
+      onSelected: (ctx, u) {
+        // When: 「注文」ブロック選択時
+        // Where: userActionHome（ダイアログ内）
+        // What: 選択ユーザー向けの注文フローを表示
+        // How: カテゴリー→メニュー選択→数量指定→placeOrder 呼び出し
+        showOrderFromUserDialog(
+          pageContext: ctx,
+          user: u,
+          onBackToUserActionHome: () {
+            showUserActionHome(context: ctx, sourcePage: 'sideGameTableHome', user: u);
+          },
+        );
+      },
+    );
+
+// 塊M: Tipの参照
+_UserActionItem _buildBlockM(Map<String, dynamic> user) => _UserActionItem(
+      label: 'Tipの参照',
+      icon: Icons.visibility,
+      color: Colors.orange,
+      onSelected: (ctx, u) {
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String?;
+        
+        if (userId == null || pokerName == null) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('ユーザー情報が不足しています')),
+          );
+          return;
+        }
+        
+        showSideGameTipViewDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
+        );
+      },
+    );
+
+// 塊N: Tipの引き出し
+_UserActionItem _buildBlockN(Map<String, dynamic> user) => _UserActionItem(
+      label: 'Tipの引き出し',
+      icon: Icons.account_balance_wallet,
+      color: Colors.red,
+      onSelected: (ctx, u) {
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String?;
+        
+        if (userId == null || pokerName == null) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('ユーザー情報が不足しています')),
+          );
+          return;
+        }
+        
+        showSideGameTipWithdrawDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
+        );
+      },
+    );
+
+// 塊O: Tipの預入と退席
+_UserActionItem _buildBlockO(Map<String, dynamic> user) => _UserActionItem(
+      label: 'Tipの預入と退席',
+      icon: Icons.account_balance,
+      color: Colors.green,
+      onSelected: (ctx, u) {
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String?;
+        final tableId = u['tableId'] as String?;
+        final seatNumber = u['seatNumber'] as int?;
+        
+        if (userId == null || pokerName == null || tableId == null || seatNumber == null) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('SideGame情報が不足しています')),
+          );
+          return;
+        }
+        
+        showSideGameTipDepositDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
+          tableId: tableId,
+          seatNumber: seatNumber,
+        );
+      },
+    );
+
+// 塊P: Chipの購入
+_UserActionItem _buildBlockP(Map<String, dynamic> user) => _UserActionItem(
+      label: 'Chipの購入',
+      icon: Icons.shopping_cart,
+      color: Colors.teal,
+      onSelected: (ctx, u) {
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String?;
+        
+        if (userId == null || pokerName == null) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('ユーザー情報が不足しています')),
+          );
+          return;
+        }
+        
+        showSideGameChipPurchaseDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
+        );
+      },
+    );
+
+// 塊Q: 退席
+_UserActionItem _buildBlockQ(Map<String, dynamic> user) => _UserActionItem(
+      label: '退席',
+      icon: Icons.exit_to_app,
+      color: Colors.red,
+      onSelected: (ctx, u) async {
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String?;
+        final tableId = u['tableId'] as String?;
+        final seatNumber = u['seatNumber'] as int?;
+        
+        if (userId == null || pokerName == null || tableId == null || seatNumber == null) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('SideGame情報が不足しています')),
+          );
+          return;
+        }
+        
+        // 退席確認ダイアログを表示
+        final confirmed = await showDialog<bool>(
+          context: ctx,
+          builder: (context) => AlertDialog(
+            title: const Text('退席確認'),
+            content: Text('${pokerName}様を退席させますか？'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('キャンセル'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red,
+                  foregroundColor: Colors.white,
+                ),
+                child: const Text('退席'),
+              ),
+            ],
+          ),
+        );
+        
+        if (confirmed == true) {
+          try {
+            final functions = FirebaseFunctions.instance;
+            final callable = functions.httpsCallable('leaveSeat');
+            
+            await callable.call({
+              'tableId': tableId,
+              'seatNumber': seatNumber,
+              'userId': userId,
+            });
+            
+            if (ctx.mounted) {
+              ScaffoldMessenger.of(ctx).showSnackBar(
+                SnackBar(
+                  content: Text('${pokerName}様を退席させました'),
+                  backgroundColor: Colors.green,
+                ),
+              );
+            }
+          } catch (e) {
+            if (ctx.mounted) {
+              ScaffoldMessenger.of(ctx).showSnackBar(
+                SnackBar(
+                  content: Text('退席処理に失敗しました: $e'),
+                  backgroundColor: Colors.red,
+                ),
+              );
+            }
+          }
+        }
+      },
+    );
+
 final Map<String, UserActionBuilder> _blockRegistry = <String, UserActionBuilder>{
   // ブロックID → ビルダー
   'A': _buildBlockA, // 注文
@@ -342,6 +546,12 @@ final Map<String, UserActionBuilder> _blockRegistry = <String, UserActionBuilder
   'I': _buildBlockI, // Bust＆リエントリー
   'J': _buildBlockJ, // Bust&退席
   'K': _buildBlockK, // Addon
+  'L': _buildBlockL, // SideGame注文
+  'M': _buildBlockM, // Tipの参照
+  'N': _buildBlockN, // Tipの引き出し
+  'O': _buildBlockO, // Tipの預入と退席
+  'P': _buildBlockP, // Chipの購入
+  'Q': _buildBlockQ, // 退席
 };
 
 List<_UserActionItem> _buildActionsFromBlocks({


### PR DESCRIPTION
- ログユーティリティ関数（logUtils.ts）を作成
- ユーザー作成時にログサブコレクション（sideGameChipLogs, pointALogs, pointBLogs）を初期化
- depositTip.ts, withdrawTip.ts, placeOrder.ts, setRankingData.tsにログ記録機能を追加
- placeOrder.tsのChip購入処理を修正（sideGameTip加算、ログ記録、データ整合性向上）
- createMenuPage.dartのUI改善（項目並び順変更、Chipカテゴリー自動入力機能）
- SideGame機能をuser_action_home.dartに統合（ブロック型アーキテクチャ）
- メニューカテゴリーに'Chip'を追加