### PR TITLE
注文管理システムの実装

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
         applicationId = "com.example.amuse_app_template"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 23  // Firebase Auth 24.0.0 requires API 23 or higher
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/firestore.rules
+++ b/firestore.rules
@@ -124,6 +124,18 @@ service cloud.firestore {
       allow write: if false; // 書き込みはCloud Functions経由のみ
     }
 
+    // orders コレクション（開発用：読み取り・書き込み全許可）
+    match /orders/{orderId} {
+      allow read: if true; // 開発用：全許可
+      allow write: if true; // 開発用：全許可
+      
+      // _TodaysOrders サブコレクション
+      match /_TodaysOrders/{subOrderId} {
+        allow read: if true; // 開発用：全許可
+        allow write: if true; // 開発用：全許可
+      }
+    }
+
     // 管理者コレクション
     match /admins/{adminId} {
       allow read: if request.auth != null && request.auth.uid == adminId;

--- a/functions/src/callables/assignSeatToPlayer.ts
+++ b/functions/src/callables/assignSeatToPlayer.ts
@@ -109,6 +109,13 @@ export const assignSeatToPlayer = functions.https.onCall(async (data, context) =
         seats: updatedSeats,
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       });
+
+      // 8. todaysBillsのcurrentTable/currentSeatを更新
+      transaction.update(todayBillsDoc.ref, {
+        currentTable: tableId,
+        currentSeat: seatNumber,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
       
       // 5. usersサブコレクションにユーザー情報を記録
       // TODO: 今後実装予定 - usersサブコレクションへの記録

--- a/functions/src/callables/bustAndExit.ts
+++ b/functions/src/callables/bustAndExit.ts
@@ -111,6 +111,23 @@ export const bustAndExit = functions.https.onCall(async (data, context) => {
         bustedUser: bustedUser,
       });
 
+      // 7. todaysBillsのcurrentTable/currentSeatをnullに設定
+      const todayBillsQuery = db.collection('todaysBills')
+        .where('userId', '==', userId)
+        .where('status', '==', 'open')
+        .limit(1);
+      
+      const todayBillsSnapshot = await transaction.get(todayBillsQuery);
+      
+      if (!todayBillsSnapshot.empty) {
+        const todayBillsDoc = todayBillsSnapshot.docs[0];
+        transaction.update(todayBillsDoc.ref, {
+          currentTable: null,
+          currentSeat: null,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      }
+
       return { success: true, userId, tableId, seatNumber };
     });
 

--- a/functions/src/callables/reseatAllPlayers.ts
+++ b/functions/src/callables/reseatAllPlayers.ts
@@ -38,6 +38,7 @@ export const reseatAllPlayers = functions.https.onCall(async (data, context) => 
       
       // 2. todaysBillsからユーザー情報を事前に取得（すべての読み取りを最初に実行）
       const userPokerNames: { [userId: string]: string } = {};
+      const todaysBillsDocs: { [userId: string]: any } = {};
       
       for (const assignment of playerAssignments) {
         const { userId } = assignment;
@@ -52,8 +53,10 @@ export const reseatAllPlayers = functions.https.onCall(async (data, context) => 
         let pokerName = `Player_${userId}`;
         
         if (!todayBillsSnapshot.empty) {
-          const todayBillsData = todayBillsSnapshot.docs[0].data();
+          const todayBillsDoc = todayBillsSnapshot.docs[0];
+          const todayBillsData = todayBillsDoc.data();
           pokerName = todayBillsData.pokerName || pokerName;
+          todaysBillsDocs[userId] = todayBillsDoc; // ドキュメント参照を保存
         }
         
         userPokerNames[userId] = pokerName;
@@ -69,6 +72,10 @@ export const reseatAllPlayers = functions.https.onCall(async (data, context) => 
           tableSeatDocsMap.set(tableId, tableSeatDoc);
         }
       }
+      
+      // 4. waitingドキュメントを事前に読み取り
+      const waitingRef = tablesSeatRef.doc('waiting');
+      const waitingDoc = await transaction.get(waitingRef);
       
       // 全ての読み取りが完了したので、ここから書き込み操作を開始
       
@@ -123,14 +130,42 @@ export const reseatAllPlayers = functions.https.onCall(async (data, context) => 
           updatedAt: admin.firestore.FieldValue.serverTimestamp(),
         });
       }
+
+      // 7. todaysBillsのcurrentTable/currentSeatを更新（事前に取得したドキュメント参照を使用）
+      for (const assignment of playerAssignments) {
+        const { userId, tableId, seatNumber } = assignment;
+        
+        if (todaysBillsDocs[userId]) {
+          const todayBillsDoc = todaysBillsDocs[userId];
+          transaction.update(todayBillsDoc.ref, {
+            currentTable: tableId,
+            currentSeat: seatNumber,
+            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          });
+        }
+      }
       
-      // 5. 待機者リストをクリア
-      const waitingRef = tablesSeatRef.doc('waiting');
-      transaction.update(waitingRef, {
-        waiting: {},
-        count: 0,
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
-      });
+      // 5. 待機者リストから割り当てられたユーザーのみを削除（事前に読み取ったドキュメントを使用）
+      if (waitingDoc.exists) {
+        const waitingData = waitingDoc.data()!;
+        const currentWaiting = waitingData.waiting || {};
+        
+        // 割り当てられたユーザーのみを削除
+        const assignedUserIds = new Set(playerAssignments.map(assignment => assignment.userId));
+        const updatedWaiting = { ...currentWaiting };
+        
+        for (const userId of assignedUserIds) {
+          if (updatedWaiting.hasOwnProperty(userId)) {
+            delete updatedWaiting[userId];
+          }
+        }
+        
+        transaction.update(waitingRef, {
+          waiting: updatedWaiting,
+          count: Object.keys(updatedWaiting).length,
+          updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+      }
       
       // 6. eventsサブコレクションに記録（ロールバック用）
       // TODO: 今後実装予定 - eventsサブコレクションへの記録

--- a/lib/Home/terminalHomePage.dart
+++ b/lib/Home/terminalHomePage.dart
@@ -9,6 +9,7 @@ import 'package:amuse_app_template/Home/systemSettingsPage.dart';
 import 'package:amuse_app_template/tournament/scheduling/pages/tournament_creation_menu_page.dart';
 import 'package:amuse_app_template/Accounting/accountingPage.dart';
 import 'package:amuse_app_template/sideGame/pages/side_game_table_list.dart';
+import 'package:amuse_app_template/OrderView/OrderManagement/order_management_page.dart';
 import 'package:flutter/material.dart';
 
 class terminalHomePage extends StatefulWidget {
@@ -33,7 +34,7 @@ class _terminalHomePageState extends State<terminalHomePage> {
       (label: 'Tournament 作成', destination: const TournamentCreationMenuPage()),
       (label: 'Tournament Home', destination: const ScheduledTournamentListPage()),
       (label: 'sideGame', destination: const SideGameTableListPage()),
-      (label: 'デモ2', destination: const PlaceholderPage(title: 'demo2')),
+      (label: '注文管理', destination: const OrderManagementPage()),
       (label: 'スタッフ打刻', destination: const StaffAttendancePage()),
       (label: '会計管理', destination: const AccountingPage()),
     ];

--- a/lib/OrderView/OrderManagement/order_card.dart
+++ b/lib/OrderView/OrderManagement/order_card.dart
@@ -1,0 +1,336 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class OrderCard extends StatelessWidget {
+  final Map<String, dynamic> order;
+  final Function(String orderId, String newStatus) onStatusChanged;
+  final Function(String orderId) onEdit;
+  final String? localStatus;
+
+  const OrderCard({
+    super.key,
+    required this.order,
+    required this.onStatusChanged,
+    required this.onEdit,
+    this.localStatus,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final items = order['items'] as List<dynamic>? ?? [];
+    final userName = order['userName'] ?? '不明';
+    final currentTable = order['currentTable'] ?? '';
+    final currentSeat = order['currentSeat'] ?? '';
+    final status = localStatus ?? order['status'] ?? 'preparing';
+    final createdAt = order['createdAt'] as Timestamp?;
+    final updatedAt = order['updatedAt'] as Timestamp?;
+    
+    return Dismissible(
+      key: Key(order['id'] ?? ''),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        color: Colors.green,
+        child: const Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.check_circle, color: Colors.white, size: 32),
+            Text(
+              '提供済み',
+              style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ),
+      confirmDismiss: (direction) async {
+        return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('提供済みにしますか？'),
+            content: const Text('この注文を提供済みとしてマークします。'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('キャンセル'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('確定'),
+              ),
+            ],
+          ),
+        );
+      },
+      onDismissed: (direction) async {
+        await _markAsServed(context);
+      },
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: InkWell(
+          onTap: () => _handleCardTap(context),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ヘッダー部分
+                Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            userName,
+                            style: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          if (currentTable.isNotEmpty || currentSeat != null)
+                            Text(
+                              '${currentTable.isNotEmpty ? '卓: $currentTable' : ''}${currentSeat != null ? ' シート: $currentSeat' : ''}',
+                              style: TextStyle(
+                                color: Colors.grey[600],
+                                fontSize: 14,
+                              ),
+                            )
+                          else
+                            Text(
+                              '現在はテーブルに着席されていません',
+                              style: TextStyle(
+                                color: Colors.orange[600],
+                                fontSize: 14,
+                                fontStyle: FontStyle.italic,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    // ステータス表示
+                    _buildStatusChip(status),
+                    const SizedBox(width: 8),
+                    // 編集ボタン
+                    IconButton(
+                      onPressed: () => onEdit(order['id']),
+                      icon: const Icon(Icons.edit, color: Colors.blue),
+                    ),
+                  ],
+                ),
+                
+                const SizedBox(height: 12),
+                
+                // 注文アイテム一覧
+                ...items.map<Widget>((item) {
+                  final name = item['name'] ?? '';
+                  final quantity = item['quantity'] ?? 1;
+                  final category = item['category'] ?? '';
+                  
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: _getCategoryColor(category),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Text(
+                            _getCategoryDisplayName(category),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 10,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            name,
+                            style: const TextStyle(fontSize: 14),
+                          ),
+                        ),
+                        Text(
+                          '×$quantity',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.blue[700],
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }).toList(),
+                
+                const SizedBox(height: 8),
+                
+                // 時間表示
+                Row(
+                  children: [
+                    Icon(Icons.access_time, size: 16, color: Colors.grey[600]),
+                    const SizedBox(width: 4),
+                    Text(
+                      _formatTime(createdAt, updatedAt, status),
+                      style: TextStyle(
+                        color: Colors.grey[600],
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// ステータスチップを構築
+  Widget _buildStatusChip(String status) {
+    Color color;
+    String text;
+    IconData icon;
+    
+    switch (status) {
+      case 'preparing':
+        color = Colors.orange;
+        text = '準備中';
+        icon = Icons.restaurant;
+        break;
+      case 'in_progress':
+        color = Colors.blue;
+        text = '作成・提供中';
+        icon = Icons.local_dining;
+        break;
+      case 'served':
+        color = Colors.green;
+        text = '提供済み';
+        icon = Icons.check_circle;
+        break;
+      default:
+        color = Colors.grey;
+        text = '不明';
+        icon = Icons.help;
+    }
+    
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: color),
+          const SizedBox(width: 4),
+          Text(
+            text,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// カテゴリー色を取得
+  Color _getCategoryColor(String category) {
+    switch (category) {
+      case 'food':
+        return Colors.orange;
+      case 'drink':
+        return Colors.blue;
+      case 'Chip':
+        return Colors.purple;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  /// カテゴリー表示名を取得
+  String _getCategoryDisplayName(String category) {
+    switch (category) {
+      case 'food':
+        return 'フード';
+      case 'drink':
+        return 'ドリンク';
+      case 'Chip':
+        return 'チップ';
+      default:
+        return category;
+    }
+  }
+
+  /// 時間をフォーマット
+  String _formatTime(Timestamp? createdAt, Timestamp? updatedAt, String status) {
+    final time = status == 'served' ? updatedAt : createdAt;
+    if (time == null) return '';
+    
+    final dateTime = time.toDate();
+    return '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+
+  /// カードタップ処理
+  void _handleCardTap(BuildContext context) {
+    final currentStatus = localStatus ?? order['status'] ?? 'preparing';
+    
+    if (currentStatus == 'preparing') {
+      onStatusChanged(order['id'], 'in_progress');
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('作成・提供中に変更しました'),
+          backgroundColor: Colors.blue,
+        ),
+      );
+    }
+  }
+
+  /// 提供済みにマーク
+  Future<void> _markAsServed(BuildContext context) async {
+    try {
+      // Firestoreのステータスを更新
+      await FirebaseFirestore.instance
+          .collection('orders')
+          .doc(_getDateString())
+          .collection('_TodaysOrders')
+          .doc(order['id'])
+          .update({
+        'status': 'served',
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('提供済みにマークしました'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラーが発生しました: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  /// 日付文字列を取得
+  String _getDateString() {
+    return order['date'] ?? DateTime.now().toIso8601String().split('T')[0].replaceAll('-', '');
+  }
+}

--- a/lib/OrderView/OrderManagement/order_edit_dialog.dart
+++ b/lib/OrderView/OrderManagement/order_edit_dialog.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class OrderEditDialog extends StatefulWidget {
+  final String orderId;
+  final VoidCallback onOrderUpdated;
+
+  const OrderEditDialog({
+    super.key,
+    required this.orderId,
+    required this.onOrderUpdated,
+  });
+
+  @override
+  State<OrderEditDialog> createState() => _OrderEditDialogState();
+}
+
+class _OrderEditDialogState extends State<OrderEditDialog> {
+  List<Map<String, dynamic>> _items = [];
+  bool _isLoading = true;
+  bool _isUpdating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOrderData();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('注文編集'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('注文内容を編集してください'),
+                  const SizedBox(height: 16),
+                  ..._items.asMap().entries.map((entry) {
+                    final index = entry.key;
+                    final item = entry.value;
+                    return _buildItemEditor(index, item);
+                  }).toList(),
+                ],
+              ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isUpdating ? null : () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+        TextButton(
+          onPressed: _isUpdating ? null : _cancelOrder,
+          child: const Text('注文取り消し', style: TextStyle(color: Colors.red)),
+        ),
+        ElevatedButton(
+          onPressed: _isUpdating ? null : _updateOrder,
+          child: _isUpdating
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('更新'),
+        ),
+      ],
+    );
+  }
+
+  /// アイテムエディターを構築
+  Widget _buildItemEditor(int index, Map<String, dynamic> item) {
+    final quantityController = TextEditingController(
+      text: (item['quantity'] ?? 1).toString(),
+    );
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    item['name'] ?? '',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                    ),
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: _getCategoryColor(item['category'] ?? ''),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    _getCategoryDisplayName(item['category'] ?? ''),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Text('数量: '),
+                SizedBox(
+                  width: 80,
+                  child: TextField(
+                    controller: quantityController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    ),
+                    onChanged: (value) {
+                      final quantity = int.tryParse(value) ?? 1;
+                      if (quantity > 0) {
+                        setState(() {
+                          _items[index]['quantity'] = quantity;
+                        });
+                      }
+                    },
+                  ),
+                ),
+                const Spacer(),
+                IconButton(
+                  onPressed: () => _removeItem(index),
+                  icon: const Icon(Icons.delete, color: Colors.red),
+                  tooltip: 'このアイテムを削除',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// カテゴリー色を取得
+  Color _getCategoryColor(String category) {
+    switch (category) {
+      case 'food':
+        return Colors.orange;
+      case 'drink':
+        return Colors.blue;
+      case 'Chip':
+        return Colors.purple;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  /// カテゴリー表示名を取得
+  String _getCategoryDisplayName(String category) {
+    switch (category) {
+      case 'food':
+        return 'フード';
+      case 'drink':
+        return 'ドリンク';
+      case 'Chip':
+        return 'チップ';
+      default:
+        return category;
+    }
+  }
+
+  /// アイテムを削除
+  void _removeItem(int index) {
+    setState(() {
+      _items.removeAt(index);
+    });
+  }
+
+  /// 注文データを読み込み
+  Future<void> _loadOrderData() async {
+    try {
+      final today = DateTime.now();
+      final dateString = '${today.year}${today.month.toString().padLeft(2, '0')}${today.day.toString().padLeft(2, '0')}';
+      
+      final doc = await FirebaseFirestore.instance
+          .collection('orders')
+          .doc(dateString)
+          .collection('_TodaysOrders')
+          .doc(widget.orderId)
+          .get();
+
+      if (doc.exists) {
+        final data = doc.data()!;
+        setState(() {
+          _items = List<Map<String, dynamic>>.from(data['items'] ?? []);
+          _isLoading = false;
+        });
+      } else {
+        setState(() {
+          _isLoading = false;
+        });
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('注文データが見つかりません')),
+          );
+          Navigator.of(context).pop();
+        }
+      }
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('データの読み込みに失敗しました: $e')),
+        );
+        Navigator.of(context).pop();
+      }
+    }
+  }
+
+  /// 注文を更新
+  Future<void> _updateOrder() async {
+    if (_items.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('注文アイテムがありません')),
+      );
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('注文を更新しますか？'),
+        content: const Text('この変更を確定しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('確定'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    setState(() {
+      _isUpdating = true;
+    });
+
+    try {
+      final today = DateTime.now();
+      final dateString = '${today.year}${today.month.toString().padLeft(2, '0')}${today.day.toString().padLeft(2, '0')}';
+      
+      await FirebaseFirestore.instance
+          .collection('orders')
+          .doc(dateString)
+          .collection('_TodaysOrders')
+          .doc(widget.orderId)
+          .update({
+        'items': _items,
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+
+      if (mounted) {
+        Navigator.of(context).pop();
+        widget.onOrderUpdated();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('注文を更新しました')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('更新に失敗しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUpdating = false;
+        });
+      }
+    }
+  }
+
+  /// 注文を取り消し
+  Future<void> _cancelOrder() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('注文を取り消しますか？'),
+        content: const Text('この注文を完全に削除します。この操作は取り消せません。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('削除', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    setState(() {
+      _isUpdating = true;
+    });
+
+    try {
+      final today = DateTime.now();
+      final dateString = '${today.year}${today.month.toString().padLeft(2, '0')}${today.day.toString().padLeft(2, '0')}';
+      
+      await FirebaseFirestore.instance
+          .collection('orders')
+          .doc(dateString)
+          .collection('_TodaysOrders')
+          .doc(widget.orderId)
+          .delete();
+
+      if (mounted) {
+        Navigator.of(context).pop();
+        widget.onOrderUpdated();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('注文を取り消しました')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('取り消しに失敗しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUpdating = false;
+        });
+      }
+    }
+  }
+}

--- a/lib/OrderView/OrderManagement/order_management_page.dart
+++ b/lib/OrderView/OrderManagement/order_management_page.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+import 'order_card.dart';
+import 'order_edit_dialog.dart';
+
+class OrderManagementPage extends StatefulWidget {
+  const OrderManagementPage({super.key});
+
+  @override
+  State<OrderManagementPage> createState() => _OrderManagementPageState();
+}
+
+class _OrderManagementPageState extends State<OrderManagementPage> {
+  int _selectedTabIndex = 0;
+  
+  // ローカル状態管理
+  Map<String, String> _localOrderStatus = {};
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('注文管理'),
+        backgroundColor: Colors.blue,
+        foregroundColor: Colors.white,
+      ),
+      body: Column(
+        children: [
+          // タブ切り替え
+          _buildTabBar(),
+          
+          // 注文一覧
+          Expanded(
+            child: _buildOrderList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+
+  /// タブバーを構築
+  Widget _buildTabBar() {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: Colors.grey[300]!)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: _buildTabButton(
+              index: 0,
+              title: '準備中・提供中',
+              icon: Icons.restaurant,
+              color: Colors.orange,
+            ),
+          ),
+          Expanded(
+            child: _buildTabButton(
+              index: 1,
+              title: '提供済み',
+              icon: Icons.check_circle,
+              color: Colors.green,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// タブボタンを構築
+  Widget _buildTabButton({
+    required int index,
+    required String title,
+    required IconData icon,
+    required Color color,
+  }) {
+    final isSelected = _selectedTabIndex == index;
+    return InkWell(
+      onTap: () {
+        setState(() {
+          _selectedTabIndex = index;
+        });
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? color.withOpacity(0.1) : Colors.transparent,
+          border: isSelected 
+              ? Border(bottom: BorderSide(color: color, width: 3))
+              : null,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: isSelected ? color : Colors.grey),
+            const SizedBox(width: 8),
+            Text(
+              title,
+              style: TextStyle(
+                color: isSelected ? color : Colors.grey,
+                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 注文一覧を構築
+  Widget _buildOrderList() {
+    return StreamBuilder<List<Map<String, dynamic>>>(
+      stream: _getOrdersStream(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(
+            child: Text('エラー: ${snapshot.error}', style: const TextStyle(color: Colors.red)),
+          );
+        }
+
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final orders = snapshot.data ?? [];
+        
+        if (orders.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  _selectedTabIndex == 0 ? Icons.restaurant : Icons.check_circle,
+                  size: 64,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  _selectedTabIndex == 0 
+                      ? '準備中・提供中の注文はありません'
+                      : '提供済みの注文はありません',
+                  style: const TextStyle(color: Colors.grey, fontSize: 16),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: orders.length,
+          itemBuilder: (context, index) {
+            final order = orders[index];
+            return OrderCard(
+              order: order,
+              onStatusChanged: (orderId, newStatus) {
+                _updateOrderStatus(orderId, newStatus);
+              },
+              onEdit: (orderId) {
+                _showEditDialog(orderId);
+              },
+              localStatus: _localOrderStatus[order['id']],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// 注文ストリームを取得
+  Stream<List<Map<String, dynamic>>> _getOrdersStream() {
+    final today = DateFormat('yyyyMMdd').format(DateTime.now());
+    final yesterday = DateFormat('yyyyMMdd').format(DateTime.now().subtract(const Duration(days: 1)));
+    
+    return Stream.periodic(const Duration(seconds: 1)).asyncMap((_) async {
+      List<Map<String, dynamic>> allOrders = [];
+      
+      // 当日と前日の注文を取得
+      for (final dateString in [today, yesterday]) {
+        try {
+          final subCollectionSnapshot = await FirebaseFirestore.instance
+              .collection('orders')
+              .doc(dateString)
+              .collection('_TodaysOrders')
+              .get();
+          
+          for (final doc in subCollectionSnapshot.docs) {
+            final data = doc.data();
+            data['id'] = doc.id;
+            data['date'] = dateString;
+            allOrders.add(data);
+          }
+        } catch (e) {
+          debugPrint('注文データ取得エラー ($dateString): $e');
+        }
+      }
+      
+      return _processOrders(allOrders);
+    });
+  }
+
+  /// 注文データを処理
+  List<Map<String, dynamic>> _processOrders(List<Map<String, dynamic>> allOrders) {
+    // ステータスでフィルタリング
+    final targetStatuses = _selectedTabIndex == 0 
+        ? ['preparing', 'in_progress'] 
+        : ['served'];
+    
+    allOrders = allOrders.where((order) => 
+        targetStatuses.contains(order['status'])).toList();
+    
+    
+    // ソート
+    allOrders.sort((a, b) {
+      if (_selectedTabIndex == 0) {
+        // 準備中・提供中: createdAtが古い順
+        final aTime = (a['createdAt'] as Timestamp?)?.toDate() ?? DateTime(0);
+        final bTime = (b['createdAt'] as Timestamp?)?.toDate() ?? DateTime(0);
+        return aTime.compareTo(bTime);
+      } else {
+        // 提供済み: updatedAtが新しい順
+        final aTime = (a['updatedAt'] as Timestamp?)?.toDate() ?? DateTime(0);
+        final bTime = (b['updatedAt'] as Timestamp?)?.toDate() ?? DateTime(0);
+        return bTime.compareTo(aTime);
+      }
+    });
+    
+    return allOrders;
+  }
+
+  /// 注文ステータスを更新
+  void _updateOrderStatus(String orderId, String newStatus) {
+    setState(() {
+      _localOrderStatus[orderId] = newStatus;
+    });
+  }
+
+  /// 編集ダイアログを表示
+  void _showEditDialog(String orderId) {
+    showDialog(
+      context: context,
+      builder: (context) => OrderEditDialog(
+        orderId: orderId,
+        onOrderUpdated: () {
+          // 注文更新後の処理
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('注文を更新しました')),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/tournament/active/pages/tournament_home_page.dart
+++ b/lib/tournament/active/pages/tournament_home_page.dart
@@ -993,8 +993,8 @@ class _TournamentHomePageState extends State<TournamentHomePage> {
                                       }
 
                                       final allDocs = seatedSnapshot.data?.docs ?? [];
-                                      // 'waiting'ドキュメントを除外
-                                      final tables = allDocs.where((doc) => doc.id != 'waiting').toList();
+                                      // 'waiting'と'busted'ドキュメントを除外
+                                      final tables = allDocs.where((doc) => doc.id != 'waiting' && doc.id != 'busted').toList();
                                       
                                       int totalOccupiedSeats = 0;
                                       for (final tableDoc in tables) {
@@ -1045,8 +1045,8 @@ class _TournamentHomePageState extends State<TournamentHomePage> {
                                   }
 
                                   final allDocs = tablesSnapshot.data?.docs ?? [];
-                                  // 'waiting'ドキュメントを除外
-                                  final tables = allDocs.where((doc) => doc.id != 'waiting').toList();
+                                  // 'waiting'と'busted'ドキュメントを除外
+                                  final tables = allDocs.where((doc) => doc.id != 'waiting' && doc.id != 'busted').toList();
                                   debugPrint('=== 卓データ取得成功 ===');
                                   debugPrint('全ドキュメント数: ${allDocs.length}');
                                   debugPrint('卓数: ${tables.length}');

--- a/lib/tournament/active/widgets/dialogs/assign_seat_dialog.dart
+++ b/lib/tournament/active/widgets/dialogs/assign_seat_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:amuse_app_template/tournament/active/tournament_service.dart';
 import 'package:amuse_app_template/tournament/active/models/table_and_users.dart';
 import 'package:amuse_app_template/tournament/active/services/tournament_data_service.dart';
@@ -80,47 +81,17 @@ class _AssignSeatDialogState extends State<AssignSeatDialog> {
             
             const SizedBox(height: 16),
             
-            // テーブル選択
+            // テーブル選択（リアルタイム状態監視）
             if (_isLoadingData)
               const SizedBox.shrink()
             else
-              DropdownButtonFormField<String>(
-                decoration: const InputDecoration(
-                  labelText: 'テーブル',
-                  border: OutlineInputBorder(),
-                ),
-                value: _selectedTableId,
-                items: _tournamentTables
-                    .map((table) => DropdownMenuItem(
-                          value: table.tableId,
-                          child: Text('${table.name} (${table.maxSeats}席)'),
-                        ))
-                    .toList(),
-                onChanged: (value) {
-                  setState(() {
-                    _selectedTableId = value;
-                    _selectedSeatNumber = null; // テーブル変更時はシートをリセット
-                  });
-                },
-              ),
+              _buildTableSelectionWithStatus(),
             
             const SizedBox(height: 16),
             
-            // シート選択
+            // シート選択（リアルタイム状態監視）
             if (_selectedTableId != null) ...[
-              DropdownButtonFormField<int>(
-                decoration: const InputDecoration(
-                  labelText: 'シート番号',
-                  border: OutlineInputBorder(),
-                ),
-                value: _selectedSeatNumber,
-                items: _buildSeatItems(),
-                onChanged: (value) {
-                  setState(() {
-                    _selectedSeatNumber = value;
-                  });
-                },
-              ),
+              _buildSeatSelectionWithStatus(),
               
               const SizedBox(height: 16),
             ],
@@ -165,6 +136,153 @@ class _AssignSeatDialogState extends State<AssignSeatDialog> {
       return DropdownMenuItem(
         value: seatNumber,
         child: Text('シート $seatNumber'),
+      );
+    });
+  }
+
+  /// テーブル選択（リアルタイム状態監視）
+  Widget _buildTableSelectionWithStatus() {
+    return StreamBuilder<QuerySnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('scheduledTournaments')
+          .doc(widget.tournamentId)
+          .collection('tablesSeat')
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Text('エラー: ${snapshot.error}', style: const TextStyle(color: Colors.red));
+        }
+        
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        
+        final allDocs = snapshot.data?.docs ?? [];
+        final tables = allDocs.where((doc) => doc.id != 'waiting' && doc.id != 'busted').toList();
+        
+        return DropdownButtonFormField<String>(
+          decoration: const InputDecoration(
+            labelText: 'テーブル',
+            border: OutlineInputBorder(),
+          ),
+          value: _selectedTableId,
+          items: tables.map((tableDoc) {
+            final tableId = tableDoc.id;
+            final tableData = tableDoc.data() != null 
+                ? Map<String, dynamic>.from(tableDoc.data()! as Map)
+                : null;
+            final seats = tableData?['seats'] as Map<String, dynamic>? ?? {};
+            
+            // 着席数をカウント
+            final occupiedSeats = seats.entries
+                .where((entry) => entry.key.endsWith('UserId') && entry.value != null)
+                .length;
+            
+            // 最大席数を取得
+            final maxSeats = tableData?['maxSeats'] as int? ?? 0;
+            
+            return DropdownMenuItem(
+              value: tableId,
+              child: Text('$tableId ($occupiedSeats/$maxSeats席)'),
+            );
+          }).toList(),
+          onChanged: (value) {
+            setState(() {
+              _selectedTableId = value;
+              _selectedSeatNumber = null; // テーブル変更時はシートをリセット
+            });
+          },
+        );
+      },
+    );
+  }
+
+  /// 座席の状態を取得するStreamBuilder
+  Widget _buildSeatSelectionWithStatus() {
+    if (_selectedTableId == null) {
+      return const SizedBox.shrink();
+    }
+
+    return StreamBuilder<DocumentSnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('scheduledTournaments')
+          .doc(widget.tournamentId)
+          .collection('tablesSeat')
+          .doc(_selectedTableId!)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Text('エラー: ${snapshot.error}', style: const TextStyle(color: Colors.red));
+        }
+        
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        
+        final data = snapshot.data?.data() != null 
+            ? Map<String, dynamic>.from(snapshot.data!.data()! as Map)
+            : null;
+        final seats = data?['seats'] as Map<String, dynamic>? ?? {};
+        
+        return DropdownButtonFormField<int>(
+          decoration: const InputDecoration(
+            labelText: 'シート番号',
+            border: OutlineInputBorder(),
+          ),
+          value: _selectedSeatNumber,
+          items: _buildSeatItemsWithStatus(seats),
+          onChanged: (value) {
+            setState(() {
+              _selectedSeatNumber = value;
+            });
+          },
+        );
+      },
+    );
+  }
+
+  /// 座席の状態を考慮したシート選択肢を生成
+  List<DropdownMenuItem<int>> _buildSeatItemsWithStatus(Map<String, dynamic> seats) {
+    final selectedTable = _tournamentTables.firstWhere(
+      (table) => table.tableId == _selectedTableId,
+    );
+    
+    return List.generate(selectedTable.maxSeats, (index) {
+      final seatNumber = index + 1;
+      final seatNoStr = seatNumber.toString().padLeft(2, '0');
+      final userId = seats['seat${seatNoStr}UserId'] as String?;
+      final isOccupied = userId != null && userId.isNotEmpty;
+      
+      return DropdownMenuItem(
+        value: seatNumber,
+        enabled: !isOccupied, // 着席済みの場合は無効化
+        child: Row(
+          children: [
+            Icon(
+              isOccupied ? Icons.person : Icons.event_seat,
+              color: isOccupied ? Colors.red : Colors.green,
+              size: 16,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              'シート $seatNumber',
+              style: TextStyle(
+                color: isOccupied ? Colors.grey : Colors.black,
+                fontWeight: isOccupied ? FontWeight.normal : FontWeight.bold,
+              ),
+            ),
+            if (isOccupied) ...[
+              const SizedBox(width: 4),
+              Text(
+                '(着席済み)',
+                style: TextStyle(
+                  color: Colors.red,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ],
+        ),
       );
     });
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -433,26 +433,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -694,10 +694,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -710,10 +710,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
- OrderManagementPage: 注文管理ページの実装
  - 準備中・提供中と提供済みの2つのタブ
  - リアルタイム注文データ取得
  - カテゴリーフィルター機能を削除（不要なため）

- OrderCard: 注文カードウィジェットの実装
  - スライド操作で提供済みに変更
  - タップ操作で準備中→作成・提供中に変更
  - 編集ボタンで注文編集ダイアログ表示
  - テーブル未着席時の表示メッセージ追加

- OrderEditDialog: 注文編集ダイアログの実装
  - 個数変更機能
  - 注文取り消し機能
  - 確認ダイアログ付き

- terminalHomePage: デモ2ボタンを注文管理に変更

- firestore.rules: ordersコレクションの権限追加
  - 読み取り・書き込み権限を開発用に全許可