### PR TITLE
Add month selection feature to dashboard and fix line chart styling

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -136,6 +136,53 @@ service cloud.firestore {
       }
     }
 
+    // analyticsMonthly コレクション（開発用：読み取り全許可）
+    match /analyticsMonthly/{monthId} {
+      allow read: if true; // 開発用：全許可
+      allow write: if false; // 書き込みはCloud Functions経由のみ
+      
+      // days サブコレクション
+      match /days/{dayId} {
+        allow read: if true; // 開発用：全許可
+        allow write: if false; // 書き込みはCloud Functions経由のみ
+      }
+      
+      // byCategory サブコレクション
+      match /byCategory/{categoryId} {
+        allow read: if true; // 開発用：全許可
+        allow write: if false; // 書き込みはCloud Functions経由のみ
+      }
+      
+      // byTemplateTournaments サブコレクション
+      match /byTemplateTournaments/{templateId} {
+        allow read: if true; // 開発用：全許可
+        allow write: if false; // 書き込みはCloud Functions経由のみ
+      }
+      
+      // byUser サブコレクション
+      match /byUser/{userId} {
+        allow read: if true; // 開発用：全許可
+        allow write: if false; // 書き込みはCloud Functions経由のみ
+      }
+      
+      // aggregationMarkers サブコレクション
+      match /aggregationMarkers/{markerId} {
+        allow read: if true; // 開発用：全許可
+        allow write: if false; // 書き込みはCloud Functions経由のみ
+      }
+    }
+
+    // settledBills コレクション（開発用：読み取り全許可）
+    match /settledBills/{dateId} {
+      allow read: if true; // 開発用：全許可
+      allow write: if false; // 書き込みはCloud Functions経由のみ
+      
+      match /{billId} {
+        allow read: if true; // 開発用：全許可
+        allow write: if false; // 書き込みはCloud Functions経由のみ
+      }
+    }
+
     // 管理者コレクション
     match /admins/{adminId} {
       allow read: if request.auth != null && request.auth.uid == adminId;

--- a/functions/src/analytics/generateDummyData.ts
+++ b/functions/src/analytics/generateDummyData.ts
@@ -3,143 +3,143 @@ import { getFirestore } from "firebase-admin/firestore";
 import * as admin from "firebase-admin";
 import { logger } from "firebase-functions";
 
-export const generateDummyData = onCall(async (request) => {
+// ランダムな値を生成する関数（-25%〜+25%の範囲）
+function getRandomValue(baseValue: number): number {
+  const variation = 0.5; // ±25%の範囲
+  const randomFactor = 1 + (Math.random() - 0.5) * variation;
+  return Math.round(baseValue * randomFactor);
+}
+
+// 月の日付を生成する関数
+function generateDailySales(month: string): Record<string, number> {
+  const [year, monthNum] = month.split('-');
+  const daysInMonth = new Date(parseInt(year), parseInt(monthNum), 0).getDate();
+  const dailySales: Record<string, number> = {};
+  
+  for (let day = 1; day <= daysInMonth; day++) {
+    const date = `${year}-${monthNum}-${day.toString().padStart(2, '0')}`;
+    dailySales[date] = getRandomValue(150000); // ベース値を150,000円に設定
+  }
+  
+  return dailySales;
+}
+
+export const generateDummyData = onCall({
+  timeoutSeconds: 540, // 9分のタイムアウト
+  memory: "1GiB", // メモリを1GBに設定
+}, async (request) => {
   const db = getFirestore();
-  const month = "2025-09";
+  const months = ["2025-05", "2025-06", "2025-07", "2025-08"];
 
   try {
-    logger.info(`ダミーデータ生成開始: ${month}`);
+    logger.info(`4ヶ月分のダミーデータ生成開始: ${months.join(', ')}`);
 
-    // 1. 月次インデックスドキュメントの作成
-    const monthlyRef = db.collection('analyticsMonthly').doc(month);
-    await monthlyRef.set({
-      itemsSales: 1250000,
-      sideGameChipSales: 850000,
-      extraCostSales: 320000,
-      tournamentsSales: 2100000,
-      grossSales: 4520000,
-      orderCount: 1250,
-      avgOrderValue: 3616,
-      dailySales: {
-        "2025-09-01": 145000,
-        "2025-09-02": 152000,
-        "2025-09-03": 138000,
-        "2025-09-04": 167000,
-        "2025-09-05": 189000,
-        "2025-09-06": 201000,
-        "2025-09-07": 195000,
-        "2025-09-08": 143000,
-        "2025-09-09": 156000,
-        "2025-09-10": 174000,
-        "2025-09-11": 182000,
-        "2025-09-12": 198000,
-        "2025-09-13": 215000,
-        "2025-09-14": 203000,
-        "2025-09-15": 179000,
-        "2025-09-16": 186000,
-        "2025-09-17": 192000,
-        "2025-09-18": 208000,
-        "2025-09-19": 221000,
-        "2025-09-20": 234000,
-        "2025-09-21": 198000,
-        "2025-09-22": 187000,
-        "2025-09-23": 201000,
-        "2025-09-24": 213000,
-        "2025-09-25": 226000,
-        "2025-09-26": 245000,
-        "2025-09-27": 238000,
-        "2025-09-28": 192000,
-        "2025-09-29": 178000,
-        "2025-09-30": 165000,
-      },
-      paymentTotals: {
-        cash: 1800000,
-        credit_card: 1200000,
-        electronic_money: 850000,
-        pointA: 450000,
-        pointB: 220000,
-        sideGameTip: 0,
-        sideGameChip: 0,
-      },
+    // 各月のデータを並列生成
+    const monthPromises = months.map(async (month) => {
+      logger.info(`月次データ生成開始: ${month}`);
+      
+      // 1. 月次インデックスドキュメントの作成
+      const monthlyRef = db.collection('analyticsMonthly').doc(month);
+      await monthlyRef.set({
+        itemsSales: getRandomValue(1250000),
+        sideGameChipSales: getRandomValue(850000),
+        extraCostSales: getRandomValue(320000),
+        tournamentsSales: getRandomValue(2100000),
+        grossSales: getRandomValue(4520000),
+        orderCount: getRandomValue(1250),
+        avgOrderValue: getRandomValue(3616),
+        dailySales: generateDailySales(month),
+        paymentTotals: {
+          cash: getRandomValue(1800000),
+          credit_card: getRandomValue(1200000),
+          electronic_money: getRandomValue(850000),
+          pointA: getRandomValue(450000),
+          pointB: getRandomValue(220000),
+          sideGameTip: 0,
+          sideGameChip: 0,
+        },
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
     });
 
-    // 2. daysサブコレクションの作成（30日分）
-    const daysCollection = db.collection('analyticsMonthly').doc(month).collection('days');
-    for (let day = 1; day <= 30; day++) {
-      const dateStr = `2025-09-${day.toString().padStart(2, '0')}`;
-      const dailySales = 120000 + Math.floor(Math.random() * 80000);
-      const orderCount = 15 + Math.floor(Math.random() * 25);
+      // 2. daysサブコレクションの作成
+      const daysCollection = db.collection('analyticsMonthly').doc(month).collection('days');
+      const [year, monthNum] = month.split('-');
+      const daysInMonth = new Date(parseInt(year), parseInt(monthNum), 0).getDate();
       
-      await daysCollection.doc(dateStr).set({
-        itemsSales: Math.floor(dailySales * 0.28),
-        sideGameChipSales: Math.floor(dailySales * 0.19),
-        extraCostSales: Math.floor(dailySales * 0.07),
-        tournamentsSales: Math.floor(dailySales * 0.46),
-        grossSales: dailySales,
-        orderCount: orderCount,
-        byCategory: {
-          items: Math.floor(dailySales * 0.28),
-          sideGameChip: Math.floor(dailySales * 0.19),
-          extraCost: Math.floor(dailySales * 0.07),
-          tournaments: Math.floor(dailySales * 0.46),
-        },
-        byPaymentMethod: {
-          cash: Math.floor(dailySales * 0.40),
-          credit_card: Math.floor(dailySales * 0.27),
-          electronic_money: Math.floor(dailySales * 0.19),
-          pointA: Math.floor(dailySales * 0.10),
-          pointB: Math.floor(dailySales * 0.04),
-        },
+      for (let day = 1; day <= daysInMonth; day++) {
+        const dateStr = `${year}-${monthNum}-${day.toString().padStart(2, '0')}`;
+        const dailySales = getRandomValue(150000);
+        const orderCount = getRandomValue(20);
+      
+        await daysCollection.doc(dateStr).set({
+          itemsSales: Math.floor(dailySales * 0.28),
+          sideGameChipSales: Math.floor(dailySales * 0.19),
+          extraCostSales: Math.floor(dailySales * 0.07),
+          tournamentsSales: Math.floor(dailySales * 0.46),
+          grossSales: dailySales,
+          orderCount: orderCount,
+          byCategory: {
+            items: Math.floor(dailySales * 0.28),
+            sideGameChip: Math.floor(dailySales * 0.19),
+            extraCost: Math.floor(dailySales * 0.07),
+            tournaments: Math.floor(dailySales * 0.46),
+          },
+          byPaymentMethod: {
+            cash: Math.floor(dailySales * 0.40),
+            credit_card: Math.floor(dailySales * 0.27),
+            electronic_money: Math.floor(dailySales * 0.19),
+            pointA: Math.floor(dailySales * 0.10),
+            pointB: Math.floor(dailySales * 0.04),
+          },
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       });
-    }
+      }
 
-    // 3. byCategoryサブコレクションの作成
-    const byCategoryRef = db.collection('analyticsMonthly').doc(month).collection('byCategory').doc('summary');
-    await byCategoryRef.set({
-      totals: {
-        items: 1250000,
-        sideGameChip: 850000,
-        extraCost: 320000,
-        tournaments: 2100000,
-      },
-      orderCounts: {
-        items: 850,
-        sideGameChip: 420,
-        extraCost: 180,
-        tournaments: 320,
-      },
-      itemSales: {
-        "menu001": {
-          qty: 45,
-          sales: 67500,
-          name: "ビール",
-          category: "items"
+      // 3. byCategoryサブコレクションの作成
+      const byCategoryRef = db.collection('analyticsMonthly').doc(month).collection('byCategory').doc('summary');
+      await byCategoryRef.set({
+        totals: {
+          items: getRandomValue(1250000),
+          sideGameChip: getRandomValue(850000),
+          extraCost: getRandomValue(320000),
+          tournaments: getRandomValue(2100000),
         },
-        "menu002": {
-          qty: 32,
-          sales: 48000,
-          name: "ハイボール",
-          category: "items"
+        orderCounts: {
+          items: getRandomValue(850),
+          sideGameChip: getRandomValue(420),
+          extraCost: getRandomValue(180),
+          tournaments: getRandomValue(320),
         },
-        "menu003": {
-          qty: 28,
-          sales: 42000,
-          name: "ウイスキー",
-          category: "items"
-        },
-        "menu004": {
-          qty: 55,
-          sales: 82500,
-          name: "チップス",
-          category: "items"
-        },
-        "menu005": {
-          qty: 38,
-          sales: 57000,
+        itemSales: {
+          "menu001": {
+            qty: getRandomValue(45),
+            sales: getRandomValue(67500),
+            name: "ビール",
+            category: "items"
+          },
+          "menu002": {
+            qty: getRandomValue(32),
+            sales: getRandomValue(48000),
+            name: "ハイボール",
+            category: "items"
+          },
+          "menu003": {
+            qty: getRandomValue(28),
+            sales: getRandomValue(42000),
+            name: "ウイスキー",
+            category: "items"
+          },
+          "menu004": {
+            qty: getRandomValue(55),
+            sales: getRandomValue(82500),
+            name: "チップス",
+            category: "items"
+          },
+          "menu005": {
+            qty: getRandomValue(38),
+            sales: getRandomValue(57000),
           name: "ナッツ",
           category: "items"
         },
@@ -148,8 +148,8 @@ export const generateDummyData = onCall(async (request) => {
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
     });
 
-    // 4. byTemplateTournamentsサブコレクションの作成（30個のトーナメントテンプレート）
-    const byTemplateTournamentsCollection = db.collection('analyticsMonthly').doc(month).collection('byTemplateTournaments');
+      // 4. byTemplateTournamentsサブコレクションの作成（30個のトーナメントテンプレート）
+      const byTemplateTournamentsCollection = db.collection('analyticsMonthly').doc(month).collection('byTemplateTournaments');
     const tournamentTemplates = [
       { id: "template001", name: "ポーカーナイト" },
       { id: "template002", name: "トーナメントA" },
@@ -183,25 +183,25 @@ export const generateDummyData = onCall(async (request) => {
       { id: "template030", name: "チャンピオンシップ4" },
     ];
 
-    for (const template of tournamentTemplates) {
-      const entryCount = 15 + Math.floor(Math.random() * 35);
-      const entrySales = entryCount * (5000 + Math.floor(Math.random() * 10000));
-      const reentryCount = Math.floor(entryCount * 0.3);
-      const reentrySales = reentryCount * (3000 + Math.floor(Math.random() * 5000));
-      const addonCount = Math.floor(entryCount * 0.2);
-      const addonSales = addonCount * (2000 + Math.floor(Math.random() * 3000));
+      for (const template of tournamentTemplates.slice(0, 10)) { // 30個から10個に削減
+        const entryCount = getRandomValue(25);
+        const entrySales = getRandomValue(150000);
+        const reentryCount = getRandomValue(8);
+        const reentrySales = getRandomValue(40000);
+        const addonCount = getRandomValue(5);
+        const addonSales = getRandomValue(15000);
       const totalTournamentSales = entrySales + reentrySales + addonSales;
 
-      const dailyData: any = {};
-      for (let day = 1; day <= 30; day++) {
-        const dateStr = `2025-09-${day.toString().padStart(2, '0')}`;
-        const dailyEntryCount = Math.floor(Math.random() * 3);
-        const dailyEntrySales = dailyEntryCount * (5000 + Math.floor(Math.random() * 10000));
-        const dailyReentryCount = Math.floor(dailyEntryCount * 0.3);
-        const dailyReentrySales = dailyReentryCount * (3000 + Math.floor(Math.random() * 5000));
-        const dailyAddonCount = Math.floor(dailyEntryCount * 0.2);
-        const dailyAddonSales = dailyAddonCount * (2000 + Math.floor(Math.random() * 3000));
-        const dailyTotalSales = dailyEntrySales + dailyReentrySales + dailyAddonSales;
+        const dailyData: any = {};
+        for (let day = 1; day <= daysInMonth; day++) {
+          const dateStr = `${year}-${monthNum}-${day.toString().padStart(2, '0')}`;
+          const dailyEntryCount = getRandomValue(2);
+          const dailyEntrySales = getRandomValue(15000);
+          const dailyReentryCount = getRandomValue(1);
+          const dailyReentrySales = getRandomValue(5000);
+          const dailyAddonCount = getRandomValue(1);
+          const dailyAddonSales = getRandomValue(3000);
+          const dailyTotalSales = dailyEntrySales + dailyReentrySales + dailyAddonSales;
 
         dailyData[`${dateStr}.entryCount`] = dailyEntryCount;
         dailyData[`${dateStr}.entrySales`] = dailyEntrySales;
@@ -229,8 +229,8 @@ export const generateDummyData = onCall(async (request) => {
       });
     }
 
-    // 5. byUserサブコレクションの作成（80個のユーザー）
-    const byUserCollection = db.collection('analyticsMonthly').doc(month).collection('byUser');
+      // 5. byUserサブコレクションの作成（80個のユーザー）
+      const byUserCollection = db.collection('analyticsMonthly').doc(month).collection('byUser');
     const pokerNames = [
       "ポーカープレイヤー1", "ポーカープレイヤー2", "ポーカープレイヤー3", "ポーカープレイヤー4", "ポーカープレイヤー5",
       "ポーカープレイヤー6", "ポーカープレイヤー7", "ポーカープレイヤー8", "ポーカープレイヤー9", "ポーカープレイヤー10",
@@ -250,35 +250,35 @@ export const generateDummyData = onCall(async (request) => {
       "ポーカープレイヤー76", "ポーカープレイヤー77", "ポーカープレイヤー78", "ポーカープレイヤー79", "ポーカープレイヤー80"
     ];
 
-    for (let i = 0; i < 80; i++) {
-      const userId = `user${(i + 1).toString().padStart(3, '0')}`;
-      const pokerName = pokerNames[i];
-      const orderCount = 5 + Math.floor(Math.random() * 20);
-      const grossSales = 15000 + Math.floor(Math.random() * 85000);
-      const itemsSales = Math.floor(grossSales * (0.2 + Math.random() * 0.3));
-      const sideGameChipSales = Math.floor(grossSales * (0.1 + Math.random() * 0.2));
-      const extraCostSales = Math.floor(grossSales * (0.05 + Math.random() * 0.1));
-      const tournamentsSales = grossSales - itemsSales - sideGameChipSales - extraCostSales;
+      for (let i = 0; i < 20; i++) { // ユーザー数を80から20に削減
+        const userId = `user${(i + 1).toString().padStart(3, '0')}`;
+        const pokerName = pokerNames[i];
+        const orderCount = getRandomValue(15);
+        const grossSales = getRandomValue(50000);
+        const itemsSales = getRandomValue(Math.floor(grossSales * 0.3));
+        const sideGameChipSales = getRandomValue(Math.floor(grossSales * 0.15));
+        const extraCostSales = getRandomValue(Math.floor(grossSales * 0.08));
+        const tournamentsSales = grossSales - itemsSales - sideGameChipSales - extraCostSales;
 
-      const dailySales: any = {};
-      for (let day = 1; day <= 30; day++) {
-        const dateStr = `2025-09-${day.toString().padStart(2, '0')}`;
-        if (Math.random() > 0.7) { // 30%の確率でその日に来店
-          dailySales[dateStr] = 2000 + Math.floor(Math.random() * 8000);
+        const dailySales: any = {};
+        for (let day = 1; day <= daysInMonth; day++) {
+          const dateStr = `${year}-${monthNum}-${day.toString().padStart(2, '0')}`;
+          if (Math.random() > 0.7) { // 30%の確率でその日に来店
+            dailySales[dateStr] = getRandomValue(5000);
+          }
         }
-      }
 
-      const paymentTotals = {
-        cash: Math.floor(grossSales * (0.3 + Math.random() * 0.2)),
-        credit_card: Math.floor(grossSales * (0.2 + Math.random() * 0.2)),
-        electronic_money: Math.floor(grossSales * (0.1 + Math.random() * 0.2)),
-        pointA: Math.floor(grossSales * (0.05 + Math.random() * 0.15)),
-        pointB: Math.floor(grossSales * (0.02 + Math.random() * 0.08)),
-        sideGameTip: 0,
-        sideGameChip: 0,
-      };
+        const paymentTotals = {
+          cash: getRandomValue(Math.floor(grossSales * 0.4)),
+          credit_card: getRandomValue(Math.floor(grossSales * 0.3)),
+          electronic_money: getRandomValue(Math.floor(grossSales * 0.15)),
+          pointA: getRandomValue(Math.floor(grossSales * 0.1)),
+          pointB: getRandomValue(Math.floor(grossSales * 0.05)),
+          sideGameTip: 0,
+          sideGameChip: 0,
+        };
 
-      await byUserCollection.doc(userId).set({
+        await byUserCollection.doc(userId).set({
         grossSales: grossSales,
         itemsSales: itemsSales,
         extraCostSales: extraCostSales,
@@ -293,21 +293,28 @@ export const generateDummyData = onCall(async (request) => {
       });
     }
 
-    logger.info(`ダミーデータ生成完了: ${month}`);
+      logger.info(`月次データ生成完了: ${month}`);
+      return month;
+    });
+
+    // すべての月の処理を並列実行
+    await Promise.all(monthPromises);
+
+    logger.info(`4ヶ月分のダミーデータ生成完了: ${months.join(', ')}`);
     return {
       success: true,
-      message: `ダミーデータ生成完了: ${month}`,
+      message: `4ヶ月分のダミーデータ生成完了: ${months.join(', ')}`,
       data: {
-        monthlyIndex: 1,
-        days: 30,
-        byCategory: 1,
-        byTemplateTournaments: 30,
-        byUser: 80,
+        monthlyIndex: 4,
+        days: 31 + 30 + 31 + 31, // 5月(31日) + 6月(30日) + 7月(31日) + 8月(31日)
+        byCategory: 4,
+        byTemplateTournaments: 40, // 10 × 4ヶ月
+        byUser: 80, // 20 × 4ヶ月
       }
     };
 
   } catch (error) {
-    logger.error('ダミーデータ生成エラー:', error);
+    logger.error('4ヶ月分のダミーデータ生成エラー:', error);
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),

--- a/lib/Home/systemSettingsPage.dart
+++ b/lib/Home/systemSettingsPage.dart
@@ -79,7 +79,7 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
               child: ListTile(
                 leading: const Icon(Icons.data_usage, color: Colors.purple),
                 title: const Text('ダミーデータ生成（テスト用）'),
-                subtitle: const Text('analyticsMonthlyに2025-09のダミーデータを生成します'),
+                subtitle: const Text('analyticsMonthlyに2025-05〜2025-08のダミーデータを生成します'),
                 trailing: _isProcessing
                     ? const SizedBox(
                         width: 20,
@@ -225,13 +225,14 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
         return AlertDialog(
           title: const Text('ダミーデータ生成'),
           content: const Text(
-            'analyticsMonthlyに2025-09のダミーデータを生成しますか？\n\n'
-            '生成されるデータ:\n'
+            'analyticsMonthlyに2025-05〜2025-08のダミーデータを生成しますか？\n\n'
+            '生成されるデータ（各月）:\n'
             '• 月次インデックス: 1件\n'
             '• 日次サマリー: 30件\n'
             '• カテゴリ別: 1件\n'
             '• トーナメントテンプレート別: 30件\n'
             '• ユーザー別: 80件\n\n'
+            '合計: 4ヶ月分のデータ\n'
             '本機能はテスト用です。',
           ),
           actions: [
@@ -277,7 +278,7 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
             children: [
               CircularProgressIndicator(),
               SizedBox(width: 16),
-              Text('ダミーデータ生成中...'),
+              Text('4ヶ月分のダミーデータ生成中...'),
             ],
           ),
         );
@@ -285,12 +286,12 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
     );
 
     try {
-      debugPrint('ダミーデータ生成開始');
+      debugPrint('4ヶ月分のダミーデータ生成開始');
       
       final callable = _functions.httpsCallable('generateDummyData');
       final result = await callable.call();
 
-      debugPrint('ダミーデータ生成結果: $result');
+      debugPrint('4ヶ月分のダミーデータ生成結果: $result');
 
       // ローディングダイアログを閉じる
       Navigator.of(context).pop();
@@ -299,7 +300,7 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text('ダミーデータ生成完了: ${result.data['message'] ?? ''}'),
+              content: Text('4ヶ月分のダミーデータ生成完了: ${result.data['message'] ?? ''}'),
               backgroundColor: Colors.green,
             ),
           );
@@ -308,7 +309,7 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
         _showErrorDialog(result.data['error'] ?? 'ダミーデータ生成に失敗しました');
       }
     } catch (e) {
-      debugPrint('ダミーデータ生成エラー: $e');
+      debugPrint('4ヶ月分のダミーデータ生成エラー: $e');
       
       // ローディングダイアログを閉じる
       Navigator.of(context).pop();
@@ -316,7 +317,7 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
       if (e.toString().contains('UNAUTHENTICATED')) {
         _showErrorDialog('認証エラー: ログインしてから再度お試しください。');
       } else {
-        _showErrorDialog('ダミーデータ生成に失敗しました: $e');
+        _showErrorDialog('4ヶ月分のダミーデータ生成に失敗しました: $e');
       }
     } finally {
       setState(() {

--- a/lib/Home/terminalHomePage.dart
+++ b/lib/Home/terminalHomePage.dart
@@ -10,6 +10,7 @@ import 'package:amuse_app_template/tournament/scheduling/pages/tournament_creati
 import 'package:amuse_app_template/Accounting/accountingPage.dart';
 import 'package:amuse_app_template/sideGame/pages/side_game_table_list.dart';
 import 'package:amuse_app_template/OrderView/OrderManagement/order_management_page.dart';
+import 'package:amuse_app_template/dashboard/home/dashboard_home_page.dart';
 import 'package:flutter/material.dart';
 
 class terminalHomePage extends StatefulWidget {
@@ -37,6 +38,7 @@ class _terminalHomePageState extends State<terminalHomePage> {
       (label: '注文管理', destination: const OrderManagementPage()),
       (label: 'スタッフ打刻', destination: const StaffAttendancePage()),
       (label: '会計管理', destination: const AccountingPage()),
+      (label: '売上ダッシュボード', destination: const DashboardHomePage()),
     ];
 
     return Scaffold(

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -1,0 +1,141 @@
+/// 売上ダッシュボード用フォーマッター
+/// 
+/// 責務: 金額・日付・数値の表示フォーマット
+/// 参照フィールド: なし（純粋なユーティリティ）
+/// 遅延ロード: なし
+
+import 'package:intl/intl.dart';
+
+class Formatters {
+  /// 金額を3桁区切りでフォーマット（円記号付き）
+  /// 例: 1234567 → "1,234,567円"
+  static String formatCurrency(int amount) {
+    if (amount < 0) return "0円";
+    return NumberFormat('#,###').format(amount) + '円';
+  }
+
+  /// 金額を3桁区切りでフォーマット（円記号なし）
+  /// 例: 1234567 → "1,234,567"
+  static String formatNumber(int amount) {
+    if (amount < 0) return "0";
+    return NumberFormat('#,###').format(amount);
+  }
+
+  /// 金額を短縮形でフォーマット（万円単位）
+  /// 例: 1234567 → "123.5万円"
+  static String formatCurrencyShort(int amount) {
+    if (amount < 0) return "0円";
+    if (amount < 10000) return formatCurrency(amount);
+    
+    final man = amount / 10000;
+    if (man < 100) {
+      return '${(man * 10).round() / 10}万円';
+    } else {
+      return '${man.round()}万円';
+    }
+  }
+
+  /// 日付を YYYY-MM-DD から M/D 形式にフォーマット
+  /// 例: "2025-09-15" → "9/15"
+  static String formatDateShort(String dateStr) {
+    try {
+      final date = DateTime.parse(dateStr);
+      return '${date.month}/${date.day}';
+    } catch (e) {
+      return dateStr;
+    }
+  }
+
+  /// 日付を YYYY-MM-DD から M月D日 形式にフォーマット
+  /// 例: "2025-09-15" → "9月15日"
+  static String formatDateJapanese(String dateStr) {
+    try {
+      final date = DateTime.parse(dateStr);
+      return '${date.month}月${date.day}日';
+    } catch (e) {
+      return dateStr;
+    }
+  }
+
+  /// 年月を YYYY-MM から YYYY年M月 形式にフォーマット
+  /// 例: "2025-09" → "2025年9月"
+  static String formatYearMonth(String yyyymm) {
+    try {
+      final parts = yyyymm.split('-');
+      final year = int.parse(parts[0]);
+      final month = int.parse(parts[1]);
+      return '${year}年${month}月';
+    } catch (e) {
+      return yyyymm;
+    }
+  }
+
+  /// 月番号を M月 形式にフォーマット
+  /// 例: 9 → "9月"
+  static String formatMonth(int month) {
+    return '${month}月';
+  }
+
+  /// 比率をパーセント形式でフォーマット
+  /// 例: 0.345 → "34.5%"
+  static String formatPercentage(double ratio) {
+    return '${(ratio * 100).toStringAsFixed(1)}%';
+  }
+
+  /// 平均客単価をフォーマット
+  /// 例: 3616.5 → "3,617円"
+  static String formatAvgOrderValue(double avgValue) {
+    return formatCurrency(avgValue.round());
+  }
+
+  /// 来店回数をフォーマット
+  /// 例: 1250 → "1,250回"
+  static String formatOrderCount(int count) {
+    return '${formatNumber(count)}回';
+  }
+
+  /// 商品名を省略表示用にフォーマット（最大12文字）
+  /// 例: "とても長い商品名です" → "とても長い商品名..."
+  static String formatItemName(String name, {int maxLength = 12}) {
+    if (name.length <= maxLength) return name;
+    return '${name.substring(0, maxLength - 3)}...';
+  }
+
+  /// カテゴリ名を日本語に変換
+  static String getCategoryDisplayName(String category) {
+    switch (category) {
+      case 'items':
+        return '商品';
+      case 'sideGameChip':
+        return 'サイドゲームチップ';
+      case 'tournaments':
+        return 'トーナメント';
+      case 'extraCost':
+        return 'その他料金';
+      default:
+        return category;
+    }
+  }
+
+  /// 支払い方法名を日本語に変換
+  static String getPaymentMethodDisplayName(String method) {
+    switch (method) {
+      case 'cash':
+        return '現金';
+      case 'credit_card':
+        return 'クレジットカード';
+      case 'electronic_money':
+        return '電子マネー';
+      case 'pointA':
+        return 'ポイントA';
+      case 'pointB':
+        return 'ポイントB';
+      case 'sideGameChip':
+        return 'サイドゲームチップ';
+      case 'sideGameTip':
+        return 'サイドゲームチップ';
+      default:
+        return method;
+    }
+  }
+}

--- a/lib/core/widgets/skeleton.dart
+++ b/lib/core/widgets/skeleton.dart
@@ -1,0 +1,218 @@
+/// スケルトンローディング用ウィジェット
+/// 
+/// 責務: データ読み込み中のプレースホルダー表示
+/// 参照フィールド: なし（純粋なUIコンポーネント）
+/// 遅延ロード: なし
+
+import 'package:flutter/material.dart';
+
+class Skeleton extends StatefulWidget {
+  final double? width;
+  final double? height;
+  final double borderRadius;
+  final Color? baseColor;
+  final Color? highlightColor;
+
+  const Skeleton({
+    super.key,
+    this.width,
+    this.height,
+    this.borderRadius = 8.0,
+    this.baseColor,
+    this.highlightColor,
+  });
+
+  @override
+  State<Skeleton> createState() => _SkeletonState();
+}
+
+class _SkeletonState extends State<Skeleton>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1500),
+      vsync: this,
+    );
+    _animation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+    _controller.repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final baseColor = widget.baseColor ?? theme.colorScheme.surface;
+    final highlightColor = widget.highlightColor ?? theme.colorScheme.onSurface.withOpacity(0.1);
+
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, child) {
+        return Container(
+          width: widget.width,
+          height: widget.height,
+          decoration: BoxDecoration(
+            color: Color.lerp(baseColor, highlightColor, _animation.value),
+            borderRadius: BorderRadius.circular(widget.borderRadius),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// カード用スケルトン
+class SkeletonCard extends StatelessWidget {
+  final double? width;
+  final double? height;
+  final EdgeInsets padding;
+
+  const SkeletonCard({
+    super.key,
+    this.width,
+    this.height,
+    this.padding = const EdgeInsets.all(16.0),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      padding: padding,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Skeleton(width: double.infinity, height: 20),
+          const SizedBox(height: 8),
+          const Skeleton(width: 100, height: 16),
+          const SizedBox(height: 12),
+          const Skeleton(width: double.infinity, height: 40),
+        ],
+      ),
+    );
+  }
+}
+
+/// グラフ用スケルトン
+class SkeletonChart extends StatelessWidget {
+  final double? width;
+  final double? height;
+
+  const SkeletonChart({
+    super.key,
+    this.width,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Skeleton(width: 120, height: 20),
+          const SizedBox(height: 16),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: List.generate(
+                5,
+                (index) => Row(
+                  children: [
+                    const Skeleton(width: 20, height: 16),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Skeleton(
+                        width: double.infinity,
+                        height: 12,
+                        borderRadius: 6,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// メトリックカード用スケルトン
+class SkeletonMetricCard extends StatelessWidget {
+  final double? width;
+  final double? height;
+
+  const SkeletonMetricCard({
+    super.key,
+    this.width,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height ?? 100,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          const Skeleton(width: 80, height: 16),
+          const Skeleton(width: 120, height: 24),
+          const Skeleton(width: 60, height: 14),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/dashboard/category/category_item_breakdown_page.dart
+++ b/lib/dashboard/category/category_item_breakdown_page.dart
@@ -1,0 +1,368 @@
+/// 商品別詳細画面
+/// 
+/// 責務: 商品別売上データの詳細表示（売上・数量切り替え）
+/// 参照フィールド: analyticsMonthly/{YYYY-MM}/byCategory/summary.itemSales
+/// 遅延ロード: なし（データは既に取得済み）
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/repo/analytics_repository.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+import '../../core/widgets/skeleton.dart';
+
+// region Riverpod Providers
+
+/// カテゴリサマリーのProvider
+final categorySummaryProvider = FutureProvider.family<CategorySummaryDoc?, String>((ref, yyyymm) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchCategorySummary(yyyymm);
+});
+
+// endregion
+
+class CategoryItemBreakdownPage extends ConsumerStatefulWidget {
+  final String? month;
+  
+  const CategoryItemBreakdownPage({
+    super.key,
+    this.month,
+  });
+
+  @override
+  ConsumerState<CategoryItemBreakdownPage> createState() => _CategoryItemBreakdownPageState();
+}
+
+class _CategoryItemBreakdownPageState extends ConsumerState<CategoryItemBreakdownPage> {
+  String _sortBy = 'sales'; // 'sales' or 'qty'
+  String _category = 'all'; // 'all', 'items', 'sideGameChip', 'extraCost', 'tournaments'
+  
+  final List<String> _sortOptions = ['売上', '数量'];
+  final List<String> _categoryOptions = ['全て', '商品', 'サイドゲームチップ', '追加料金', 'トーナメント'];
+
+  @override
+  Widget build(BuildContext context) {
+    final currentMonth = widget.month ?? AnalyticsRepository().getCurrentYearMonth();
+    final categorySummaryAsync = ref.watch(categorySummaryProvider(currentMonth));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('商品別詳細 - ${Formatters.formatYearMonth(currentMonth)}'),
+        backgroundColor: Colors.blue[700],
+        foregroundColor: Colors.white,
+        centerTitle: true,
+      ),
+      body: categorySummaryAsync.when(
+        data: (categorySummary) {
+          if (categorySummary == null) {
+            return const Center(
+              child: Text('データが見つかりません'),
+            );
+          }
+          return _buildItemBreakdownContent(context, categorySummary);
+        },
+        loading: () => _buildSkeletonContent(context),
+        error: (error, stack) => Center(
+          child: Text('エラーが発生しました: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSkeletonContent(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // フィルター（スケルトン）
+          const Skeleton(width: double.infinity, height: 60),
+          const SizedBox(height: 16),
+          // 商品リスト（スケルトン）
+          const SkeletonChart(width: double.infinity, height: 400),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemBreakdownContent(BuildContext context, CategorySummaryDoc categorySummary) {
+    final filteredItems = _getFilteredItems(categorySummary);
+    
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // フィルター
+          _buildFilters(context),
+          const SizedBox(height: 16),
+          // 商品リスト
+          _buildItemList(context, filteredItems),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilters(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          // 並び順
+          Row(
+            children: [
+              const Text(
+                '並び順: ',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: SegmentedButton<String>(
+                  segments: _sortOptions.map((option) => 
+                    ButtonSegment<String>(
+                      value: option,
+                      label: Text(option),
+                    ),
+                  ).toList(),
+                  selected: {_sortBy == 'sales' ? '売上' : '数量'},
+                  onSelectionChanged: (Set<String> selection) {
+                    setState(() {
+                      _sortBy = selection.first == '売上' ? 'sales' : 'qty';
+                    });
+                  },
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          // カテゴリ
+          Row(
+            children: [
+              const Text(
+                'カテゴリ: ',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: SegmentedButton<String>(
+                  segments: _categoryOptions.map((option) => 
+                    ButtonSegment<String>(
+                      value: option,
+                      label: Text(option),
+                    ),
+                  ).toList(),
+                  selected: {_getCategoryDisplayName(_category)},
+                  onSelectionChanged: (Set<String> selection) {
+                    setState(() {
+                      _category = _getCategoryValue(selection.first);
+                    });
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemList(BuildContext context, List<ItemSalesData> items) {
+    if (items.isEmpty) {
+      return Container(
+        height: 200,
+        child: const Center(
+          child: Text('該当する商品がありません'),
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '商品一覧 (${items.length}件)',
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          ...items.asMap().entries.map((entry) {
+            final index = entry.key;
+            final item = entry.value;
+            
+            return Container(
+              margin: const EdgeInsets.only(bottom: 8.0),
+              padding: const EdgeInsets.all(12.0),
+              decoration: BoxDecoration(
+                color: Colors.grey[50],
+                borderRadius: BorderRadius.circular(8.0),
+                border: Border.all(color: Colors.grey[200]!),
+              ),
+              child: Row(
+                children: [
+                  // 順位
+                  Container(
+                    width: 24,
+                    height: 24,
+                    decoration: BoxDecoration(
+                      color: _getRankColor(index + 1),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(
+                      child: Text(
+                        '${index + 1}',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // 商品情報
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          Formatters.formatItemName(item.name),
+                          style: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        Text(
+                          '${Formatters.formatNumber(item.qty)}個',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey[600],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // 売上・数量
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        Formatters.formatCurrency(item.sales),
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.blue,
+                        ),
+                      ),
+                      Text(
+                        Formatters.getCategoryDisplayName(item.category),
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: Colors.grey[500],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+          }).toList(),
+        ],
+      ),
+    );
+  }
+
+  List<ItemSalesData> _getFilteredItems(CategorySummaryDoc categorySummary) {
+    List<ItemSalesData> items = categorySummary.topItems;
+    
+    // カテゴリフィルター
+    if (_category != 'all') {
+      items = items.where((item) => item.category == _category).toList();
+    }
+    
+    // 並び順
+    if (_sortBy == 'sales') {
+      items.sort((a, b) => b.sales.compareTo(a.sales));
+    } else {
+      items.sort((a, b) => b.qty.compareTo(a.qty));
+    }
+    
+    return items;
+  }
+
+  String _getCategoryDisplayName(String category) {
+    switch (category) {
+      case 'all':
+        return '全て';
+      case 'items':
+        return '商品';
+      case 'sideGameChip':
+        return 'サイドゲームチップ';
+      case 'extraCost':
+        return '追加料金';
+      case 'tournaments':
+        return 'トーナメント';
+      default:
+        return category;
+    }
+  }
+
+  String _getCategoryValue(String displayName) {
+    switch (displayName) {
+      case '全て':
+        return 'all';
+      case '商品':
+        return 'items';
+      case 'サイドゲームチップ':
+        return 'sideGameChip';
+      case '追加料金':
+        return 'extraCost';
+      case 'トーナメント':
+        return 'tournaments';
+      default:
+        return 'all';
+    }
+  }
+
+  Color _getRankColor(int rank) {
+    switch (rank) {
+      case 1:
+        return Colors.amber;
+      case 2:
+        return Colors.grey[400]!;
+      case 3:
+        return Colors.orange[300]!;
+      default:
+        return Colors.blue;
+    }
+  }
+}

--- a/lib/dashboard/category/category_overview_page.dart
+++ b/lib/dashboard/category/category_overview_page.dart
@@ -1,0 +1,306 @@
+/// カテゴリ詳細画面
+/// 
+/// 責務: カテゴリ別売上データの詳細表示
+/// 参照フィールド: analyticsMonthly/{YYYY-MM}（月次Doc）、byCategory/summary（商品別）
+/// 遅延ロード: あり（商品別データは初回ロード時）
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/repo/analytics_repository.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+import '../widgets/horizontal_bar_chart.dart';
+import '../../core/widgets/skeleton.dart';
+import 'category_item_breakdown_page.dart';
+
+// region Riverpod Providers
+
+/// 月次データのProvider
+final monthlyDataProvider = FutureProvider.family<MonthlyDoc?, String>((ref, yyyymm) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchMonthlyDoc(yyyymm);
+});
+
+/// カテゴリサマリーのProvider
+final categorySummaryProvider = FutureProvider.family<CategorySummaryDoc?, String>((ref, yyyymm) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchCategorySummary(yyyymm);
+});
+
+// endregion
+
+class CategoryOverviewPage extends ConsumerWidget {
+  final String? month;
+  
+  const CategoryOverviewPage({
+    super.key,
+    this.month,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentMonth = month ?? AnalyticsRepository().getCurrentYearMonth();
+    final monthlyDataAsync = ref.watch(monthlyDataProvider(currentMonth));
+    final categorySummaryAsync = ref.watch(categorySummaryProvider(currentMonth));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('カテゴリ詳細 - ${Formatters.formatYearMonth(currentMonth)}'),
+        backgroundColor: Colors.blue[700],
+        foregroundColor: Colors.white,
+        centerTitle: true,
+      ),
+      body: monthlyDataAsync.when(
+        data: (monthlyData) {
+          if (monthlyData == null) {
+            return const Center(
+              child: Text('データが見つかりません'),
+            );
+          }
+          return _buildCategoryContent(context, monthlyData, categorySummaryAsync);
+        },
+        loading: () => _buildSkeletonContent(context),
+        error: (error, stack) => Center(
+          child: Text('エラーが発生しました: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSkeletonContent(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // カテゴリ別横棒グラフ（スケルトン）
+          const SkeletonChart(width: double.infinity, height: 300),
+          const SizedBox(height: 16),
+          // 商品別詳細（スケルトン）
+          const SkeletonChart(width: double.infinity, height: 400),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryContent(BuildContext context, MonthlyDoc monthlyData, AsyncValue<CategorySummaryDoc?> categorySummaryAsync) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // カテゴリ別横棒グラフ
+          _buildCategoryChart(context, monthlyData),
+          const SizedBox(height: 16),
+          // 商品別詳細
+          _buildItemBreakdown(context, categorySummaryAsync),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryChart(BuildContext context, MonthlyDoc monthlyData) {
+    return Container(
+      height: 300,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'カテゴリ別売上',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: HorizontalBarChart(
+              categoryData: monthlyData.categorySales,
+              showValues: true,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemBreakdown(BuildContext context, AsyncValue<CategorySummaryDoc?> categorySummaryAsync) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '商品別売上',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              TextButton(
+                onPressed: () {
+                  // 商品別詳細画面へ遷移
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const CategoryItemBreakdownPage(),
+                    ),
+                  );
+                },
+                child: const Text('詳細を見る'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          categorySummaryAsync.when(
+            data: (categorySummary) {
+              if (categorySummary == null) {
+                return const Center(
+                  child: Text('商品データが見つかりません'),
+                );
+              }
+              return _buildItemList(categorySummary);
+            },
+            loading: () => const Center(
+              child: CircularProgressIndicator(),
+            ),
+            error: (error, stack) => Center(
+              child: Text('エラーが発生しました: $error'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemList(CategorySummaryDoc categorySummary) {
+    final topItems = categorySummary.topItems.take(10).toList();
+    
+    if (topItems.isEmpty) {
+      return const Center(
+        child: Text('商品データがありません'),
+      );
+    }
+
+    return Column(
+      children: topItems.asMap().entries.map((entry) {
+        final index = entry.key;
+        final item = entry.value;
+        
+        return Container(
+          margin: const EdgeInsets.only(bottom: 8.0),
+          padding: const EdgeInsets.all(12.0),
+          decoration: BoxDecoration(
+            color: Colors.grey[50],
+            borderRadius: BorderRadius.circular(8.0),
+            border: Border.all(color: Colors.grey[200]!),
+          ),
+          child: Row(
+            children: [
+              // 順位
+              Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  color: _getRankColor(index + 1),
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    '${index + 1}',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              // 商品情報
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      Formatters.formatItemName(item.name),
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    Text(
+                      '${Formatters.formatNumber(item.qty)}個',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // 売上
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    Formatters.formatCurrency(item.sales),
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.blue,
+                    ),
+                  ),
+                  Text(
+                    Formatters.getCategoryDisplayName(item.category),
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Colors.grey[500],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Color _getRankColor(int rank) {
+    switch (rank) {
+      case 1:
+        return Colors.amber;
+      case 2:
+        return Colors.grey[400]!;
+      case 3:
+        return Colors.orange[300]!;
+      default:
+        return Colors.blue;
+    }
+  }
+}

--- a/lib/dashboard/daily/daily_trend_page.dart
+++ b/lib/dashboard/daily/daily_trend_page.dart
@@ -1,0 +1,332 @@
+/// 日次推移画面
+/// 
+/// 責務: 日次売上推移の詳細表示（現金・電子マネー・ポイント切り替え）
+/// 参照フィールド: analyticsMonthly/{YYYY-MM}/days/{YYYY-MM-DD}
+/// 遅延ロード: あり（日次データは初回ロード時）
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/repo/analytics_repository.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+import '../widgets/line_chart.dart';
+import '../../core/widgets/skeleton.dart';
+
+// region Riverpod Providers
+
+/// 日次データのProvider
+final dailyDataProvider = FutureProvider.family<List<DailyDoc>, String>((ref, yyyymm) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchMonthlyDays(yyyymm);
+});
+
+// endregion
+
+class DailyTrendPage extends ConsumerStatefulWidget {
+  final String? month;
+  
+  const DailyTrendPage({
+    super.key,
+    this.month,
+  });
+
+  @override
+  ConsumerState<DailyTrendPage> createState() => _DailyTrendPageState();
+}
+
+class _DailyTrendPageState extends ConsumerState<DailyTrendPage> {
+  String _selectedView = 'all'; // 'all', 'cash_credit_emoney', 'points'
+  
+  final List<String> _viewOptions = ['全て', '現金・クレカ・電子マネー', 'ポイント'];
+
+  @override
+  Widget build(BuildContext context) {
+    final currentMonth = widget.month ?? AnalyticsRepository().getCurrentYearMonth();
+    final dailyDataAsync = ref.watch(dailyDataProvider(currentMonth));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('日次推移 - ${Formatters.formatYearMonth(currentMonth)}'),
+        backgroundColor: Colors.blue[700],
+        foregroundColor: Colors.white,
+        centerTitle: true,
+      ),
+      body: dailyDataAsync.when(
+        data: (dailyData) {
+          if (dailyData.isEmpty) {
+            return const Center(
+              child: Text('データが見つかりません'),
+            );
+          }
+          return _buildDailyContent(context, dailyData);
+        },
+        loading: () => _buildSkeletonContent(context),
+        error: (error, stack) => Center(
+          child: Text('エラーが発生しました: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSkeletonContent(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // ビュー選択（スケルトン）
+          const Skeleton(width: double.infinity, height: 60),
+          const SizedBox(height: 16),
+          // 折れ線グラフ（スケルトン）
+          const SkeletonChart(width: double.infinity, height: 400),
+          const SizedBox(height: 16),
+          // 日次詳細（スケルトン）
+          const SkeletonChart(width: double.infinity, height: 300),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDailyContent(BuildContext context, List<DailyDoc> dailyData) {
+    final filteredData = _getFilteredData(dailyData);
+    
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // ビュー選択
+          _buildViewSelector(context),
+          const SizedBox(height: 16),
+          // 折れ線グラフ
+          _buildLineChart(context, filteredData),
+          const SizedBox(height: 16),
+          // 日次詳細
+          _buildDailyDetails(context, filteredData),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildViewSelector(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '表示切り替え',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 12),
+          SegmentedButton<String>(
+            segments: _viewOptions.map((option) => 
+              ButtonSegment<String>(
+                value: option,
+                label: Text(option),
+              ),
+            ).toList(),
+            selected: {_getViewDisplayName(_selectedView)},
+            onSelectionChanged: (Set<String> selection) {
+              setState(() {
+                _selectedView = _getViewValue(selection.first);
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLineChart(BuildContext context, List<DailyDoc> dailyData) {
+    return Container(
+      height: 400,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: LineChart(
+        dailyData: dailyData.map((doc) => DailySales(
+          doc.date,
+          _getSalesForView(doc),
+        )).toList(),
+        title: '日次売上推移',
+      ),
+    );
+  }
+
+  Widget _buildDailyDetails(BuildContext context, List<DailyDoc> dailyData) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '日次詳細 (${dailyData.length}日)',
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          ...dailyData.map((doc) {
+            final sales = _getSalesForView(doc);
+            final percentage = _getPercentage(dailyData, sales);
+            
+            return Container(
+              margin: const EdgeInsets.only(bottom: 8.0),
+              padding: const EdgeInsets.all(12.0),
+              decoration: BoxDecoration(
+                color: Colors.grey[50],
+                borderRadius: BorderRadius.circular(8.0),
+                border: Border.all(color: Colors.grey[200]!),
+              ),
+              child: Row(
+                children: [
+                  // 日付
+                  Container(
+                    width: 60,
+                    child: Text(
+                      Formatters.formatDateShort(doc.date),
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // 売上情報
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          Formatters.formatCurrency(sales),
+                          style: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.blue,
+                          ),
+                        ),
+                        Text(
+                          '${Formatters.formatNumber(doc.orderCount)}回',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey[600],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // 進捗バー
+                  Container(
+                    width: 80,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[200],
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: FractionallySizedBox(
+                      alignment: Alignment.centerLeft,
+                      widthFactor: percentage,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Colors.blue,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }).toList(),
+        ],
+      ),
+    );
+  }
+
+  List<DailyDoc> _getFilteredData(List<DailyDoc> dailyData) {
+    // 現在のビューに応じてフィルタリング
+    // 実際の実装では、必要に応じてデータをフィルタリング
+    return dailyData;
+  }
+
+  int _getSalesForView(DailyDoc doc) {
+    switch (_selectedView) {
+      case 'cash_credit_emoney':
+        return (doc.byPaymentMethod['cash'] ?? 0) + 
+               (doc.byPaymentMethod['credit_card'] ?? 0) + 
+               (doc.byPaymentMethod['electronic_money'] ?? 0);
+      case 'points':
+        return (doc.byPaymentMethod['pointA'] ?? 0) + 
+               (doc.byPaymentMethod['pointB'] ?? 0) + 
+               (doc.byPaymentMethod['sideGameChip'] ?? 0);
+      default:
+        return doc.grossSales;
+    }
+  }
+
+  double _getPercentage(List<DailyDoc> dailyData, int sales) {
+    if (dailyData.isEmpty) return 0.0;
+    final maxSales = dailyData.map((doc) => _getSalesForView(doc)).reduce((a, b) => a > b ? a : b);
+    return maxSales > 0 ? sales / maxSales : 0.0;
+  }
+
+  String _getViewDisplayName(String view) {
+    switch (view) {
+      case 'all':
+        return '全て';
+      case 'cash_credit_emoney':
+        return '現金・クレカ・電子マネー';
+      case 'points':
+        return 'ポイント';
+      default:
+        return view;
+    }
+  }
+
+  String _getViewValue(String displayName) {
+    switch (displayName) {
+      case '全て':
+        return 'all';
+      case '現金・クレカ・電子マネー':
+        return 'cash_credit_emoney';
+      case 'ポイント':
+        return 'points';
+      default:
+        return 'all';
+    }
+  }
+}

--- a/lib/dashboard/home/dashboard_home_page.dart
+++ b/lib/dashboard/home/dashboard_home_page.dart
@@ -1,0 +1,697 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fl_chart/fl_chart.dart' as fl_chart;
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../data/repo/analytics_repository.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+import '../../core/widgets/skeleton.dart';
+import '../widgets/horizontal_bar_chart.dart';
+import '../widgets/donut_chart.dart';
+import '../widgets/line_chart.dart';
+import '../widgets/metric_card.dart';
+import '../yearly/yearly_overview_page.dart';
+import '../category/category_overview_page.dart';
+import '../payments/payment_breakdown_page.dart';
+import '../daily/daily_trend_page.dart';
+
+// region Riverpod Providers
+
+/// 利用可能な月のリストのProvider
+final availableMonthsProvider = FutureProvider<List<String>>((ref) async {
+  final firestore = FirebaseFirestore.instance;
+  final snapshot = await firestore.collection('analyticsMonthly').get();
+  final months = snapshot.docs.map((doc) => doc.id).toList();
+  months.sort((a, b) => b.compareTo(a)); // 新しい順にソート
+  return months;
+});
+
+/// 選択された月のProvider
+final selectedMonthProvider = StateProvider<String>((ref) {
+  final repository = AnalyticsRepository();
+  return repository.getCurrentYearMonth();
+});
+
+/// 月次データのProvider
+final monthlyDataProvider = FutureProvider<MonthlyDoc?>((ref) async {
+  final repository = AnalyticsRepository();
+  final selectedMonth = ref.watch(selectedMonthProvider);
+  return repository.fetchMonthlyDoc(selectedMonth);
+});
+
+/// 直近6ヶ月の総売上データのProvider
+final lastSixMonthsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchLastSixMonthsGrossSales();
+});
+
+// endregion
+
+class DashboardHomePage extends ConsumerWidget {
+  const DashboardHomePage({super.key});
+
+  /// 月の表示形式をフォーマット（YYYY-MM → YYYY年MM月）
+  String _formatMonthDisplay(String monthId) {
+    if (monthId.isEmpty) return '';
+    final parts = monthId.split('-');
+    if (parts.length != 2) return monthId;
+    final year = parts[0];
+    final month = parts[1];
+    return '${year}年${month}月';
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final monthlyDataAsync = ref.watch(monthlyDataProvider);
+
+    return Scaffold(
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(MediaQuery.of(context).size.height * 0.08),
+        child: AppBar(
+          title: const Text('売上ダッシュボード'),
+          backgroundColor: Colors.blue[700],
+          foregroundColor: Colors.white,
+          centerTitle: true,
+          actions: [
+            Consumer(
+              builder: (context, ref, child) {
+                final selectedMonth = ref.watch(selectedMonthProvider);
+                final availableMonthsAsync = ref.watch(availableMonthsProvider);
+                
+                return availableMonthsAsync.when(
+                  data: (availableMonths) {
+                    if (availableMonths.isEmpty) {
+                      return const SizedBox.shrink();
+                    }
+                    
+                    final displayText = _formatMonthDisplay(selectedMonth);
+                    
+                    return PopupMenuButton<String>(
+                      onSelected: (month) {
+                        ref.read(selectedMonthProvider.notifier).state = month;
+                      },
+                      itemBuilder: (context) {
+                        return availableMonths.map((month) {
+                          return PopupMenuItem<String>(
+                            value: month,
+                            child: Text(_formatMonthDisplay(month)),
+                          );
+                        }).toList();
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                        child: Text(
+                          displayText,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                            decoration: TextDecoration.underline,
+                            decorationColor: Colors.white,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                  loading: () => const SizedBox.shrink(),
+                  error: (error, stack) => const SizedBox.shrink(),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+      body: monthlyDataAsync.when(
+        data: (monthlyData) {
+          if (monthlyData == null) {
+            return const Center(
+              child: Text('データが見つかりません'),
+            );
+          }
+          return _buildDashboardContent(context, monthlyData);
+        },
+        loading: () => _buildSkeletonContent(context),
+        error: (error, stack) => Center(
+          child: Text('エラーが発生しました: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSkeletonContent(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+    
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          // 上部3つのカード（年間比較・支払い方法別・カテゴリ別売り上げ）
+          Row(
+            children: [
+              // 年間比較グラフ
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.38,
+                height: screenHeight * 0.38,
+                child: const SkeletonChart(),
+              ),
+              // 支払い方法別グラフ
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.28,
+                height: screenHeight * 0.38,
+                child: const SkeletonChart(),
+              ),
+              // カテゴリ別売り上げグラフ
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.28,
+                height: screenHeight * 0.38,
+                child: const SkeletonChart(),
+              ),
+            ],
+          ),
+          
+          // 中間のカード群とカテゴリ別
+          Row(
+            children: [
+              // KPIカード群（2x2）
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: SkeletonMetricCard(),
+                        ),
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: SkeletonMetricCard(),
+                        ),
+                      ],
+                    ),
+                    Row(
+                      children: [
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: SkeletonMetricCard(),
+                        ),
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: SkeletonMetricCard(),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              // 当月カテゴリ別
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.58,
+                height: screenHeight * 0.28,
+                child: const SkeletonChart(),
+              ),
+            ],
+          ),
+          
+          // 当月日次推移
+          Container(
+            margin: EdgeInsets.all(screenWidth * 0.005),
+            width: screenWidth * 0.98,
+            height: screenHeight * 0.40,
+            child: const SkeletonChart(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDashboardContent(BuildContext context, MonthlyDoc monthlyData) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+    
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          // 上部3つのカード（年間比較・支払い方法別・カテゴリ別売り上げ）
+          Row(
+            children: [
+              // 年間比較グラフ
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.38,
+                height: screenHeight * 0.33,
+                child: _buildYearlyComparisonMini(context, monthlyData),
+              ),
+              // 支払い方法別グラフ
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.28,
+                height: screenHeight * 0.33,
+                child: _buildPaymentMethodChart(context, monthlyData),
+              ),
+              // カテゴリ別売り上げグラフ
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.28,
+                height: screenHeight * 0.33,
+                child: _buildCategoryCompositionChart(context, monthlyData),
+              ),
+            ],
+          ),
+          
+          // 中間のカード群とカテゴリ別
+          Row(
+            children: [
+              // KPIカード群（2x2）
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                child: Column(
+                  children: [
+                    Row(
+                      children: [
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: MetricCard(
+                            title: '今月総売上',
+                            value: Formatters.formatCurrency(monthlyData.grossSales),
+                            color: Colors.blue,
+                            icon: Icons.attach_money,
+                          ),
+                        ),
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: MetricCard(
+                            title: '来店数',
+                            value: Formatters.formatOrderCount(monthlyData.orderCount),
+                            color: Colors.green,
+                            icon: Icons.people,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Row(
+                      children: [
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: MetricCard(
+                            title: '平均客単価',
+                            value: Formatters.formatAvgOrderValue(monthlyData.avgOrderValue),
+                            color: Colors.orange,
+                            icon: Icons.trending_up,
+                          ),
+                        ),
+                        Container(
+                          margin: EdgeInsets.all(screenWidth * 0.005),
+                          width: screenWidth * 0.18,
+                          height: screenHeight * 0.14,
+                          child: BestWorstMetricCard(
+                            bestDate: monthlyData.bestWorstDays.bestDate,
+                            bestAmount: monthlyData.bestWorstDays.bestAmount,
+                            worstDate: monthlyData.bestWorstDays.worstDate,
+                            worstAmount: monthlyData.bestWorstDays.worstAmount,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              // 当月カテゴリ別
+              Container(
+                margin: EdgeInsets.all(screenWidth * 0.005),
+                width: screenWidth * 0.58,
+                height: screenHeight * 0.28,
+                child: _buildCategoryChart(context, monthlyData),
+              ),
+            ],
+          ),
+          
+          // 当月日次推移
+          Container(
+            margin: EdgeInsets.all(screenWidth * 0.005),
+            width: screenWidth * 0.98,
+            height: screenHeight * 0.40,
+            child: _buildDailyTrendChart(context, monthlyData),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildYearlyComparisonMini(BuildContext context, MonthlyDoc monthlyData) {
+    return Container(
+      height: 280,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '月ごとの比較',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const YearlyOverviewPage(initialTab: '総売上'),
+                    ),
+                  );
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.blue[100],
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Text(
+                    '詳細',
+                    style: TextStyle(fontSize: 12),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          // 直近6ヶ月の折れ線グラフ
+          Expanded(
+            child: Consumer(
+              builder: (context, ref, child) {
+                final lastSixMonthsAsync = ref.watch(lastSixMonthsProvider);
+                
+                return lastSixMonthsAsync.when(
+                  data: (data) {
+                    if (data.isEmpty) {
+                      return const Center(
+                        child: Text('データがありません'),
+                      );
+                    }
+                    return _buildThreeMonthsLineChartWithAxis(data);
+                  },
+                  loading: () => const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                  error: (error, stack) => Center(
+                    child: Text('エラー: $error'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildThreeMonthsLineChartWithAxis(List<Map<String, dynamic>> data) {
+    if (data.isEmpty) {
+      return const Center(
+        child: Text('データがありません'),
+      );
+    }
+
+    // デバッグ用ログ
+    print('グラフ表示用データ: ${data.map((e) => '${e['monthId']}(${e['monthName']}): ${e['grossSales']}').join(', ')}');
+
+    // データを月順にソート
+    data.sort((a, b) => a['monthId'].compareTo(b['monthId']));
+
+    // 最大値を取得（Y軸のスケール用）
+    final maxValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a > b ? a : b);
+    final minValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a < b ? a : b);
+    final range = maxValue - minValue;
+    final padding = range * 0.1; // 10%のパディング
+
+    return Row(
+      children: [
+        // 縦軸用のスペース（倍のサイズ）
+        SizedBox(
+          width: 60, // 縦軸用のスペースを倍のサイズに
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: List.generate(5, (index) {
+              final value = (maxValue / 4) * (4 - index);
+              return Text(
+                value == 0 ? '0円' : '${(value / 10000).floor()}万円',
+                style: const TextStyle(fontSize: 10),
+                textAlign: TextAlign.right,
+              );
+            }),
+          ),
+        ),
+        // グラフ部分
+        Expanded(
+          child: _buildThreeMonthsLineChart(data),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildThreeMonthsLineChart(List<Map<String, dynamic>> data) {
+    if (data.isEmpty) {
+      return const Center(
+        child: Text('データがありません'),
+      );
+    }
+
+    // デバッグ用ログ
+    print('グラフ表示用データ: ${data.map((e) => '${e['monthId']}(${e['monthName']}): ${e['grossSales']}').join(', ')}');
+
+    // データを月順にソート
+    data.sort((a, b) => a['monthId'].compareTo(b['monthId']));
+
+    // 最大値を取得（Y軸のスケール用）
+    final maxValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a > b ? a : b);
+    final minValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a < b ? a : b);
+    final range = maxValue - minValue;
+    final padding = range * 0.1; // 10%のパディング
+
+    return fl_chart.LineChart(
+      fl_chart.LineChartData(
+        gridData: fl_chart.FlGridData(
+          show: true,
+          drawVerticalLine: false,
+          horizontalInterval: (maxValue - minValue) / 4, // 4つの水平線を表示
+        ),
+        titlesData: fl_chart.FlTitlesData(
+          leftTitles: const fl_chart.AxisTitles(
+            sideTitles: fl_chart.SideTitles(showTitles: false),
+          ),
+          topTitles: const fl_chart.AxisTitles(
+            sideTitles: fl_chart.SideTitles(showTitles: false),
+          ),
+          rightTitles: const fl_chart.AxisTitles(
+            sideTitles: fl_chart.SideTitles(showTitles: false),
+          ),
+          bottomTitles: fl_chart.AxisTitles(
+            sideTitles: fl_chart.SideTitles(
+              showTitles: true,
+              getTitlesWidget: (value, meta) {
+                final index = value.toInt();
+                if (index >= 0 && index < data.length) {
+                  return Text(
+                    data[index]['monthName'],
+                    style: const TextStyle(fontSize: 12),
+                  );
+                }
+                return const Text('');
+              },
+              interval: 1, // 各データポイントにラベルを表示
+            ),
+          ),
+        ),
+        borderData: fl_chart.FlBorderData(show: false),
+        lineBarsData: [
+          fl_chart.LineChartBarData(
+            spots: data.asMap().entries.map((entry) {
+              return fl_chart.FlSpot(entry.key.toDouble(), entry.value['grossSales'].toDouble());
+            }).toList(),
+            isCurved: false,
+            color: Colors.blue,
+            barWidth: 3,
+            isStrokeCapRound: true,
+            dotData: const fl_chart.FlDotData(show: true),
+            belowBarData: fl_chart.BarAreaData(
+              show: true,
+              color: Colors.blue.withValues(alpha: 0.1),
+            ),
+          ),
+        ],
+        minY: 0, // 最小値を0に設定
+        maxY: maxValue.toDouble(), // 最大値を最も売り上げの多い月の価格に設定
+        minX: 0,
+        maxX: (data.length - 1).toDouble(),
+      ),
+    );
+  }
+
+
+
+  Widget _buildCategoryChart(BuildContext context, MonthlyDoc monthlyData) {
+    return Container(
+      height: 220,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '当月カテゴリ別',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: HorizontalBarChart(
+              categoryData: monthlyData.categorySales,
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const CategoryOverviewPage(),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPaymentMethodChart(BuildContext context, MonthlyDoc monthlyData) {
+    return Container(
+      height: 220,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: DonutChart(
+        paymentData: monthlyData.paymentMethodSales,
+        title: '支払手段',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const PaymentBreakdownPage(),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildCategoryCompositionChart(BuildContext context, MonthlyDoc monthlyData) {
+    return Container(
+      height: 220,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: DonutChart(
+        categoryData: monthlyData.categorySales,
+        title: 'カテゴリ構成',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const CategoryOverviewPage(),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildDailyTrendChart(BuildContext context, MonthlyDoc monthlyData) {
+    return Container(
+      height: 240,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: LineChart(
+        dailyData: monthlyData.dailySalesList,
+        title: '当月日次推移',
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const DailyTrendPage(),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/dashboard/payments/payment_breakdown_page.dart
+++ b/lib/dashboard/payments/payment_breakdown_page.dart
@@ -1,0 +1,412 @@
+/// 支払い方法詳細画面
+/// 
+/// 責務: 支払い方法別売上データの詳細表示（当月・年間比較）
+/// 参照フィールド: analyticsMonthly/{YYYY-MM}（当月）、年間データ（年間比較）
+/// 遅延ロード: あり（年間データは初回ロード時）
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/repo/analytics_repository.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+import '../widgets/donut_chart.dart';
+import '../widgets/stacked_bar_chart.dart';
+import '../../core/widgets/skeleton.dart';
+
+// region Riverpod Providers
+
+/// 月次データのProvider
+final monthlyDataProvider = FutureProvider.family<MonthlyDoc?, String>((ref, yyyymm) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchMonthlyDoc(yyyymm);
+});
+
+/// 年間データのProvider
+final yearlyDataProvider = FutureProvider.family<List<MonthlyDoc>, String>((ref, year) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchYearlyMonthlyDocs(year);
+});
+
+// endregion
+
+class PaymentBreakdownPage extends ConsumerStatefulWidget {
+  final String? month;
+  
+  const PaymentBreakdownPage({
+    super.key,
+    this.month,
+  });
+
+  @override
+  ConsumerState<PaymentBreakdownPage> createState() => _PaymentBreakdownPageState();
+}
+
+class _PaymentBreakdownPageState extends ConsumerState<PaymentBreakdownPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  String _selectedYear = '';
+  
+  final List<String> _tabs = [
+    '当月',
+    '年間比較',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedYear = DateTime.now().year.toString();
+    _tabController = TabController(
+      length: _tabs.length,
+      vsync: this,
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentMonth = widget.month ?? AnalyticsRepository().getCurrentYearMonth();
+    final monthlyDataAsync = ref.watch(monthlyDataProvider(currentMonth));
+    final yearlyDataAsync = ref.watch(yearlyDataProvider(_selectedYear));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('支払い方法詳細 - ${Formatters.formatYearMonth(currentMonth)}'),
+        backgroundColor: Colors.blue[700],
+        foregroundColor: Colors.white,
+        centerTitle: true,
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: _tabs.map((tab) => Tab(text: tab)).toList(),
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          // 当月タブ
+          _buildCurrentMonthTab(context, monthlyDataAsync),
+          // 年間比較タブ
+          _buildYearlyComparisonTab(context, yearlyDataAsync),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentMonthTab(BuildContext context, AsyncValue<MonthlyDoc?> monthlyDataAsync) {
+    return monthlyDataAsync.when(
+      data: (monthlyData) {
+        if (monthlyData == null) {
+          return const Center(
+            child: Text('データが見つかりません'),
+          );
+        }
+        return _buildCurrentMonthContent(context, monthlyData);
+      },
+      loading: () => _buildSkeletonContent(context),
+      error: (error, stack) => Center(
+        child: Text('エラーが発生しました: $error'),
+      ),
+    );
+  }
+
+  Widget _buildYearlyComparisonTab(BuildContext context, AsyncValue<List<MonthlyDoc>> yearlyDataAsync) {
+    return yearlyDataAsync.when(
+      data: (yearlyData) {
+        if (yearlyData.isEmpty) {
+          return const Center(
+            child: Text('データが見つかりません'),
+          );
+        }
+        return _buildYearlyComparisonContent(context, yearlyData);
+      },
+      loading: () => _buildSkeletonContent(context),
+      error: (error, stack) => Center(
+        child: Text('エラーが発生しました: $error'),
+      ),
+    );
+  }
+
+  Widget _buildSkeletonContent(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // ドーナツグラフ（スケルトン）
+          const SkeletonChart(width: double.infinity, height: 300),
+          const SizedBox(height: 16),
+          // 支払い方法リスト（スケルトン）
+          const SkeletonChart(width: double.infinity, height: 400),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentMonthContent(BuildContext context, MonthlyDoc monthlyData) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // 支払い方法ドーナツグラフ
+          _buildPaymentDonutChart(context, monthlyData),
+          const SizedBox(height: 16),
+          // 支払い方法詳細リスト
+          _buildPaymentMethodList(context, monthlyData),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildYearlyComparisonContent(BuildContext context, List<MonthlyDoc> yearlyData) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // 年選択
+          _buildYearSelector(context),
+          const SizedBox(height: 16),
+          // 年間支払い方法推移
+          _buildYearlyPaymentChart(context, yearlyData),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPaymentDonutChart(BuildContext context, MonthlyDoc monthlyData) {
+    return Container(
+      height: 300,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: DonutChart(
+        paymentData: monthlyData.paymentMethodSales,
+        title: '当月支払い方法別',
+      ),
+    );
+  }
+
+  Widget _buildPaymentMethodList(BuildContext context, MonthlyDoc monthlyData) {
+    final paymentMethods = monthlyData.paymentMethodSales;
+    final total = paymentMethods.map((p) => p.sales).reduce((a, b) => a + b);
+    
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '支払い方法別詳細',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          ...paymentMethods.map((payment) {
+            final percentage = total > 0 ? (payment.sales / total) * 100 : 0.0;
+            
+            return Container(
+              margin: const EdgeInsets.only(bottom: 12.0),
+              padding: const EdgeInsets.all(16.0),
+              decoration: BoxDecoration(
+                color: Colors.grey[50],
+                borderRadius: BorderRadius.circular(8.0),
+                border: Border.all(color: Colors.grey[200]!),
+              ),
+              child: Row(
+                children: [
+                  // 支払い方法アイコン
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: _getPaymentMethodColor(payment.method),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      _getPaymentMethodIcon(payment.method),
+                      color: Colors.white,
+                      size: 20,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  // 支払い方法情報
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          Formatters.getPaymentMethodDisplayName(payment.method),
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        Text(
+                          '${Formatters.formatCurrency(payment.sales)} (${Formatters.formatPercentage(percentage / 100)})',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey[600],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // 進捗バー
+                  Container(
+                    width: 100,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[200],
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: FractionallySizedBox(
+                      alignment: Alignment.centerLeft,
+                      widthFactor: percentage / 100,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: _getPaymentMethodColor(payment.method),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }).toList(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildYearSelector(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          const Text(
+            '対象年: ',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(width: 8),
+          DropdownButton<String>(
+            value: _selectedYear,
+            onChanged: (String? newValue) {
+              if (newValue != null) {
+                setState(() {
+                  _selectedYear = newValue;
+                });
+              }
+            },
+            items: List.generate(5, (index) {
+              final year = DateTime.now().year - index;
+              return DropdownMenuItem<String>(
+                value: year.toString(),
+                child: Text('${year}年'),
+              );
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildYearlyPaymentChart(BuildContext context, List<MonthlyDoc> yearlyData) {
+    return Container(
+      height: 400,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: StackedBarChart(
+        yearlyData: yearlyData,
+        chartType: 'payment',
+        title: '年間支払い方法別推移',
+      ),
+    );
+  }
+
+  Color _getPaymentMethodColor(String method) {
+    switch (method) {
+      case 'cash':
+        return Colors.green;
+      case 'credit_card':
+        return Colors.blue;
+      case 'electronic_money':
+        return Colors.orange;
+      case 'pointA':
+        return Colors.purple;
+      case 'pointB':
+        return Colors.pink;
+      case 'sideGameChip':
+        return Colors.teal;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  IconData _getPaymentMethodIcon(String method) {
+    switch (method) {
+      case 'cash':
+        return Icons.money;
+      case 'credit_card':
+        return Icons.credit_card;
+      case 'electronic_money':
+        return Icons.phone_android;
+      case 'pointA':
+        return Icons.stars;
+      case 'pointB':
+        return Icons.star;
+      case 'sideGameChip':
+        return Icons.casino;
+      default:
+        return Icons.payment;
+    }
+  }
+}

--- a/lib/dashboard/widgets/donut_chart.dart
+++ b/lib/dashboard/widgets/donut_chart.dart
@@ -1,0 +1,230 @@
+/// ドーナツグラフウィジェット
+/// 
+/// 責務: 支払い方法・カテゴリ構成のドーナツグラフ表示
+/// 参照フィールド: MonthlyDoc.paymentMethodSales, MonthlyDoc.categorySales
+/// 遅延ロード: なし（データは既に取得済み）
+
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+
+class DonutChart extends StatelessWidget {
+  final List<PaymentMethodSales>? paymentData;
+  final List<CategorySales>? categoryData;
+  final String title;
+  final double? height;
+  final VoidCallback? onTap;
+
+  const DonutChart({
+    super.key,
+    this.paymentData,
+    this.categoryData,
+    required this.title,
+    this.height,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // 画面縦幅の13%を円グラフの半径として使用
+    final screenHeight = MediaQuery.of(context).size.height;
+    final chartRadius = screenHeight * 0.06;
+    
+    final data = paymentData ?? categoryData;
+    if (data == null || data.isEmpty) {
+      return Container(
+        height: height ?? 220,
+        child: const Center(
+          child: Text('データがありません'),
+        ),
+      );
+    }
+
+    // 0以外のデータのみをフィルタリング
+    final filteredData = data.where((item) => (item as dynamic).sales > 0).toList();
+    if (filteredData.isEmpty) {
+      return Container(
+        height: height ?? 220,
+        child: const Center(
+          child: Text('データがありません'),
+        ),
+      );
+    }
+
+    final total = filteredData.map((e) => (e as dynamic).sales).reduce((a, b) => a + b);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: height ?? 220,
+        padding: const EdgeInsets.all(16.0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // タイトルと円グラフを縦に配置
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  // ドーナツグラフ全体のサイズ（画面縦幅の13%の直径）
+                  width: chartRadius * 2,
+                  height: chartRadius * 2,
+                  child: PieChart(
+                    PieChartData(
+                      pieTouchData: PieTouchData(
+                        enabled: true,
+                        touchCallback: (FlTouchEvent event, pieTouchResponse) {
+                          // タップ時の処理（必要に応じて実装）
+                        },
+                      ),
+                      sectionsSpace: 2,
+                      // ドーナツの内側の穴のサイズ（外側半径の30%）
+                      centerSpaceRadius: chartRadius * 0.3,
+                      sections: _buildSections(filteredData, total, chartRadius),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                // 合計金額
+                Center(
+                  child: Text(
+                    Formatters.formatCurrency(total),
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.blue,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(width: 16),
+            // 文字群（カテゴリ名称・合計金額・割合）
+            Expanded(
+              child: SingleChildScrollView(
+                child: _buildLegend(filteredData, total),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<PieChartSectionData> _buildSections(List<dynamic> data, int total, double chartRadius) {
+    final colors = [
+      Colors.blue,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+      Colors.red,
+      Colors.teal,
+      Colors.indigo,
+      Colors.pink,
+    ];
+
+    return data.asMap().entries.map((entry) {
+      final index = entry.key;
+      final item = entry.value;
+      final color = colors[index % colors.length];
+      final percentage = ((item as dynamic).sales / total) * 100;
+
+      return PieChartSectionData(
+        color: color,
+        value: (item as dynamic).sales.toDouble(),
+        title: '',
+        radius: chartRadius, // 円グラフの実際のサイズ（画面縦幅の13%）
+        titleStyle: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
+        badgeWidget: null,
+        badgePositionPercentageOffset: 1.3,
+      );
+    }).toList();
+  }
+
+  Widget _buildLegend(List<dynamic> data, int total) {
+    final colors = [
+      Colors.blue,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+      Colors.red,
+      Colors.teal,
+      Colors.indigo,
+      Colors.pink,
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: data.asMap().entries.map((entry) {
+        final index = entry.key;
+        final item = entry.value;
+        final color = colors[index % colors.length];
+        final percentage = ((item as dynamic).sales / total) * 100;
+
+        String displayName;
+        if (paymentData != null) {
+          displayName = Formatters.getPaymentMethodDisplayName((item as dynamic).method);
+        } else {
+          displayName = Formatters.getCategoryDisplayName((item as dynamic).category);
+        }
+
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 6.0),
+          child: Row(
+            children: [
+              // 色付き円
+              Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              // カテゴリ名称と金額・割合
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // カテゴリ名称
+                    Text(
+                      displayName,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    // 金額と割合
+                    Text(
+                      '${Formatters.formatCurrency((item as dynamic).sales)}(${Formatters.formatPercentage(percentage / 100)})',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/dashboard/widgets/horizontal_bar_chart.dart
+++ b/lib/dashboard/widgets/horizontal_bar_chart.dart
@@ -1,0 +1,162 @@
+/// 横棒グラフウィジェット
+/// 
+/// 責務: カテゴリ別売上データの横棒グラフ表示
+/// 参照フィールド: MonthlyDoc.categorySales
+/// 遅延ロード: なし（データは既に取得済み）
+
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+
+class HorizontalBarChart extends StatelessWidget {
+  final List<CategorySales> categoryData;
+  final double? height;
+  final bool showValues;
+  final VoidCallback? onTap;
+
+  const HorizontalBarChart({
+    super.key,
+    required this.categoryData,
+    this.height,
+    this.showValues = true,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (categoryData.isEmpty) {
+      return Container(
+        height: height ?? 200,
+        child: const Center(
+          child: Text('データがありません'),
+        ),
+      );
+    }
+
+    // 最大値を取得（スケール用）
+    final maxValue = categoryData.map((e) => e.sales).reduce((a, b) => a > b ? a : b);
+    final maxScale = (maxValue * 1.05).round();
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: height ?? 200,
+        padding: const EdgeInsets.all(16.0),
+        child: BarChart(
+          BarChartData(
+            alignment: BarChartAlignment.spaceAround,
+            maxY: maxScale.toDouble(),
+            barTouchData: BarTouchData(
+              enabled: true,
+                  touchTooltipData: BarTouchTooltipData(
+                    tooltipRoundedRadius: 8,
+                    getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                      return BarTooltipItem(
+                        '${Formatters.getCategoryDisplayName(rod.toY.toString())}\n${Formatters.formatCurrency(rod.toY.toInt())}',
+                        const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                        ),
+                      );
+                    },
+                  ),
+            ),
+            titlesData: FlTitlesData(
+              show: true,
+              rightTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              topTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  getTitlesWidget: (value, meta) {
+                    if (value.toInt() >= 0 && value.toInt() < categoryData.length) {
+                      return Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: Text(
+                          Formatters.getCategoryDisplayName(categoryData[value.toInt()].category),
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      );
+                    }
+                    return const Text('');
+                  },
+                ),
+              ),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  reservedSize: 60,
+                  getTitlesWidget: (value, meta) {
+                    return Text(
+                      Formatters.formatNumber(value.toInt()),
+                      style: const TextStyle(
+                        fontSize: 10,
+                        color: Colors.grey,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            borderData: FlBorderData(show: false),
+            barGroups: _buildBarGroups(),
+            gridData: FlGridData(
+              show: true,
+              drawVerticalLine: false,
+              horizontalInterval: maxScale / 5,
+              getDrawingHorizontalLine: (value) {
+                return FlLine(
+                  color: Colors.grey.withOpacity(0.2),
+                  strokeWidth: 1,
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<BarChartGroupData> _buildBarGroups() {
+    final colors = [
+      Colors.blue,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+    ];
+
+    return categoryData.asMap().entries.map((entry) {
+      final index = entry.key;
+      final data = entry.value;
+      final color = colors[index % colors.length];
+
+      return BarChartGroupData(
+        x: index,
+        barRods: [
+          BarChartRodData(
+            toY: data.sales.toDouble(),
+            color: color,
+            width: 20,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(4),
+              topRight: Radius.circular(4),
+            ),
+            backDrawRodData: BackgroundBarChartRodData(
+              show: true,
+              color: Colors.grey.withOpacity(0.1),
+            ),
+          ),
+        ],
+        showingTooltipIndicators: [],
+      );
+    }).toList();
+  }
+}

--- a/lib/dashboard/widgets/line_chart.dart
+++ b/lib/dashboard/widgets/line_chart.dart
@@ -1,0 +1,199 @@
+/// 折れ線グラフウィジェット
+/// 
+/// 責務: 日次売上推移の折れ線グラフ表示
+/// 参照フィールド: MonthlyDoc.dailySalesList
+/// 遅延ロード: なし（データは既に取得済み）
+
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart' as fl_chart;
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+
+class LineChart extends StatelessWidget {
+  final List<DailySales> dailyData;
+  final String title;
+  final double? height;
+  final VoidCallback? onTap;
+
+  const LineChart({
+    super.key,
+    required this.dailyData,
+    required this.title,
+    this.height,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (dailyData.isEmpty) {
+      return Container(
+        height: height ?? 240,
+        child: const Center(
+          child: Text('データがありません'),
+        ),
+      );
+    }
+
+    // 最大値を取得（スケール用）
+    final maxValue = dailyData.map((e) => e.sales).reduce((a, b) => a > b ? a : b);
+    final maxScale = (maxValue * 1.1).round();
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: height ?? 240,
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+            child: fl_chart.LineChart(
+              fl_chart.LineChartData(
+                  lineTouchData: fl_chart.LineTouchData(
+                    enabled: true,
+                    touchTooltipData: fl_chart.LineTouchTooltipData(
+                      tooltipRoundedRadius: 8,
+                      getTooltipItems: (touchedSpots) {
+                        return touchedSpots.map((touchedSpot) {
+                          final index = touchedSpot.x.toInt();
+                          if (index >= 0 && index < dailyData.length) {
+                            final data = dailyData[index];
+                            return fl_chart.LineTooltipItem(
+                              '${Formatters.formatDateJapanese(data.date)}\n${Formatters.formatCurrency(data.sales)}',
+                              const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                              ),
+                            );
+                          }
+                          return null;
+                        }).toList();
+                      },
+                    ),
+                  ),
+                  gridData: fl_chart.FlGridData(
+                    show: true,
+                    drawVerticalLine: false,
+                    horizontalInterval: maxScale / 5,
+                    getDrawingHorizontalLine: (value) {
+                      return fl_chart.FlLine(
+                        color: Colors.grey.withOpacity(0.2),
+                        strokeWidth: 1,
+                      );
+                    },
+                  ),
+                  titlesData: fl_chart.FlTitlesData(
+                    show: true,
+                    rightTitles: const fl_chart.AxisTitles(
+                      sideTitles: fl_chart.SideTitles(showTitles: false),
+                    ),
+                    topTitles: const fl_chart.AxisTitles(
+                      sideTitles: fl_chart.SideTitles(showTitles: false),
+                    ),
+                    bottomTitles: fl_chart.AxisTitles(
+                      sideTitles: fl_chart.SideTitles(
+                        showTitles: true,
+                        reservedSize: 30,
+                        interval: _calculateInterval(dailyData.length),
+                        getTitlesWidget: (value, meta) {
+                          final index = value.toInt();
+                          if (index >= 0 && index < dailyData.length) {
+                            final data = dailyData[index];
+                            return Padding(
+                              padding: const EdgeInsets.only(top: 8.0),
+                              child: Text(
+                                Formatters.formatDateShort(data.date),
+                                style: const TextStyle(
+                                  fontSize: 10,
+                                  color: Colors.grey,
+                                ),
+                              ),
+                            );
+                          }
+                          return const Text('');
+                        },
+                      ),
+                    ),
+                    leftTitles: fl_chart.AxisTitles(
+                      sideTitles: fl_chart.SideTitles(
+                        showTitles: true,
+                        reservedSize: 60,
+                        getTitlesWidget: (value, meta) {
+                          return Text(
+                            Formatters.formatNumber(value.toInt()),
+                            style: const TextStyle(
+                              fontSize: 10,
+                              color: Colors.grey,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  borderData: fl_chart.FlBorderData(
+                    show: true,
+                    border: Border.all(
+                      color: Colors.grey.withOpacity(0.2),
+                      width: 1,
+                    ),
+                  ),
+                  minX: 0,
+                  maxX: (dailyData.length - 1).toDouble(),
+                  minY: 0,
+                  maxY: maxScale.toDouble(),
+                  lineBarsData: [
+                    fl_chart.LineChartBarData(
+                      spots: _buildSpots(),
+                      isCurved: false,
+                      color: Colors.blue,
+                      barWidth: 3,
+                      isStrokeCapRound: true,
+                      dotData: fl_chart.FlDotData(
+                        show: true,
+                        getDotPainter: (spot, percent, barData, index) {
+                          return fl_chart.FlDotCirclePainter(
+                            radius: 4,
+                            color: Colors.blue,
+                            strokeWidth: 2,
+                            strokeColor: Colors.white,
+                          );
+                        },
+                      ),
+                      belowBarData: fl_chart.BarAreaData(
+                        show: true,
+                        color: Colors.blue.withOpacity(0.1),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<fl_chart.FlSpot> _buildSpots() {
+    return dailyData.asMap().entries.map((entry) {
+      final index = entry.key;
+      final data = entry.value;
+      return fl_chart.FlSpot(index.toDouble(), data.sales.toDouble());
+    }).toList();
+  }
+
+  double _calculateInterval(int dataLength) {
+    if (dataLength <= 7) return 1;
+    if (dataLength <= 15) return 2;
+    if (dataLength <= 31) return 5;
+    return 10;
+  }
+}

--- a/lib/dashboard/widgets/metric_card.dart
+++ b/lib/dashboard/widgets/metric_card.dart
@@ -1,0 +1,211 @@
+/// メトリックカードウィジェット
+/// 
+/// 責務: KPI表示用のメトリックカード
+/// 参照フィールド: MonthlyDoc（各種メトリック）
+/// 遅延ロード: なし（データは既に取得済み）
+
+import 'package:flutter/material.dart';
+import '../../core/utils/formatters.dart';
+
+class MetricCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final String? subtitle;
+  final Color? color;
+  final IconData? icon;
+  final VoidCallback? onTap;
+  final double? width;
+  final double? height;
+
+  const MetricCard({
+    super.key,
+    required this.title,
+    required this.value,
+    this.subtitle,
+    this.color,
+    this.icon,
+    this.onTap,
+    this.width,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: width,
+        height: height ?? 100,
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          borderRadius: BorderRadius.circular(16.0),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                if (icon != null) ...[
+                  Icon(
+                    icon,
+                    size: 16,
+                    color: color ?? Colors.grey[600],
+                  ),
+                  const SizedBox(width: 8),
+                ],
+                Expanded(
+                  child: Text(
+                    title,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.grey[600],
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            Text(
+              value,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: color ?? Colors.black87,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+            if (subtitle != null)
+              Text(
+                subtitle!,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey[500],
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// ベスト/ワースト日表示用のメトリックカード
+class BestWorstMetricCard extends StatelessWidget {
+  final String? bestDate;
+  final int? bestAmount;
+  final String? worstDate;
+  final int? worstAmount;
+  final VoidCallback? onTap;
+  final double? width;
+  final double? height;
+
+  const BestWorstMetricCard({
+    super.key,
+    this.bestDate,
+    this.bestAmount,
+    this.worstDate,
+    this.worstAmount,
+    this.onTap,
+    this.width,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: width,
+        height: height ?? 100,
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          borderRadius: BorderRadius.circular(16.0),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'ベスト/ワースト日',
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey,
+              ),
+            ),
+            const SizedBox(height: 6),
+            if (bestDate != null && bestAmount != null) ...[
+              Row(
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: const BoxDecoration(
+                      color: Colors.green,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '${Formatters.formatDateJapanese(bestDate!)}: ${Formatters.formatCurrency(bestAmount!)}',
+                      style: const TextStyle(fontSize: 10),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 2),
+            ],
+            if (worstDate != null && worstAmount != null) ...[
+              Row(
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: const BoxDecoration(
+                      color: Colors.red,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '${Formatters.formatDateJapanese(worstDate!)}: ${Formatters.formatCurrency(worstAmount!)}',
+                      style: const TextStyle(fontSize: 10),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+            if (bestDate == null && worstDate == null)
+              const Text(
+                'データなし',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/dashboard/widgets/stacked_bar_chart.dart
+++ b/lib/dashboard/widgets/stacked_bar_chart.dart
@@ -1,0 +1,247 @@
+/// 積み上げ棒グラフウィジェット
+/// 
+/// 責務: 年間比較用の積み上げ棒グラフ表示
+/// 参照フィールド: List<MonthlyDoc>（年間データ）
+/// 遅延ロード: あり（年間データ取得時）
+
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+import '../../data/models/analytics_models.dart';
+import '../../core/utils/formatters.dart';
+
+class StackedBarChart extends StatelessWidget {
+  final List<MonthlyDoc> yearlyData;
+  final String chartType; // 'payment', 'category', 'sales', 'orders', 'avgValue'
+  final String title;
+  final double? height;
+  final VoidCallback? onTap;
+
+  const StackedBarChart({
+    super.key,
+    required this.yearlyData,
+    required this.chartType,
+    required this.title,
+    this.height,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (yearlyData.isEmpty) {
+      return Container(
+        height: height ?? 280,
+        child: const Center(
+          child: Text('データがありません'),
+        ),
+      );
+    }
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: height ?? 280,
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: BarChart(
+                BarChartData(
+                  alignment: BarChartAlignment.spaceAround,
+                  maxY: _calculateMaxY(),
+                  barTouchData: BarTouchData(
+                    enabled: true,
+                  touchTooltipData: BarTouchTooltipData(
+                    tooltipRoundedRadius: 8,
+                      getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                        final month = group.x.toInt();
+                        final value = rod.toY.toInt();
+                        return BarTooltipItem(
+                          '${month + 1}月\n${Formatters.formatCurrency(value)}',
+                          const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  titlesData: FlTitlesData(
+                    show: true,
+                    rightTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    topTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    bottomTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        getTitlesWidget: (value, meta) {
+                          final month = value.toInt();
+                          if (month >= 0 && month < yearlyData.length) {
+                            return Padding(
+                              padding: const EdgeInsets.only(top: 8.0),
+                              child: Text(
+                                Formatters.formatMonth(month + 1),
+                                style: const TextStyle(
+                                  fontSize: 12,
+                                  color: Colors.grey,
+                                ),
+                              ),
+                            );
+                          }
+                          return const Text('');
+                        },
+                      ),
+                    ),
+                    leftTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 60,
+                        getTitlesWidget: (value, meta) {
+                          return Text(
+                            Formatters.formatNumber(value.toInt()),
+                            style: const TextStyle(
+                              fontSize: 10,
+                              color: Colors.grey,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  borderData: FlBorderData(show: false),
+                  barGroups: _buildBarGroups(),
+                  gridData: FlGridData(
+                    show: true,
+                    drawVerticalLine: false,
+                    horizontalInterval: _calculateMaxY() / 5,
+                    getDrawingHorizontalLine: (value) {
+                      return FlLine(
+                        color: Colors.grey.withOpacity(0.2),
+                        strokeWidth: 1,
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  double _calculateMaxY() {
+    switch (chartType) {
+      case 'payment':
+        return yearlyData.map((doc) => 
+          doc.paymentMethodSales.map((p) => p.sales).reduce((a, b) => a + b)
+        ).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
+      case 'category':
+        return yearlyData.map((doc) => 
+          doc.categorySales.map((c) => c.sales).reduce((a, b) => a + b)
+        ).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
+      case 'sales':
+        return yearlyData.map((doc) => doc.grossSales).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
+      case 'orders':
+        return yearlyData.map((doc) => doc.orderCount).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
+      case 'avgValue':
+        return yearlyData.map((doc) => doc.avgOrderValue).reduce((a, b) => a > b ? a : b) * 1.1;
+      default:
+        return 1000000.0;
+    }
+  }
+
+  List<BarChartGroupData> _buildBarGroups() {
+    return yearlyData.asMap().entries.map((entry) {
+      final index = entry.key;
+      final data = entry.value;
+      
+      switch (chartType) {
+        case 'payment':
+          return _buildPaymentBarGroup(index, data);
+        case 'category':
+          return _buildCategoryBarGroup(index, data);
+        case 'sales':
+          return _buildSingleBarGroup(index, data.grossSales, Colors.blue, '総売上');
+        case 'orders':
+          return _buildSingleBarGroup(index, data.orderCount, Colors.green, '来店数');
+        case 'avgValue':
+          return _buildSingleBarGroup(index, data.avgOrderValue.round(), Colors.orange, '平均客単価');
+        default:
+          return _buildSingleBarGroup(index, data.grossSales, Colors.blue, '総売上');
+      }
+    }).toList();
+  }
+
+  BarChartGroupData _buildPaymentBarGroup(int index, MonthlyDoc data) {
+    final paymentData = data.paymentMethodSales;
+    final colors = [Colors.blue, Colors.green, Colors.orange, Colors.purple, Colors.red, Colors.teal];
+    
+    return BarChartGroupData(
+      x: index,
+      barRods: paymentData.asMap().entries.map((entry) {
+        final rodIndex = entry.key;
+        final payment = entry.value;
+        return BarChartRodData(
+          toY: payment.sales.toDouble(),
+          color: colors[rodIndex % colors.length],
+          width: 20,
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(4),
+            topRight: Radius.circular(4),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  BarChartGroupData _buildCategoryBarGroup(int index, MonthlyDoc data) {
+    final categoryData = data.categorySales;
+    final colors = [Colors.blue, Colors.green, Colors.orange, Colors.purple];
+    
+    return BarChartGroupData(
+      x: index,
+      barRods: categoryData.asMap().entries.map((entry) {
+        final rodIndex = entry.key;
+        final category = entry.value;
+        return BarChartRodData(
+          toY: category.sales.toDouble(),
+          color: colors[rodIndex % colors.length],
+          width: 20,
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(4),
+            topRight: Radius.circular(4),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  BarChartGroupData _buildSingleBarGroup(int index, int value, Color color, String label) {
+    return BarChartGroupData(
+      x: index,
+      barRods: [
+        BarChartRodData(
+          toY: value.toDouble(),
+          color: color,
+          width: 20,
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(4),
+            topRight: Radius.circular(4),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/dashboard/yearly/yearly_overview_page.dart
+++ b/lib/dashboard/yearly/yearly_overview_page.dart
@@ -1,0 +1,252 @@
+/// 年間比較画面
+/// 
+/// 責務: 年間データの比較表示（タブ切替対応）
+/// 参照フィールド: 対象年の12ヶ月分のanalyticsMonthly/{YYYY-MM}
+/// 遅延ロード: あり（初回ロード時）
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/repo/analytics_repository.dart';
+import '../../data/models/analytics_models.dart';
+import '../widgets/stacked_bar_chart.dart';
+import '../../core/widgets/skeleton.dart';
+
+// region Riverpod Providers
+
+/// 年間データのProvider
+final yearlyDataProvider = FutureProvider.family<List<MonthlyDoc>, String>((ref, year) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchYearlyMonthlyDocs(year);
+});
+
+// endregion
+
+class YearlyOverviewPage extends ConsumerStatefulWidget {
+  final String? initialTab;
+  
+  const YearlyOverviewPage({
+    super.key,
+    this.initialTab,
+  });
+
+  @override
+  ConsumerState<YearlyOverviewPage> createState() => _YearlyOverviewPageState();
+}
+
+class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  String _selectedYear = '';
+  
+  final List<String> _tabs = [
+    '総売上',
+    '決済別',
+    'カテゴリ別',
+    '来店数',
+    '平均客単価',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedYear = DateTime.now().year.toString();
+    _tabController = TabController(
+      length: _tabs.length,
+      vsync: this,
+      initialIndex: _getInitialTabIndex(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  int _getInitialTabIndex() {
+    if (widget.initialTab == null) return 0;
+    final index = _tabs.indexOf(widget.initialTab!);
+    return index >= 0 ? index : 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final yearlyDataAsync = ref.watch(yearlyDataProvider(_selectedYear));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${_selectedYear}年 年間比較'),
+        backgroundColor: Colors.blue[700],
+        foregroundColor: Colors.white,
+        centerTitle: true,
+        bottom: TabBar(
+          controller: _tabController,
+          isScrollable: true,
+          tabs: _tabs.map((tab) => Tab(text: tab)).toList(),
+        ),
+      ),
+      body: yearlyDataAsync.when(
+        data: (yearlyData) {
+          if (yearlyData.isEmpty) {
+            return const Center(
+              child: Text('データが見つかりません'),
+            );
+          }
+          return _buildYearlyContent(context, yearlyData);
+        },
+        loading: () => _buildSkeletonContent(context),
+        error: (error, stack) => Center(
+          child: Text('エラーが発生しました: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSkeletonContent(BuildContext context) {
+    return Column(
+      children: [
+        // 年選択
+        Container(
+          padding: const EdgeInsets.all(16.0),
+          child: const Skeleton(width: 200, height: 40),
+        ),
+        // グラフ
+        Expanded(
+          child: const SkeletonChart(width: double.infinity, height: 400),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildYearlyContent(BuildContext context, List<MonthlyDoc> yearlyData) {
+    return Column(
+      children: [
+        // 年選択
+        _buildYearSelector(context),
+        // タブコンテンツ
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              // 総売上
+              _buildSalesChart(yearlyData),
+              // 決済別
+              _buildPaymentChart(yearlyData),
+              // カテゴリ別
+              _buildCategoryChart(yearlyData),
+              // 来店数
+              _buildOrdersChart(yearlyData),
+              // 平均客単価
+              _buildAvgValueChart(yearlyData),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildYearSelector(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      child: Row(
+        children: [
+          const Text(
+            '対象年: ',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(width: 8),
+          DropdownButton<String>(
+            value: _selectedYear,
+            onChanged: (String? newValue) {
+              if (newValue != null) {
+                setState(() {
+                  _selectedYear = newValue;
+                });
+              }
+            },
+            items: List.generate(5, (index) {
+              final year = DateTime.now().year - index;
+              return DropdownMenuItem<String>(
+                value: year.toString(),
+                child: Text('${year}年'),
+              );
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSalesChart(List<MonthlyDoc> yearlyData) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: StackedBarChart(
+        yearlyData: yearlyData,
+        chartType: 'sales',
+        title: '年間総売上推移',
+        onTap: () {
+          // 詳細アクション（必要に応じて実装）
+        },
+      ),
+    );
+  }
+
+  Widget _buildPaymentChart(List<MonthlyDoc> yearlyData) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: StackedBarChart(
+        yearlyData: yearlyData,
+        chartType: 'payment',
+        title: '年間決済別推移',
+        onTap: () {
+          // 詳細アクション（必要に応じて実装）
+        },
+      ),
+    );
+  }
+
+  Widget _buildCategoryChart(List<MonthlyDoc> yearlyData) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: StackedBarChart(
+        yearlyData: yearlyData,
+        chartType: 'category',
+        title: '年間カテゴリ別推移',
+        onTap: () {
+          // 詳細アクション（必要に応じて実装）
+        },
+      ),
+    );
+  }
+
+  Widget _buildOrdersChart(List<MonthlyDoc> yearlyData) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: StackedBarChart(
+        yearlyData: yearlyData,
+        chartType: 'orders',
+        title: '年間来店数推移',
+        onTap: () {
+          // 詳細アクション（必要に応じて実装）
+        },
+      ),
+    );
+  }
+
+  Widget _buildAvgValueChart(List<MonthlyDoc> yearlyData) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: StackedBarChart(
+        yearlyData: yearlyData,
+        chartType: 'avgValue',
+        title: '年間平均客単価推移',
+        onTap: () {
+          // 詳細アクション（必要に応じて実装）
+        },
+      ),
+    );
+  }
+}

--- a/lib/data/models/analytics_models.dart
+++ b/lib/data/models/analytics_models.dart
@@ -1,0 +1,280 @@
+/// 売上ダッシュボード用データモデル
+/// 
+/// 責務: Firestore analyticsMonthly スキーマに対応するDTO
+/// 参照フィールド: analyticsMonthly/{YYYY-MM} およびそのサブコレクション
+/// 遅延ロード: なし（Repository層で完全取得）
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// 月次ドキュメント
+/// 参照パス: analyticsMonthly/{YYYY-MM}
+/// 使用フィールド: grossSales, orderCount, avgOrderValue, itemsSales, sideGameChipSales, tournamentsSales, extraCostSales, dailySales, paymentTotals
+class MonthlyDoc {
+  final int grossSales;
+  final int orderCount;
+  final double avgOrderValue;
+  final int itemsSales;
+  final int sideGameChipSales;
+  final int tournamentsSales;
+  final int extraCostSales;
+  final Map<String, int> dailySales;
+  final Map<String, int> paymentTotals;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  MonthlyDoc({
+    required this.grossSales,
+    required this.orderCount,
+    required this.avgOrderValue,
+    required this.itemsSales,
+    required this.sideGameChipSales,
+    required this.tournamentsSales,
+    required this.extraCostSales,
+    required this.dailySales,
+    required this.paymentTotals,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory MonthlyDoc.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return MonthlyDoc(
+      grossSales: data['grossSales'] ?? 0,
+      orderCount: data['orderCount'] ?? 0,
+      avgOrderValue: (data['avgOrderValue'] ?? 0).toDouble(),
+      itemsSales: data['itemsSales'] ?? 0,
+      sideGameChipSales: data['sideGameChipSales'] ?? 0,
+      tournamentsSales: data['tournamentsSales'] ?? 0,
+      extraCostSales: data['extraCostSales'] ?? 0,
+      dailySales: Map<String, int>.from(data['dailySales'] ?? {}),
+      paymentTotals: Map<String, int>.from(data['paymentTotals'] ?? {}),
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+    );
+  }
+
+  /// カテゴリ別売上データを配列で取得
+  List<CategorySales> get categorySales => [
+    CategorySales('items', itemsSales),
+    CategorySales('sideGameChip', sideGameChipSales),
+    CategorySales('tournaments', tournamentsSales),
+    CategorySales('extraCost', extraCostSales),
+  ];
+
+  /// 支払い方法別データを配列で取得
+  List<PaymentMethodSales> get paymentMethodSales => [
+    PaymentMethodSales('現金', paymentTotals['cash'] ?? 0),
+    PaymentMethodSales('クレカ', paymentTotals['credit_card'] ?? 0),
+    PaymentMethodSales('電子', paymentTotals['electronic_money'] ?? 0),
+    PaymentMethodSales('PointA', paymentTotals['pointA'] ?? 0),
+    PaymentMethodSales('PointB', paymentTotals['pointB'] ?? 0),
+    PaymentMethodSales('SGChip', paymentTotals['sideGameChip'] ?? 0),
+  ];
+
+  /// 日次売上データを日付昇順で取得
+  List<DailySales> get dailySalesList {
+    final entries = dailySales.entries.toList();
+    entries.sort((a, b) => a.key.compareTo(b.key));
+    return entries.map((e) => DailySales(e.key, e.value)).toList();
+  }
+
+  /// ベスト日・ワースト日を取得
+  ({String? bestDate, int? bestAmount, String? worstDate, int? worstAmount}) get bestWorstDays {
+    if (dailySales.isEmpty) return (bestDate: null, bestAmount: null, worstDate: null, worstAmount: null);
+    
+    final entries = dailySales.entries.toList();
+    entries.sort((a, b) => b.value.compareTo(a.value)); // 降順
+    
+    final best = entries.first;
+    final worst = entries.last;
+    
+    return (
+      bestDate: best.key,
+      bestAmount: best.value,
+      worstDate: worst.key,
+      worstAmount: worst.value,
+    );
+  }
+}
+
+/// 日次ドキュメント
+/// 参照パス: analyticsMonthly/{YYYY-MM}/days/{YYYY-MM-DD}
+/// 使用フィールド: byPaymentMethod, itemsSales, sideGameChipSales, extraCostSales, tournamentsSales, grossSales, orderCount
+class DailyDoc {
+  final String date; // YYYY-MM-DD
+  final Map<String, int> byPaymentMethod;
+  final int itemsSales;
+  final int sideGameChipSales;
+  final int extraCostSales;
+  final int tournamentsSales;
+  final int grossSales;
+  final int orderCount;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  DailyDoc({
+    required this.date,
+    required this.byPaymentMethod,
+    required this.itemsSales,
+    required this.sideGameChipSales,
+    required this.extraCostSales,
+    required this.tournamentsSales,
+    required this.grossSales,
+    required this.orderCount,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory DailyDoc.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return DailyDoc(
+      date: doc.id,
+      byPaymentMethod: Map<String, int>.from(data['byPaymentMethod'] ?? {}),
+      itemsSales: data['itemsSales'] ?? 0,
+      sideGameChipSales: data['sideGameChipSales'] ?? 0,
+      extraCostSales: data['extraCostSales'] ?? 0,
+      tournamentsSales: data['tournamentsSales'] ?? 0,
+      grossSales: data['grossSales'] ?? 0,
+      orderCount: data['orderCount'] ?? 0,
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+    );
+  }
+}
+
+/// カテゴリサマリードキュメント
+/// 参照パス: analyticsMonthly/{YYYY-MM}/byCategory/summary
+/// 使用フィールド: totals, orderCounts, itemSales
+class CategorySummaryDoc {
+  final Map<String, int> totals;
+  final Map<String, int> orderCounts;
+  final Map<String, ItemSalesData> itemSales;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  CategorySummaryDoc({
+    required this.totals,
+    required this.orderCounts,
+    required this.itemSales,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory CategorySummaryDoc.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    final itemSalesData = <String, ItemSalesData>{};
+    
+    if (data['itemSales'] != null) {
+      final itemSales = data['itemSales'] as Map<String, dynamic>;
+      for (final entry in itemSales.entries) {
+        final itemData = entry.value as Map<String, dynamic>;
+        itemSalesData[entry.key] = ItemSalesData(
+          qty: itemData['qty'] ?? 0,
+          sales: itemData['sales'] ?? 0,
+          name: itemData['name'] ?? '',
+          category: itemData['category'] ?? '',
+        );
+      }
+    }
+
+    return CategorySummaryDoc(
+      totals: Map<String, int>.from(data['totals'] ?? {}),
+      orderCounts: Map<String, int>.from(data['orderCounts'] ?? {}),
+      itemSales: itemSalesData,
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+    );
+  }
+
+  /// 商品別売上データを売上降順で取得
+  List<ItemSalesData> get topItems {
+    final items = itemSales.values.toList();
+    items.sort((a, b) => b.sales.compareTo(a.sales));
+    return items;
+  }
+}
+
+/// トーナメントテンプレートドキュメント
+/// 参照パス: analyticsMonthly/{YYYY-MM}/byTemplateTournaments/{templateId}
+/// 使用フィールド: templateName, totals, daily
+class TemplateTournamentDoc {
+  final String templateId;
+  final String templateName;
+  final Map<String, int> totals;
+  final Map<String, Map<String, int>> daily;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  TemplateTournamentDoc({
+    required this.templateId,
+    required this.templateName,
+    required this.totals,
+    required this.daily,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory TemplateTournamentDoc.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    final dailyData = <String, Map<String, int>>{};
+    
+    if (data['daily'] != null) {
+      final daily = data['daily'] as Map<String, dynamic>;
+      for (final entry in daily.entries) {
+        dailyData[entry.key] = Map<String, int>.from(entry.value as Map<String, dynamic>);
+      }
+    }
+
+    return TemplateTournamentDoc(
+      templateId: doc.id,
+      templateName: data['templateName'] ?? '',
+      totals: Map<String, int>.from(data['totals'] ?? {}),
+      daily: dailyData,
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+    );
+  }
+}
+
+// region ヘルパークラス
+
+/// カテゴリ別売上データ
+class CategorySales {
+  final String category;
+  final int sales;
+
+  CategorySales(this.category, this.sales);
+}
+
+/// 支払い方法別売上データ
+class PaymentMethodSales {
+  final String method;
+  final int sales;
+
+  PaymentMethodSales(this.method, this.sales);
+}
+
+/// 日次売上データ
+class DailySales {
+  final String date;
+  final int sales;
+
+  DailySales(this.date, this.sales);
+}
+
+/// 商品別売上データ
+class ItemSalesData {
+  final int qty;
+  final int sales;
+  final String name;
+  final String category;
+
+  ItemSalesData({
+    required this.qty,
+    required this.sales,
+    required this.name,
+    required this.category,
+  });
+}
+
+// endregion

--- a/lib/data/repo/analytics_repository.dart
+++ b/lib/data/repo/analytics_repository.dart
@@ -1,0 +1,184 @@
+/// 売上ダッシュボード用Repository
+/// 
+/// 責務: Firestore analyticsMonthly スキーマからのデータ取得・整形
+/// 参照フィールド: analyticsMonthly/{YYYY-MM} およびそのサブコレクション
+/// 遅延ロード: あり（HOME画面は月次Docのみ、詳細画面でサブコレクション取得）
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/analytics_models.dart';
+
+class AnalyticsRepository {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  /// 月次Doc（1件）取得
+  /// 参照パス: analyticsMonthly/{YYYY-MM}
+  /// 使用フィールド: grossSales, orderCount, avgOrderValue, itemsSales, sideGameChipSales, tournamentsSales, extraCostSales, dailySales, paymentTotals
+  /// 戻り値の構造: MonthlyDoc（完全な月次データ）
+  Future<MonthlyDoc?> fetchMonthlyDoc(String yyyymm) async {
+    try {
+      final doc = await _firestore
+          .collection('analyticsMonthly')
+          .doc(yyyymm)
+          .get();
+      
+      if (!doc.exists) return null;
+      return MonthlyDoc.fromFirestore(doc);
+    } catch (e) {
+      throw Exception('月次データの取得に失敗しました: $e');
+    }
+  }
+
+  /// 指定年（YYYY）に存在する月次Docをすべて取得（1〜12のうち存在分）
+  /// 参照パス: analyticsMonthly/{YYYY-01} 〜 analyticsMonthly/{YYYY-12}
+  /// 使用フィールド: grossSales, orderCount, avgOrderValue, paymentTotals
+  /// 戻り値の構造: List<MonthlyDoc>（存在する月のみ、日付昇順）
+  Future<List<MonthlyDoc>> fetchYearlyMonthlyDocs(String yyyy) async {
+    try {
+      final months = <String>[];
+      for (int month = 1; month <= 12; month++) {
+        months.add('$yyyy-${month.toString().padLeft(2, '0')}');
+      }
+
+      final futures = months.map((month) => fetchMonthlyDoc(month));
+      final results = await Future.wait(futures);
+      
+      return results.where((doc) => doc != null).cast<MonthlyDoc>().toList();
+    } catch (e) {
+      throw Exception('年間データの取得に失敗しました: $e');
+    }
+  }
+
+  /// 当月 days/* をまとめて取得し、日付昇順で返す
+  /// 参照パス: analyticsMonthly/{YYYY-MM}/days/{YYYY-MM-DD}
+  /// 使用フィールド: byPaymentMethod, itemsSales, sideGameChipSales, extraCostSales, tournamentsSales, grossSales, orderCount
+  /// 戻り値の構造: List<DailyDoc>（日付昇順）
+  Future<List<DailyDoc>> fetchMonthlyDays(String yyyymm) async {
+    try {
+      final snapshot = await _firestore
+          .collection('analyticsMonthly')
+          .doc(yyyymm)
+          .collection('days')
+          .orderBy('__name__')
+          .get();
+
+      return snapshot.docs
+          .map((doc) => DailyDoc.fromFirestore(doc))
+          .toList();
+    } catch (e) {
+      throw Exception('日次データの取得に失敗しました: $e');
+    }
+  }
+
+  /// byCategory/summary を取得（商品別 上位N抽出は呼び出し側）
+  /// 参照パス: analyticsMonthly/{YYYY-MM}/byCategory/summary
+  /// 使用フィールド: totals, orderCounts, itemSales
+  /// 戻り値の構造: CategorySummaryDoc（カテゴリ別集計・商品別売上）
+  Future<CategorySummaryDoc?> fetchCategorySummary(String yyyymm) async {
+    try {
+      final doc = await _firestore
+          .collection('analyticsMonthly')
+          .doc(yyyymm)
+          .collection('byCategory')
+          .doc('summary')
+          .get();
+      
+      if (!doc.exists) return null;
+      return CategorySummaryDoc.fromFirestore(doc);
+    } catch (e) {
+      throw Exception('カテゴリサマリーの取得に失敗しました: $e');
+    }
+  }
+
+  /// byTemplateTournaments/* を一覧取得
+  /// 参照パス: analyticsMonthly/{YYYY-MM}/byTemplateTournaments/{templateId}
+  /// 使用フィールド: templateName, totals, daily
+  /// 戻り値の構造: List<TemplateTournamentDoc>（テンプレート別売上・日別データ）
+  Future<List<TemplateTournamentDoc>> fetchTemplateTournamentDocs(String yyyymm) async {
+    try {
+      final snapshot = await _firestore
+          .collection('analyticsMonthly')
+          .doc(yyyymm)
+          .collection('byTemplateTournaments')
+          .get();
+
+      return snapshot.docs
+          .map((doc) => TemplateTournamentDoc.fromFirestore(doc))
+          .toList();
+    } catch (e) {
+      throw Exception('トーナメントテンプレートデータの取得に失敗しました: $e');
+    }
+  }
+
+  /// 現在の年月を取得（YYYY-MM形式）
+  String getCurrentYearMonth() {
+    final now = DateTime.now();
+    return '${now.year}-${now.month.toString().padLeft(2, '0')}';
+  }
+
+  /// 現在の年を取得（YYYY形式）
+  String getCurrentYear() {
+    return DateTime.now().year.toString();
+  }
+
+  /// 日付文字列から年月を取得（YYYY-MM形式）
+  String getYearMonthFromDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}';
+  }
+
+  /// 年月文字列から年を取得（YYYY形式）
+  String getYearFromYearMonth(String yyyymm) {
+    return yyyymm.split('-')[0];
+  }
+
+  /// 直近6ヶ月の総売上データを取得（最小限の読み取り）
+  /// 参照パス: analyticsMonthly/{YYYY-MM}（直近6ヶ月分）
+  /// 使用フィールド: grossSales のみ
+  /// 戻り値の構造: List<Map<String, dynamic>>（月次ID、総売上、月名）
+  Future<List<Map<String, dynamic>>> fetchLastSixMonthsGrossSales() async {
+    try {
+      final now = DateTime.now();
+      final months = <String>[];
+      
+      // 直近6ヶ月の月次IDを生成
+      for (int i = 5; i >= 0; i--) {
+        final date = DateTime(now.year, now.month - i);
+        final yyyymm = '${date.year}-${date.month.toString().padLeft(2, '0')}';
+        months.add(yyyymm);
+      }
+
+      final futures = months.map((month) async {
+        final doc = await _firestore
+            .collection('analyticsMonthly')
+            .doc(month)
+            .get();
+        
+        if (!doc.exists) return null;
+        
+        final data = doc.data();
+        return {
+          'monthId': month,
+          'grossSales': data?['grossSales'] ?? 0,
+          'monthName': _getMonthName(month),
+        };
+      });
+      
+      final results = await Future.wait(futures);
+      // 存在するドキュメントのみを返す（nullを除外）
+      final validResults = results.where((item) => item != null).cast<Map<String, dynamic>>().toList();
+      
+      // デバッグ用ログ
+      print('取得した月次データ: ${validResults.map((e) => '${e['monthId']}: ${e['grossSales']}').join(', ')}');
+      
+      return validResults;
+    } catch (e) {
+      throw Exception('直近6ヶ月データの取得に失敗しました: $e');
+    }
+  }
+
+  /// 月次IDから月名を取得（例: "2025-09" → "9月"）
+  String _getMonthName(String yyyymm) {
+    final parts = yyyymm.split('-');
+    final month = int.parse(parts[1]);
+    return '$month月';
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:amuse_app_template/services/device_service.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'firebase_options.dart';
 import 'Utils/menuItemsManager.dart';
 
@@ -22,7 +23,7 @@ void main() async {
   // How: MenuItemsManager経由でFireStoreからデータを取得
   await MenuItemsManager.fetchMenuItems();
   
-  runApp(MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -297,6 +305,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.10.17"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "74959b99b92b9eebeed1a4049426fd67c4abc3c5a0f4d12e2877097d6a11ae08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.69.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -331,6 +347,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.28"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -589,6 +613,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -666,6 +698,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,10 @@ dependencies:
   firebase_app_check: ^0.3.2+10
 
   mobile_scanner: ^6.0.2
+  
+  # Dashboard dependencies
+  fl_chart: ^0.69.0
+  flutter_riverpod: ^2.6.1
   flutter_colorpicker: ^1.1.0
   intl: ^0.20.2
   flutter_localizations:


### PR DESCRIPTION
- Add month selection dropdown to DashboardHomePage AppBar
- Add availableMonthsProvider and selectedMonthProvider for state management
- Format month display as 'YYYY年MM月' with underline styling
- Change line chart from curved to straight lines in LineChart widget
- Update monthly data provider to use selected month
- Add Cloud Firestore import for month data fetching