### PR TITLE
feat: ダッシュボードUI改善と月選択機能追加

### DIFF
--- a/lib/app_config/dashboard_config.dart
+++ b/lib/app_config/dashboard_config.dart
@@ -1,0 +1,32 @@
+/// ダッシュボードUI設定
+/// 
+/// 責務: ダッシュボードのUIカラー設定を一元管理
+/// 参照: lib/dashboard内の全UIファイル
+
+import 'package:flutter/material.dart';
+
+class DashboardConfig {
+  // シングルトンインスタンス
+  static final DashboardConfig _instance = DashboardConfig._internal();
+  factory DashboardConfig() => _instance;
+  DashboardConfig._internal();
+
+  // AppBarのカラー
+  Color appBarColor = Colors.grey[800]!;
+
+  // AppBar内の文字のカラー
+  Color appBarTextColor = Colors.white;
+
+  // Bodyの背景色
+  Color bodyBackgroundColor = Colors.brown[50]!;
+
+  // タブのカラー←これ何の色か謎
+  Color tabColor = Colors.white;
+
+  // タブ内の文字の色
+  Color tabTextColor = Colors.white;
+
+  // タブの背景色
+  Color tabBackgroundColor = Colors.grey[700]!;
+}
+

--- a/lib/dashboard/category/category_item_breakdown_page.dart
+++ b/lib/dashboard/category/category_item_breakdown_page.dart
@@ -6,12 +6,29 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../data/repo/analytics_repository.dart';
 import '../../data/models/analytics_models.dart';
 import '../../core/utils/formatters.dart';
+import '../../app_config/dashboard_config.dart';
 import '../../core/widgets/skeleton.dart';
 
 // region Riverpod Providers
+
+/// 利用可能な月のリストのProvider
+final availableMonthsProvider = FutureProvider<List<String>>((ref) async {
+  final firestore = FirebaseFirestore.instance;
+  final snapshot = await firestore.collection('analyticsMonthly').get();
+  final months = snapshot.docs.map((doc) => doc.id).toList();
+  months.sort((a, b) => b.compareTo(a)); // 新しい順にソート
+  return months;
+});
+
+/// 選択された月のProvider
+final selectedMonthProvider = StateProvider<String>((ref) {
+  final repository = AnalyticsRepository();
+  return repository.getCurrentYearMonth();
+});
 
 /// カテゴリサマリーのProvider
 final categorySummaryProvider = FutureProvider.family<CategorySummaryDoc?, String>((ref, yyyymm) async {
@@ -41,16 +58,85 @@ class _CategoryItemBreakdownPageState extends ConsumerState<CategoryItemBreakdow
   final List<String> _categoryOptions = ['全て', '商品', 'サイドゲームチップ', '追加料金', 'トーナメント'];
 
   @override
-  Widget build(BuildContext context) {
-    final currentMonth = widget.month ?? AnalyticsRepository().getCurrentYearMonth();
-    final categorySummaryAsync = ref.watch(categorySummaryProvider(currentMonth));
+  void initState() {
+    super.initState();
+    // 遷移時に渡された月をデフォルト値として設定
+    if (widget.month != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(selectedMonthProvider.notifier).state = widget.month!;
+      });
+    }
+  }
 
+  /// 月の表示形式をフォーマット（YYYY-MM → YYYY/MM）
+  String _formatMonthDisplay(String monthId) {
+    if (monthId.isEmpty) return '';
+    final parts = monthId.split('-');
+    if (parts.length != 2) return monthId;
+    final year = parts[0];
+    final month = parts[1];
+    return '$year/$month';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedMonth = ref.watch(selectedMonthProvider);
+    final categorySummaryAsync = ref.watch(categorySummaryProvider(selectedMonth));
+
+    final config = DashboardConfig();
+    
     return Scaffold(
+      backgroundColor: config.bodyBackgroundColor,
       appBar: AppBar(
-        title: Text('商品別詳細 - ${Formatters.formatYearMonth(currentMonth)}'),
-        backgroundColor: Colors.blue[700],
-        foregroundColor: Colors.white,
+        title: Text('商品別詳細 - ${Formatters.formatYearMonth(selectedMonth)}'),
+        backgroundColor: config.appBarColor,
+        foregroundColor: config.appBarTextColor,
         centerTitle: true,
+        actions: [
+          Consumer(
+            builder: (context, ref, child) {
+              final availableMonthsAsync = ref.watch(availableMonthsProvider);
+              
+              return availableMonthsAsync.when(
+                data: (availableMonths) {
+                  if (availableMonths.isEmpty) {
+                    return const SizedBox.shrink();
+                  }
+                  
+                  final displayText = _formatMonthDisplay(selectedMonth);
+                  
+                  return PopupMenuButton<String>(
+                    onSelected: (month) {
+                      ref.read(selectedMonthProvider.notifier).state = month;
+                    },
+                    itemBuilder: (context) {
+                      return availableMonths.map((month) {
+                        return PopupMenuItem<String>(
+                          value: month,
+                          child: Text(_formatMonthDisplay(month)),
+                        );
+                      }).toList();
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      child: Text(
+                        displayText,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          decoration: TextDecoration.underline,
+                          decorationColor: Colors.white,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+                loading: () => const SizedBox.shrink(),
+                error: (error, stack) => const SizedBox.shrink(),
+              );
+            },
+          ),
+        ],
       ),
       body: categorySummaryAsync.when(
         data: (categorySummary) {

--- a/lib/dashboard/category/category_overview_page.dart
+++ b/lib/dashboard/category/category_overview_page.dart
@@ -6,14 +6,32 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../data/repo/analytics_repository.dart';
 import '../../data/models/analytics_models.dart';
 import '../../core/utils/formatters.dart';
+import '../../app_config/dashboard_config.dart';
 import '../widgets/horizontal_bar_chart.dart';
+import '../widgets/stacked_bar_chart.dart';
 import '../../core/widgets/skeleton.dart';
 import 'category_item_breakdown_page.dart';
 
 // region Riverpod Providers
+
+/// 利用可能な月のリストのProvider
+final availableMonthsProvider = FutureProvider<List<String>>((ref) async {
+  final firestore = FirebaseFirestore.instance;
+  final snapshot = await firestore.collection('analyticsMonthly').get();
+  final months = snapshot.docs.map((doc) => doc.id).toList();
+  months.sort((a, b) => b.compareTo(a)); // 新しい順にソート
+  return months;
+});
+
+/// 選択された月のProvider
+final selectedMonthProvider = StateProvider<String>((ref) {
+  final repository = AnalyticsRepository();
+  return repository.getCurrentYearMonth();
+});
 
 /// 月次データのProvider
 final monthlyDataProvider = FutureProvider.family<MonthlyDoc?, String>((ref, yyyymm) async {
@@ -27,9 +45,15 @@ final categorySummaryProvider = FutureProvider.family<CategorySummaryDoc?, Strin
   return repository.fetchCategorySummary(yyyymm);
 });
 
+/// 年間データのProvider
+final yearlyDataProvider = FutureProvider.family<List<MonthlyDoc>, String>((ref, year) async {
+  final repository = AnalyticsRepository();
+  return repository.fetchYearlyMonthlyDocs(year);
+});
+
 // endregion
 
-class CategoryOverviewPage extends ConsumerWidget {
+class CategoryOverviewPage extends ConsumerStatefulWidget {
   final String? month;
   
   const CategoryOverviewPage({
@@ -38,31 +62,123 @@ class CategoryOverviewPage extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final currentMonth = month ?? AnalyticsRepository().getCurrentYearMonth();
-    final monthlyDataAsync = ref.watch(monthlyDataProvider(currentMonth));
-    final categorySummaryAsync = ref.watch(categorySummaryProvider(currentMonth));
+  ConsumerState<CategoryOverviewPage> createState() => _CategoryOverviewPageState();
+}
 
+class _CategoryOverviewPageState extends ConsumerState<CategoryOverviewPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  String _selectedYear = '';
+  
+  final List<String> _tabs = [
+    '当月',
+    '年間比較',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedYear = DateTime.now().year.toString();
+    _tabController = TabController(
+      length: _tabs.length,
+      vsync: this,
+    );
+    // 遷移時に渡された月をデフォルト値として設定
+    if (widget.month != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(selectedMonthProvider.notifier).state = widget.month!;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  /// 月の表示形式をフォーマット（YYYY-MM → YYYY/MM）
+  String _formatMonthDisplay(String monthId) {
+    if (monthId.isEmpty) return '';
+    final parts = monthId.split('-');
+    if (parts.length != 2) return monthId;
+    final year = parts[0];
+    final month = parts[1];
+    return '$year/$month';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedMonth = ref.watch(selectedMonthProvider);
+    final monthlyDataAsync = ref.watch(monthlyDataProvider(selectedMonth));
+    final categorySummaryAsync = ref.watch(categorySummaryProvider(selectedMonth));
+    final yearlyDataAsync = ref.watch(yearlyDataProvider(_selectedYear));
+
+    final config = DashboardConfig();
+    
     return Scaffold(
+      backgroundColor: config.bodyBackgroundColor,
       appBar: AppBar(
-        title: Text('カテゴリ詳細 - ${Formatters.formatYearMonth(currentMonth)}'),
-        backgroundColor: Colors.blue[700],
-        foregroundColor: Colors.white,
+        title: const Text('カテゴリ詳細'),
+        backgroundColor: config.appBarColor,
+        foregroundColor: config.appBarTextColor,
         centerTitle: true,
-      ),
-      body: monthlyDataAsync.when(
-        data: (monthlyData) {
-          if (monthlyData == null) {
-            return const Center(
-              child: Text('データが見つかりません'),
-            );
-          }
-          return _buildCategoryContent(context, monthlyData, categorySummaryAsync);
-        },
-        loading: () => _buildSkeletonContent(context),
-        error: (error, stack) => Center(
-          child: Text('エラーが発生しました: $error'),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: Container(
+            color: config.tabBackgroundColor,
+            child: TabBar(
+              controller: _tabController,
+              labelColor: config.tabTextColor,
+              unselectedLabelColor: Colors.grey[400],
+              indicatorColor: config.tabColor,
+              tabs: _tabs.map((tab) => Tab(text: tab)).toList(),
+            ),
+          ),
         ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          // 当月タブ
+          _buildCurrentMonthTab(context, monthlyDataAsync, categorySummaryAsync),
+          // 年間比較タブ
+          _buildYearlyComparisonTab(context, yearlyDataAsync),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentMonthTab(BuildContext context, AsyncValue<MonthlyDoc?> monthlyDataAsync, AsyncValue<CategorySummaryDoc?> categorySummaryAsync) {
+    return monthlyDataAsync.when(
+      data: (monthlyData) {
+        if (monthlyData == null) {
+          return const Center(
+            child: Text('データが見つかりません'),
+          );
+        }
+        return _buildCategoryContent(context, monthlyData, categorySummaryAsync);
+      },
+      loading: () => _buildSkeletonContent(context),
+      error: (error, stack) => Center(
+        child: Text('エラーが発生しました: $error'),
+      ),
+    );
+  }
+
+  Widget _buildYearlyComparisonTab(BuildContext context, AsyncValue<List<MonthlyDoc>> yearlyDataAsync) {
+    return yearlyDataAsync.when(
+      data: (yearlyData) {
+        if (yearlyData.isEmpty) {
+          return const Center(
+            child: Text('データが見つかりません'),
+          );
+        }
+        return _buildYearlyComparisonContent(context, yearlyData);
+      },
+      loading: () => _buildSkeletonContent(context),
+      error: (error, stack) => Center(
+        child: Text('エラーが発生しました: $error'),
       ),
     );
   }
@@ -87,6 +203,9 @@ class CategoryOverviewPage extends ConsumerWidget {
       padding: const EdgeInsets.all(16.0),
       child: Column(
         children: [
+          // 月選択ドロップダウン
+          _buildMonthSelector(context),
+          const SizedBox(height: 16),
           // カテゴリ別横棒グラフ
           _buildCategoryChart(context, monthlyData),
           const SizedBox(height: 16),
@@ -161,17 +280,22 @@ class CategoryOverviewPage extends ConsumerWidget {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              TextButton(
-                onPressed: () {
-                  // 商品別詳細画面へ遷移
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const CategoryItemBreakdownPage(),
-                    ),
+              Consumer(
+                builder: (context, ref, child) {
+                  final selectedMonth = ref.watch(selectedMonthProvider);
+                  return TextButton(
+                    onPressed: () {
+                      // 商品別詳細画面へ遷移
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => CategoryItemBreakdownPage(month: selectedMonth),
+                        ),
+                      );
+                    },
+                    child: const Text('詳細を見る'),
                   );
                 },
-                child: const Text('詳細を見る'),
               ),
             ],
           ),
@@ -302,5 +426,148 @@ class CategoryOverviewPage extends ConsumerWidget {
       default:
         return Colors.blue;
     }
+  }
+
+  Widget _buildMonthSelector(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Consumer(
+        builder: (context, ref, child) {
+          final selectedMonth = ref.watch(selectedMonthProvider);
+          final availableMonthsAsync = ref.watch(availableMonthsProvider);
+          
+          return availableMonthsAsync.when(
+            data: (availableMonths) {
+              return Row(
+                children: [
+                  const Text(
+                    '月選択: ',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: DropdownButton<String>(
+                      value: selectedMonth,
+                      isExpanded: true,
+                      items: availableMonths.map((month) {
+                        return DropdownMenuItem<String>(
+                          value: month,
+                          child: Text(_formatMonthDisplay(month)),
+                        );
+                      }).toList(),
+                      onChanged: (month) {
+                        if (month != null) {
+                          ref.read(selectedMonthProvider.notifier).state = month;
+                        }
+                      },
+                    ),
+                  ),
+                ],
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, stack) => const Text('エラーが発生しました'),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildYearlyComparisonContent(BuildContext context, List<MonthlyDoc> yearlyData) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          // 年選択
+          _buildYearSelector(context),
+          const SizedBox(height: 16),
+          // 年間カテゴリ別推移
+          _buildYearlyCategoryChart(context, yearlyData),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildYearSelector(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          const Text(
+            '対象年: ',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(width: 8),
+          DropdownButton<String>(
+            value: _selectedYear,
+            onChanged: (String? newValue) {
+              if (newValue != null) {
+                setState(() {
+                  _selectedYear = newValue;
+                });
+              }
+            },
+            items: List.generate(5, (index) {
+              final year = DateTime.now().year - index;
+              return DropdownMenuItem<String>(
+                value: year.toString(),
+                child: Text('${year}年'),
+              );
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildYearlyCategoryChart(BuildContext context, List<MonthlyDoc> yearlyData) {
+    return Container(
+      height: 400,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: StackedBarChart(
+        yearlyData: yearlyData,
+        chartType: 'category',
+        title: '年間カテゴリ別推移',
+      ),
+    );
   }
 }

--- a/lib/dashboard/daily/daily_trend_page.dart
+++ b/lib/dashboard/daily/daily_trend_page.dart
@@ -6,13 +6,30 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../data/repo/analytics_repository.dart';
 import '../../data/models/analytics_models.dart';
 import '../../core/utils/formatters.dart';
+import '../../app_config/dashboard_config.dart';
 import '../widgets/line_chart.dart';
 import '../../core/widgets/skeleton.dart';
 
 // region Riverpod Providers
+
+/// 利用可能な月のリストのProvider
+final availableMonthsProvider = FutureProvider<List<String>>((ref) async {
+  final firestore = FirebaseFirestore.instance;
+  final snapshot = await firestore.collection('analyticsMonthly').get();
+  final months = snapshot.docs.map((doc) => doc.id).toList();
+  months.sort((a, b) => b.compareTo(a)); // 新しい順にソート
+  return months;
+});
+
+/// 選択された月のProvider
+final selectedMonthProvider = StateProvider<String>((ref) {
+  final repository = AnalyticsRepository();
+  return repository.getCurrentYearMonth();
+});
 
 /// 日次データのProvider
 final dailyDataProvider = FutureProvider.family<List<DailyDoc>, String>((ref, yyyymm) async {
@@ -39,17 +56,86 @@ class _DailyTrendPageState extends ConsumerState<DailyTrendPage> {
   
   final List<String> _viewOptions = ['全て', '現金・クレカ・電子マネー', 'ポイント'];
 
+  /// 月の表示形式をフォーマット（YYYY-MM → YYYY/MM）
+  String _formatMonthDisplay(String monthId) {
+    if (monthId.isEmpty) return '';
+    final parts = monthId.split('-');
+    if (parts.length != 2) return monthId;
+    final year = parts[0];
+    final month = parts[1];
+    return '$year/$month';
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    // 遷移時に渡された月をデフォルト値として設定
+    if (widget.month != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(selectedMonthProvider.notifier).state = widget.month!;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final currentMonth = widget.month ?? AnalyticsRepository().getCurrentYearMonth();
-    final dailyDataAsync = ref.watch(dailyDataProvider(currentMonth));
+    final selectedMonth = ref.watch(selectedMonthProvider);
+    final dailyDataAsync = ref.watch(dailyDataProvider(selectedMonth));
 
+    final config = DashboardConfig();
+    
     return Scaffold(
+      backgroundColor: config.bodyBackgroundColor,
       appBar: AppBar(
-        title: Text('日次推移 - ${Formatters.formatYearMonth(currentMonth)}'),
-        backgroundColor: Colors.blue[700],
-        foregroundColor: Colors.white,
+        title: Text('日次推移 - ${Formatters.formatYearMonth(selectedMonth)}'),
+        backgroundColor: config.appBarColor,
+        foregroundColor: config.appBarTextColor,
         centerTitle: true,
+        actions: [
+          Consumer(
+            builder: (context, ref, child) {
+              final availableMonthsAsync = ref.watch(availableMonthsProvider);
+              
+              return availableMonthsAsync.when(
+                data: (availableMonths) {
+                  if (availableMonths.isEmpty) {
+                    return const SizedBox.shrink();
+                  }
+                  
+                  final displayText = _formatMonthDisplay(selectedMonth);
+                  
+                  return PopupMenuButton<String>(
+                    onSelected: (month) {
+                      ref.read(selectedMonthProvider.notifier).state = month;
+                    },
+                    itemBuilder: (context) {
+                      return availableMonths.map((month) {
+                        return PopupMenuItem<String>(
+                          value: month,
+                          child: Text(_formatMonthDisplay(month)),
+                        );
+                      }).toList();
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      child: Text(
+                        displayText,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                          decoration: TextDecoration.underline,
+                          decorationColor: Colors.white,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+                loading: () => const SizedBox.shrink(),
+                error: (error, stack) => const SizedBox.shrink(),
+              );
+            },
+          ),
+        ],
       ),
       body: dailyDataAsync.when(
         data: (dailyData) {

--- a/lib/dashboard/home/dashboard_home_page.dart
+++ b/lib/dashboard/home/dashboard_home_page.dart
@@ -6,6 +6,7 @@ import '../../data/repo/analytics_repository.dart';
 import '../../data/models/analytics_models.dart';
 import '../../core/utils/formatters.dart';
 import '../../core/widgets/skeleton.dart';
+import '../../app_config/dashboard_config.dart';
 import '../widgets/horizontal_bar_chart.dart';
 import '../widgets/donut_chart.dart';
 import '../widgets/line_chart.dart';
@@ -50,27 +51,30 @@ final lastSixMonthsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) a
 class DashboardHomePage extends ConsumerWidget {
   const DashboardHomePage({super.key});
 
-  /// 月の表示形式をフォーマット（YYYY-MM → YYYY年MM月）
+  /// 月の表示形式をフォーマット（YYYY-MM → YYYY/MM）
   String _formatMonthDisplay(String monthId) {
     if (monthId.isEmpty) return '';
     final parts = monthId.split('-');
     if (parts.length != 2) return monthId;
     final year = parts[0];
     final month = parts[1];
-    return '${year}年${month}月';
+    return '$year/$month';
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final monthlyDataAsync = ref.watch(monthlyDataProvider);
 
+    final config = DashboardConfig();
+    
     return Scaffold(
+      backgroundColor: config.bodyBackgroundColor,
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(MediaQuery.of(context).size.height * 0.08),
         child: AppBar(
           title: const Text('売上ダッシュボード'),
-          backgroundColor: Colors.blue[700],
-          foregroundColor: Colors.white,
+          backgroundColor: config.appBarColor,
+          foregroundColor: config.appBarTextColor,
           centerTitle: true,
           actions: [
             Consumer(
@@ -120,18 +124,24 @@ class DashboardHomePage extends ConsumerWidget {
           ],
         ),
       ),
-      body: monthlyDataAsync.when(
-        data: (monthlyData) {
-          if (monthlyData == null) {
-            return const Center(
-              child: Text('データが見つかりません'),
-            );
-          }
-          return _buildDashboardContent(context, monthlyData);
-        },
-        loading: () => _buildSkeletonContent(context),
-        error: (error, stack) => Center(
-          child: Text('エラーが発生しました: $error'),
+      body: Padding(
+        padding: EdgeInsets.only(
+          top: MediaQuery.of(context).size.height * 0.01,
+          left: MediaQuery.of(context).size.width * 0.01,
+        ),
+        child: monthlyDataAsync.when(
+          data: (monthlyData) {
+            if (monthlyData == null) {
+              return const Center(
+                child: Text('データが見つかりません'),
+              );
+            }
+            return _buildDashboardContent(context, monthlyData);
+          },
+          loading: () => _buildSkeletonContent(context),
+          error: (error, stack) => Center(
+            child: Text('エラーが発生しました: $error'),
+          ),
         ),
       ),
     );
@@ -227,7 +237,7 @@ class DashboardHomePage extends ConsumerWidget {
           // 当月日次推移
           Container(
             margin: EdgeInsets.all(screenWidth * 0.005),
-            width: screenWidth * 0.98,
+            width: screenWidth * 0.97,
             height: screenHeight * 0.40,
             child: const SkeletonChart(),
           ),
@@ -346,7 +356,7 @@ class DashboardHomePage extends ConsumerWidget {
           // 当月日次推移
           Container(
             margin: EdgeInsets.all(screenWidth * 0.005),
-            width: screenWidth * 0.98,
+            width: screenWidth * 0.96,
             height: screenHeight * 0.40,
             child: _buildDailyTrendChart(context, monthlyData),
           ),
@@ -452,36 +462,12 @@ class DashboardHomePage extends ConsumerWidget {
 
     // 最大値を取得（Y軸のスケール用）
     final maxValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a > b ? a : b);
-    final minValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a < b ? a : b);
-    final range = maxValue - minValue;
-    final padding = range * 0.1; // 10%のパディング
+    final maxScale = (maxValue * 1.1).round();
 
-    return Row(
-      children: [
-        // 縦軸用のスペース（倍のサイズ）
-        SizedBox(
-          width: 60, // 縦軸用のスペースを倍のサイズに
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: List.generate(5, (index) {
-              final value = (maxValue / 4) * (4 - index);
-              return Text(
-                value == 0 ? '0円' : '${(value / 10000).floor()}万円',
-                style: const TextStyle(fontSize: 10),
-                textAlign: TextAlign.right,
-              );
-            }),
-          ),
-        ),
-        // グラフ部分
-        Expanded(
-          child: _buildThreeMonthsLineChart(data),
-        ),
-      ],
-    );
+    return _buildThreeMonthsLineChart(data, maxScale);
   }
 
-  Widget _buildThreeMonthsLineChart(List<Map<String, dynamic>> data) {
+  Widget _buildThreeMonthsLineChart(List<Map<String, dynamic>> data, int maxScale) {
     if (data.isEmpty) {
       return const Center(
         child: Text('データがありません'),
@@ -491,50 +477,130 @@ class DashboardHomePage extends ConsumerWidget {
     // デバッグ用ログ
     print('グラフ表示用データ: ${data.map((e) => '${e['monthId']}(${e['monthName']}): ${e['grossSales']}').join(', ')}');
 
-    // データを月順にソート
-    data.sort((a, b) => a['monthId'].compareTo(b['monthId']));
-
-    // 最大値を取得（Y軸のスケール用）
-    final maxValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a > b ? a : b);
-    final minValue = data.map((e) => e['grossSales'] as int).reduce((a, b) => a < b ? a : b);
-    final range = maxValue - minValue;
-    final padding = range * 0.1; // 10%のパディング
+    // 最大売上を取得
+    final maxSales = data.map((e) => e['grossSales'] as int).reduce((a, b) => a > b ? a : b);
+    
+    // 最上位補助線の金額を決定（50万円単位）
+    int topValue;
+    if (maxSales <= 2500000) {
+      topValue = 2500000; // 250万円
+    } else if (maxSales <= 5000000) {
+      topValue = 5000000; // 500万円
+    } else if (maxSales <= 7500000) {
+      topValue = 7500000; // 750万円
+    } else if (maxSales <= 10000000) {
+      topValue = 10000000; // 1000万円
+    } else {
+      // 1000万円を超える場合は250万円刻みで増加
+      topValue = ((maxSales / 2500000).ceil() * 2500000);
+    }
 
     return fl_chart.LineChart(
       fl_chart.LineChartData(
+        lineTouchData: fl_chart.LineTouchData(
+          enabled: true,
+          touchTooltipData: fl_chart.LineTouchTooltipData(
+            tooltipRoundedRadius: 8,
+            getTooltipItems: (touchedSpots) {
+              return touchedSpots.map((touchedSpot) {
+                final index = touchedSpot.x.toInt();
+                if (index >= 0 && index < data.length) {
+                  final monthData = data[index];
+                  return fl_chart.LineTooltipItem(
+                    '${monthData['monthName']}\n${Formatters.formatCurrency(monthData['grossSales'])}',
+                    const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                    ),
+                  );
+                }
+                return null;
+              }).toList();
+            },
+          ),
+        ),
         gridData: fl_chart.FlGridData(
           show: true,
           drawVerticalLine: false,
-          horizontalInterval: (maxValue - minValue) / 4, // 4つの水平線を表示
+          horizontalInterval: topValue / 5, // 5つの間隔で6本の補助線
+          getDrawingHorizontalLine: (value) {
+            return fl_chart.FlLine(
+              color: Colors.grey.withOpacity(0.2),
+              strokeWidth: 1,
+            );
+          },
         ),
         titlesData: fl_chart.FlTitlesData(
-          leftTitles: const fl_chart.AxisTitles(
+          show: true,
+          rightTitles: const fl_chart.AxisTitles(
             sideTitles: fl_chart.SideTitles(showTitles: false),
           ),
           topTitles: const fl_chart.AxisTitles(
             sideTitles: fl_chart.SideTitles(showTitles: false),
           ),
-          rightTitles: const fl_chart.AxisTitles(
-            sideTitles: fl_chart.SideTitles(showTitles: false),
-          ),
           bottomTitles: fl_chart.AxisTitles(
             sideTitles: fl_chart.SideTitles(
               showTitles: true,
+              reservedSize: 30,
+              interval: 1,
               getTitlesWidget: (value, meta) {
                 final index = value.toInt();
                 if (index >= 0 && index < data.length) {
-                  return Text(
-                    data[index]['monthName'],
-                    style: const TextStyle(fontSize: 12),
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 8.0),
+                    child: Text(
+                      data[index]['monthName'],
+                      style: const TextStyle(
+                        fontSize: 10,
+                        color: Colors.grey,
+                      ),
+                    ),
                   );
                 }
                 return const Text('');
               },
-              interval: 1, // 各データポイントにラベルを表示
+            ),
+          ),
+          leftTitles: fl_chart.AxisTitles(
+            sideTitles: fl_chart.SideTitles(
+              showTitles: true,
+              reservedSize: 60,
+              interval: topValue / 5, // 5つの間隔で6本の補助線
+              getTitlesWidget: (value, meta) {
+                final intValue = value.toInt();
+                if (intValue == 0) {
+                  return const Text(
+                    '0',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Colors.grey,
+                    ),
+                  );
+                }
+                // 万円表記に変換
+                final manValue = intValue ~/ 10000;
+                return Text(
+                  '${manValue}万',
+                  style: const TextStyle(
+                    fontSize: 10,
+                    color: Colors.grey,
+                  ),
+                );
+              },
             ),
           ),
         ),
-        borderData: fl_chart.FlBorderData(show: false),
+        borderData: fl_chart.FlBorderData(
+          show: true,
+          border: Border.all(
+            color: Colors.grey.withOpacity(0.2),
+            width: 1,
+          ),
+        ),
+        minX: 0,
+        maxX: (data.length - 1).toDouble(),
+        minY: 0,
+        maxY: topValue.toDouble(),
         lineBarsData: [
           fl_chart.LineChartBarData(
             spots: data.asMap().entries.map((entry) {
@@ -544,17 +610,23 @@ class DashboardHomePage extends ConsumerWidget {
             color: Colors.blue,
             barWidth: 3,
             isStrokeCapRound: true,
-            dotData: const fl_chart.FlDotData(show: true),
+            dotData: fl_chart.FlDotData(
+              show: true,
+              getDotPainter: (spot, percent, barData, index) {
+                return fl_chart.FlDotCirclePainter(
+                  radius: 4,
+                  color: Colors.blue,
+                  strokeWidth: 2,
+                  strokeColor: Colors.white,
+                );
+              },
+            ),
             belowBarData: fl_chart.BarAreaData(
               show: true,
-              color: Colors.blue.withValues(alpha: 0.1),
+              color: Colors.blue.withOpacity(0.1),
             ),
           ),
         ],
-        minY: 0, // 最小値を0に設定
-        maxY: maxValue.toDouble(), // 最大値を最も売り上げの多い月の価格に設定
-        minX: 0,
-        maxX: (data.length - 1).toDouble(),
       ),
     );
   }
@@ -588,14 +660,19 @@ class DashboardHomePage extends ConsumerWidget {
           ),
           const SizedBox(height: 16),
           Expanded(
-            child: HorizontalBarChart(
-              categoryData: monthlyData.categorySales,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const CategoryOverviewPage(),
-                  ),
+            child: Consumer(
+              builder: (context, ref, child) {
+                final selectedMonth = ref.watch(selectedMonthProvider);
+                return HorizontalBarChart(
+                  categoryData: monthlyData.categorySales,
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => CategoryOverviewPage(month: selectedMonth),
+                      ),
+                    );
+                  },
                 );
               },
             ),
@@ -620,17 +697,66 @@ class DashboardHomePage extends ConsumerWidget {
           ),
         ],
       ),
-      child: DonutChart(
-        paymentData: monthlyData.paymentMethodSales,
-        title: '支払手段',
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const PaymentBreakdownPage(),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '支払手段',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Consumer(
+                builder: (context, ref, child) {
+                  final selectedMonth = ref.watch(selectedMonthProvider);
+                  return GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => PaymentBreakdownPage(month: selectedMonth),
+                        ),
+                      );
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.blue[100],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Text(
+                        '詳細',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+          Expanded(
+            child: Consumer(
+              builder: (context, ref, child) {
+                final selectedMonth = ref.watch(selectedMonthProvider);
+                return DonutChart(
+                  paymentData: monthlyData.paymentMethodSales,
+                  title: '',
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => PaymentBreakdownPage(month: selectedMonth),
+                      ),
+                    );
+                  },
+                );
+              },
             ),
-          );
-        },
+          ),
+        ],
       ),
     );
   }
@@ -650,17 +776,61 @@ class DashboardHomePage extends ConsumerWidget {
           ),
         ],
       ),
-      child: DonutChart(
-        categoryData: monthlyData.categorySales,
-        title: 'カテゴリ構成',
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const CategoryOverviewPage(),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'カテゴリ構成',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Consumer(
+                builder: (context, ref, child) {
+                  final selectedMonth = ref.watch(selectedMonthProvider);
+                  return GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => CategoryOverviewPage(month: selectedMonth),
+                        ),
+                      );
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.blue[100],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Text(
+                        '詳細',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+          Expanded(
+            child: DonutChart(
+              categoryData: monthlyData.categorySales,
+              title: '',
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const CategoryOverviewPage(),
+                  ),
+                );
+              },
             ),
-          );
-        },
+          ),
+        ],
       ),
     );
   }
@@ -680,17 +850,66 @@ class DashboardHomePage extends ConsumerWidget {
           ),
         ],
       ),
-      child: LineChart(
-        dailyData: monthlyData.dailySalesList,
-        title: '当月日次推移',
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const DailyTrendPage(),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '当月日次推移',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Consumer(
+                builder: (context, ref, child) {
+                  final selectedMonth = ref.watch(selectedMonthProvider);
+                  return GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => DailyTrendPage(month: selectedMonth),
+                        ),
+                      );
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.blue[100],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Text(
+                        '詳細',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+          Expanded(
+            child: Consumer(
+              builder: (context, ref, child) {
+                final selectedMonth = ref.watch(selectedMonthProvider);
+                return LineChart(
+                  dailyData: monthlyData.dailySalesList,
+                  title: '',
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => DailyTrendPage(month: selectedMonth),
+                      ),
+                    );
+                  },
+                );
+              },
             ),
-          );
-        },
+          ),
+        ],
       ),
     );
   }

--- a/lib/dashboard/payments/payment_breakdown_page.dart
+++ b/lib/dashboard/payments/payment_breakdown_page.dart
@@ -6,14 +6,32 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fl_chart/fl_chart.dart';
 import '../../data/repo/analytics_repository.dart';
 import '../../data/models/analytics_models.dart';
 import '../../core/utils/formatters.dart';
+import '../../app_config/dashboard_config.dart';
 import '../widgets/donut_chart.dart';
 import '../widgets/stacked_bar_chart.dart';
 import '../../core/widgets/skeleton.dart';
 
 // region Riverpod Providers
+
+/// 利用可能な月のリストのProvider
+final availableMonthsProvider = FutureProvider<List<String>>((ref) async {
+  final firestore = FirebaseFirestore.instance;
+  final snapshot = await firestore.collection('analyticsMonthly').get();
+  final months = snapshot.docs.map((doc) => doc.id).toList();
+  months.sort((a, b) => b.compareTo(a)); // 新しい順にソート
+  return months;
+});
+
+/// 選択された月のProvider
+final selectedMonthProvider = StateProvider<String>((ref) {
+  final repository = AnalyticsRepository();
+  return repository.getCurrentYearMonth();
+});
 
 /// 月次データのProvider
 final monthlyDataProvider = FutureProvider.family<MonthlyDoc?, String>((ref, yyyymm) async {
@@ -59,6 +77,12 @@ class _PaymentBreakdownPageState extends ConsumerState<PaymentBreakdownPage>
       length: _tabs.length,
       vsync: this,
     );
+    // 遷移時に渡された月をデフォルト値として設定
+    if (widget.month != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(selectedMonthProvider.notifier).state = widget.month!;
+      });
+    }
   }
 
   @override
@@ -67,21 +91,43 @@ class _PaymentBreakdownPageState extends ConsumerState<PaymentBreakdownPage>
     super.dispose();
   }
 
+  /// 月の表示形式をフォーマット（YYYY-MM → YYYY/MM）
+  String _formatMonthDisplay(String monthId) {
+    if (monthId.isEmpty) return '';
+    final parts = monthId.split('-');
+    if (parts.length != 2) return monthId;
+    final year = parts[0];
+    final month = parts[1];
+    return '$year/$month';
+  }
+
   @override
   Widget build(BuildContext context) {
-    final currentMonth = widget.month ?? AnalyticsRepository().getCurrentYearMonth();
-    final monthlyDataAsync = ref.watch(monthlyDataProvider(currentMonth));
+    final selectedMonth = ref.watch(selectedMonthProvider);
+    final monthlyDataAsync = ref.watch(monthlyDataProvider(selectedMonth));
     final yearlyDataAsync = ref.watch(yearlyDataProvider(_selectedYear));
 
+    final config = DashboardConfig();
+    
     return Scaffold(
+      backgroundColor: config.bodyBackgroundColor,
       appBar: AppBar(
-        title: Text('支払い方法詳細 - ${Formatters.formatYearMonth(currentMonth)}'),
-        backgroundColor: Colors.blue[700],
-        foregroundColor: Colors.white,
+        title: Text('支払い方法詳細'),
+        backgroundColor: config.appBarColor,
+        foregroundColor: config.appBarTextColor,
         centerTitle: true,
-        bottom: TabBar(
-          controller: _tabController,
-          tabs: _tabs.map((tab) => Tab(text: tab)).toList(),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: Container(
+            color: config.tabBackgroundColor,
+            child: TabBar(
+              controller: _tabController,
+              labelColor: config.tabTextColor,
+              unselectedLabelColor: Colors.grey[400],
+              indicatorColor: config.tabColor,
+              tabs: _tabs.map((tab) => Tab(text: tab)).toList(),
+            ),
+          ),
         ),
       ),
       body: TabBarView(
@@ -150,6 +196,9 @@ class _PaymentBreakdownPageState extends ConsumerState<PaymentBreakdownPage>
       padding: const EdgeInsets.all(16.0),
       child: Column(
         children: [
+          // 月選択プルダウン
+          _buildMonthSelector(context),
+          const SizedBox(height: 16),
           // 支払い方法ドーナツグラフ
           _buildPaymentDonutChart(context, monthlyData),
           const SizedBox(height: 16),
@@ -176,8 +225,43 @@ class _PaymentBreakdownPageState extends ConsumerState<PaymentBreakdownPage>
   }
 
   Widget _buildPaymentDonutChart(BuildContext context, MonthlyDoc monthlyData) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    // カードサイズを画面縦幅の50%に固定
+    final cardHeight = screenHeight * 0.5;
+    // 円グラフのサイズを3倍の80%（2.4倍）に
+    final chartRadius = screenHeight * 0.047 * 3 * 0.8;
+    
+    final paymentMethods = monthlyData.paymentMethodSales;
+    final total = paymentMethods.map((p) => p.sales).reduce((a, b) => a + b);
+    
+    // 0以外のデータのみをフィルタリング
+    final filteredData = paymentMethods.where((item) => item.sales > 0).toList();
+    if (filteredData.isEmpty) {
+      return Container(
+        height: cardHeight,
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          borderRadius: BorderRadius.circular(16.0),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: const Center(
+          child: Text('データがありません'),
+        ),
+      );
+    }
+
+    // 売上降順（最大を先頭）にソート
+    filteredData.sort((a, b) => b.sales.compareTo(a.sales));
+
     return Container(
-      height: 300,
+      height: cardHeight,
       padding: const EdgeInsets.all(16.0),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
@@ -190,9 +274,89 @@ class _PaymentBreakdownPageState extends ConsumerState<PaymentBreakdownPage>
           ),
         ],
       ),
-      child: DonutChart(
-        paymentData: monthlyData.paymentMethodSales,
-        title: '当月支払い方法別',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // タイトルを左上に表示
+          const Text(
+            '当月支払い方法別',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          // スペーサーで中央配置を実現
+          Expanded(
+            child: Row(
+              children: [
+                // 円グラフを中央に配置
+                Expanded(
+                  child: Stack(
+                    children: [
+                      // 円グラフ上部に合計金額を表示
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        child: Center(
+                          child: RichText(
+                            text: TextSpan(
+                              children: [
+                                const TextSpan(
+                                  text: '当月総売上：',
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.black,
+                                  ),
+                                ),
+                                TextSpan(
+                                  text: Formatters.formatCurrency(total),
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.blue,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ),
+                      // ドーナツグラフ
+                      Center(
+                        child: SizedBox(
+                          width: chartRadius * 2,
+                          height: chartRadius * 2,
+                          child: PieChart(
+                            PieChartData(
+                              startDegreeOffset: -90,
+                              pieTouchData: PieTouchData(
+                                enabled: true,
+                                touchCallback: (FlTouchEvent event, pieTouchResponse) {},
+                              ),
+                              sectionsSpace: 2,
+                              centerSpaceRadius: chartRadius * 0.3,
+                              sections: _buildDonutSections(filteredData, total, chartRadius),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 16),
+                // 凡例を右側に配置
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: _buildLegend(filteredData, total),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -405,8 +569,165 @@ class _PaymentBreakdownPageState extends ConsumerState<PaymentBreakdownPage>
         return Icons.star;
       case 'sideGameChip':
         return Icons.casino;
-      default:
-        return Icons.payment;
-    }
+   default:
+      return Icons.payment;
+   }
+  }
+
+  Widget _buildMonthSelector(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(16.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Consumer(
+        builder: (context, ref, child) {
+          final selectedMonth = ref.watch(selectedMonthProvider);
+          final availableMonthsAsync = ref.watch(availableMonthsProvider);
+          
+          return availableMonthsAsync.when(
+            data: (availableMonths) {
+              return Row(
+                children: [
+                  const Text(
+                    '月選択: ',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: DropdownButton<String>(
+                      value: selectedMonth,
+                      isExpanded: true,
+                      items: availableMonths.map((month) {
+                        return DropdownMenuItem<String>(
+                          value: month,
+                          child: Text(_formatMonthDisplay(month)),
+                        );
+                      }).toList(),
+                      onChanged: (month) {
+                        if (month != null) {
+                          ref.read(selectedMonthProvider.notifier).state = month;
+                        }
+                      },
+                    ),
+                  ),
+                ],
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, stack) => const Text('エラーが発生しました'),
+          );
+        },
+      ),
+    );
+  }
+
+  List<PieChartSectionData> _buildDonutSections(List<PaymentMethodSales> data, int total, double chartRadius) {
+    final colors = [
+      Colors.blue,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+      Colors.red,
+      Colors.teal,
+      Colors.indigo,
+      Colors.pink,
+    ];
+
+    return data.asMap().entries.map((entry) {
+      final index = entry.key;
+      final item = entry.value;
+      final color = colors[index % colors.length];
+
+      return PieChartSectionData(
+        color: color,
+        value: item.sales.toDouble(),
+        title: '',
+        radius: chartRadius,
+        titleStyle: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
+      );
+    }).toList();
+  }
+
+  Widget _buildLegend(List<PaymentMethodSales> data, int total) {
+    final colors = [
+      Colors.blue,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+      Colors.red,
+      Colors.teal,
+      Colors.indigo,
+      Colors.pink,
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: data.asMap().entries.map((entry) {
+        final index = entry.key;
+        final item = entry.value;
+        final color = colors[index % colors.length];
+        final percentage = (item.sales / total) * 100;
+
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 6.0),
+          child: Row(
+            children: [
+              // 色付き円
+              Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              // 支払い方法名称と金額・割合
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 支払い方法名称
+                    Text(
+                      Formatters.getPaymentMethodDisplayName(item.method),
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    // 金額と割合
+                    Text(
+                      '${Formatters.formatCurrency(item.sales)}(${Formatters.formatPercentage(percentage / 100)})',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    );
   }
 }

--- a/lib/dashboard/widgets/donut_chart.dart
+++ b/lib/dashboard/widgets/donut_chart.dart
@@ -29,7 +29,7 @@ class DonutChart extends StatelessWidget {
   Widget build(BuildContext context) {
     // 画面縦幅の13%を円グラフの半径として使用
     final screenHeight = MediaQuery.of(context).size.height;
-    final chartRadius = screenHeight * 0.06;
+    final chartRadius = screenHeight * 0.047;
     
     final data = paymentData ?? categoryData;
     if (data == null || data.isEmpty) {
@@ -52,6 +52,10 @@ class DonutChart extends StatelessWidget {
       );
     }
 
+    // 売上降順（最大を先頭）にソート
+    filteredData.sort((a, b) =>
+        (((b as dynamic).sales) as num).compareTo(((a as dynamic).sales) as num));
+
     final total = filteredData.map((e) => (e as dynamic).sales).reduce((a, b) => a + b);
 
     return GestureDetector(
@@ -73,13 +77,15 @@ class DonutChart extends StatelessWidget {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                const SizedBox(height: 16),
+                const SizedBox(height: 1),
                 SizedBox(
                   // ドーナツグラフ全体のサイズ（画面縦幅の13%の直径）
                   width: chartRadius * 2,
                   height: chartRadius * 2,
                   child: PieChart(
                     PieChartData(
+                      // 12時から開始（時計回りに伸びる）
+                      startDegreeOffset: -90,
                       pieTouchData: PieTouchData(
                         enabled: true,
                         touchCallback: (FlTouchEvent event, pieTouchResponse) {
@@ -93,7 +99,7 @@ class DonutChart extends StatelessWidget {
                     ),
                   ),
                 ),
-                const SizedBox(height: 8),
+                const SizedBox(height: 16),
                 // 合計金額
                 Center(
                   child: Text(
@@ -120,6 +126,7 @@ class DonutChart extends StatelessWidget {
     );
   }
 
+  // data は build 内で降順ソート済み
   List<PieChartSectionData> _buildSections(List<dynamic> data, int total, double chartRadius) {
     final colors = [
       Colors.blue,
@@ -136,7 +143,7 @@ class DonutChart extends StatelessWidget {
       final index = entry.key;
       final item = entry.value;
       final color = colors[index % colors.length];
-      final percentage = ((item as dynamic).sales / total) * 100;
+      final percentage = ((item as dynamic).sales / total) * 100; // 凡例計算用
 
       return PieChartSectionData(
         color: color,

--- a/lib/dashboard/widgets/horizontal_bar_chart.dart
+++ b/lib/dashboard/widgets/horizontal_bar_chart.dart
@@ -34,9 +34,9 @@ class HorizontalBarChart extends StatelessWidget {
       );
     }
 
-    // 最大値を取得（スケール用）
+    // 最上位補助線を計算（15万円単位）
     final maxValue = categoryData.map((e) => e.sales).reduce((a, b) => a > b ? a : b);
-    final maxScale = (maxValue * 1.05).round();
+    final topValue = _calculateTopValue(maxValue);
 
     return GestureDetector(
       onTap: onTap,
@@ -46,7 +46,7 @@ class HorizontalBarChart extends StatelessWidget {
         child: BarChart(
           BarChartData(
             alignment: BarChartAlignment.spaceAround,
-            maxY: maxScale.toDouble(),
+            maxY: topValue.toDouble(),
             barTouchData: BarTouchData(
               enabled: true,
                   touchTooltipData: BarTouchTooltipData(
@@ -94,6 +94,7 @@ class HorizontalBarChart extends StatelessWidget {
                 sideTitles: SideTitles(
                   showTitles: true,
                   reservedSize: 60,
+                  interval: topValue / 3, // 補助線と同期
                   getTitlesWidget: (value, meta) {
                     return Text(
                       Formatters.formatNumber(value.toInt()),
@@ -111,7 +112,7 @@ class HorizontalBarChart extends StatelessWidget {
             gridData: FlGridData(
               show: true,
               drawVerticalLine: false,
-              horizontalInterval: maxScale / 5,
+              horizontalInterval: topValue / 3, // 4本の補助線（0, 1/3, 2/3, 1）
               getDrawingHorizontalLine: (value) {
                 return FlLine(
                   color: Colors.grey.withOpacity(0.2),
@@ -123,6 +124,21 @@ class HorizontalBarChart extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  /// 最上位補助線を計算（15万円単位）
+  int _calculateTopValue(int maxValue) {
+    if (maxValue <= 150000) {
+      return 150000; // 15万円
+    } else if (maxValue <= 300000) {
+      return 300000; // 30万円
+    } else if (maxValue <= 450000) {
+      return 450000; // 45万円
+    } else if (maxValue <= 600000) {
+      return 600000; // 60万円
+    } else {
+      return ((maxValue / 150000).ceil() * 150000);
+    }
   }
 
   List<BarChartGroupData> _buildBarGroups() {

--- a/lib/dashboard/widgets/line_chart.dart
+++ b/lib/dashboard/widgets/line_chart.dart
@@ -34,9 +34,23 @@ class LineChart extends StatelessWidget {
       );
     }
 
-    // 最大値を取得（スケール用）
-    final maxValue = dailyData.map((e) => e.sales).reduce((a, b) => a > b ? a : b);
-    final maxScale = (maxValue * 1.1).round();
+    // 最大売上を取得
+    final maxSales = dailyData.map((e) => e.sales).reduce((a, b) => a > b ? a : b);
+    
+    // 最上位補助線の金額を決定（20,000円単位）
+    int topValue;
+    if (maxSales <= 100000) {
+      topValue = 100000; // 100,000円
+    } else if (maxSales <= 200000) {
+      topValue = 200000; // 200,000円
+    } else if (maxSales <= 300000) {
+      topValue = 300000; // 300,000円
+    } else if (maxSales <= 400000) {
+      topValue = 400000; // 400,000円
+    } else {
+      // 400,000円を超える場合は100,000円刻みで増加
+      topValue = ((maxSales / 100000).ceil() * 100000);
+    }
 
     return GestureDetector(
       onTap: onTap,
@@ -82,7 +96,7 @@ class LineChart extends StatelessWidget {
                   gridData: fl_chart.FlGridData(
                     show: true,
                     drawVerticalLine: false,
-                    horizontalInterval: maxScale / 5,
+                    horizontalInterval: topValue / 5, // 5つの間隔で6本の補助線
                     getDrawingHorizontalLine: (value) {
                       return fl_chart.FlLine(
                         color: Colors.grey.withOpacity(0.2),
@@ -126,9 +140,11 @@ class LineChart extends StatelessWidget {
                       sideTitles: fl_chart.SideTitles(
                         showTitles: true,
                         reservedSize: 60,
+                        interval: topValue / 5, // 5つの間隔で6本の補助線
                         getTitlesWidget: (value, meta) {
+                          final intValue = value.toInt();
                           return Text(
-                            Formatters.formatNumber(value.toInt()),
+                            Formatters.formatNumber(intValue),
                             style: const TextStyle(
                               fontSize: 10,
                               color: Colors.grey,
@@ -148,7 +164,7 @@ class LineChart extends StatelessWidget {
                   minX: 0,
                   maxX: (dailyData.length - 1).toDouble(),
                   minY: 0,
-                  maxY: maxScale.toDouble(),
+                  maxY: topValue.toDouble(),
                   lineBarsData: [
                     fl_chart.LineChartBarData(
                       spots: _buildSpots(),

--- a/lib/dashboard/widgets/stacked_bar_chart.dart
+++ b/lib/dashboard/widgets/stacked_bar_chart.dart
@@ -9,7 +9,7 @@ import 'package:fl_chart/fl_chart.dart';
 import '../../data/models/analytics_models.dart';
 import '../../core/utils/formatters.dart';
 
-class StackedBarChart extends StatelessWidget {
+class StackedBarChart extends StatefulWidget {
   final List<MonthlyDoc> yearlyData;
   final String chartType; // 'payment', 'category', 'sales', 'orders', 'avgValue'
   final String title;
@@ -26,26 +26,76 @@ class StackedBarChart extends StatelessWidget {
   });
 
   @override
+  State<StackedBarChart> createState() => _StackedBarChartState();
+}
+
+class _StackedBarChartState extends State<StackedBarChart> {
+  late ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+    
+    // 初期スクロール位置を設定
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _setInitialScrollPosition();
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  /// 現在月に基づいて初期スクロール位置を設定
+  void _setInitialScrollPosition() {
+    if (!_isScrollableChart()) return;
+    
+    final currentMonth = DateTime.now().month;
+    final screenWidth = MediaQuery.of(context).size.width;
+    final monthWidth = 160.0; // 各月160px幅
+    
+    // 現在月が7-12月の場合、その月が画面左に表示されるまでスクロール
+    if (currentMonth >= 7) {
+      final targetMonth = currentMonth - 1; // 0ベースのインデックス
+      final scrollOffset = (targetMonth * monthWidth) - (screenWidth * 0.1); // 少し余白を残す
+      
+      if (scrollOffset > 0) {
+        _scrollController.animateTo(
+          scrollOffset,
+          duration: const Duration(milliseconds: 500),
+          curve: Curves.easeInOut,
+        );
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (yearlyData.isEmpty) {
+    if (widget.yearlyData.isEmpty) {
       return Container(
-        height: height ?? 280,
+        height: widget.height ?? 280,
         child: const Center(
           child: Text('データがありません'),
         ),
       );
     }
 
+    final topValue = _calculateTopValue();
+    final isScrollable = _isScrollableChart();
+
     return GestureDetector(
-      onTap: onTap,
+      onTap: widget.onTap,
       child: Container(
-        height: height ?? 280,
+        height: widget.height ?? 280,
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              title,
+              widget.title,
               style: const TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
@@ -53,87 +103,186 @@ class StackedBarChart extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             Expanded(
-              child: BarChart(
-                BarChartData(
-                  alignment: BarChartAlignment.spaceAround,
-                  maxY: _calculateMaxY(),
-                  barTouchData: BarTouchData(
-                    enabled: true,
-                  touchTooltipData: BarTouchTooltipData(
-                    tooltipRoundedRadius: 8,
-                      getTooltipItem: (group, groupIndex, rod, rodIndex) {
-                        final month = group.x.toInt();
-                        final value = rod.toY.toInt();
-                        return BarTooltipItem(
-                          '${month + 1}月\n${Formatters.formatCurrency(value)}',
-                          const TextStyle(
-                            color: Colors.white,
-                            fontSize: 12,
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                  titlesData: FlTitlesData(
-                    show: true,
-                    rightTitles: const AxisTitles(
-                      sideTitles: SideTitles(showTitles: false),
-                    ),
-                    topTitles: const AxisTitles(
-                      sideTitles: SideTitles(showTitles: false),
-                    ),
-                    bottomTitles: AxisTitles(
-                      sideTitles: SideTitles(
-                        showTitles: true,
-                        getTitlesWidget: (value, meta) {
-                          final month = value.toInt();
-                          if (month >= 0 && month < yearlyData.length) {
-                            return Padding(
-                              padding: const EdgeInsets.only(top: 8.0),
-                              child: Text(
-                                Formatters.formatMonth(month + 1),
-                                style: const TextStyle(
-                                  fontSize: 12,
-                                  color: Colors.grey,
+              child: isScrollable 
+                ? SingleChildScrollView(
+                    controller: _scrollController,
+                    scrollDirection: Axis.horizontal,
+                    child: SizedBox(
+                      width: widget.yearlyData.length * 160.0, // 各月160px幅（倍に拡大）
+                      child: Column(
+                        children: [
+                          // 凡例表示（決済別・カテゴリ別のみ）
+                          if (widget.chartType == 'payment' || widget.chartType == 'category')
+                            _buildLegend(),
+                          const SizedBox(height: 8),
+                          // グラフ
+                          Expanded(
+                            child: BarChart(
+                              BarChartData(
+                                alignment: BarChartAlignment.spaceAround,
+                                maxY: topValue.toDouble(),
+                                barTouchData: BarTouchData(
+                                  enabled: true,
+                                  touchTooltipData: BarTouchTooltipData(
+                                    tooltipRoundedRadius: 8,
+                                    getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                                      final month = group.x.toInt();
+                                      final value = rod.toY.toInt();
+                                      final monthName = _getMonthName(month);
+                                      return BarTooltipItem(
+                                        '$monthName\n${Formatters.formatCurrency(value)}',
+                                        const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 12,
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                ),
+                                titlesData: FlTitlesData(
+                                  show: true,
+                                  rightTitles: AxisTitles(
+                                    sideTitles: SideTitles(
+                                      showTitles: true,
+                                      reservedSize: 60,
+                                      interval: topValue / 5, // 補助線と同期
+                                      getTitlesWidget: (value, meta) {
+                                        return _buildYAxisLabel(value.toInt());
+                                      },
+                                    ),
+                                  ),
+                                  topTitles: const AxisTitles(
+                                    sideTitles: SideTitles(showTitles: false),
+                                  ),
+                                  bottomTitles: AxisTitles(
+                                    sideTitles: SideTitles(
+                                      showTitles: true,
+                                      getTitlesWidget: (value, meta) {
+                                        final month = value.toInt();
+                                        if (month >= 0 && month < widget.yearlyData.length) {
+                                          return Padding(
+                                            padding: const EdgeInsets.only(top: 8.0),
+                                            child: Text(
+                                              _getMonthName(month),
+                                              style: const TextStyle(
+                                                fontSize: 12,
+                                                color: Colors.black,
+                                              ),
+                                            ),
+                                          );
+                                        }
+                                        return const Text('');
+                                      },
+                                    ),
+                                  ),
+                                  leftTitles: AxisTitles(
+                                    sideTitles: SideTitles(
+                                      showTitles: true,
+                                      reservedSize: 60,
+                                      interval: topValue / 5, // 補助線と同期
+                                      getTitlesWidget: (value, meta) {
+                                        return _buildYAxisLabel(value.toInt());
+                                      },
+                                    ),
+                                  ),
+                                ),
+                                borderData: FlBorderData(show: false),
+                                barGroups: _buildBarGroups(),
+                                gridData: FlGridData(
+                                  show: true,
+                                  drawVerticalLine: false,
+                                  horizontalInterval: topValue / 5, // 6本の補助線
+                                  getDrawingHorizontalLine: (value) {
+                                    return FlLine(
+                                      color: Colors.grey.withOpacity(0.2),
+                                      strokeWidth: 1,
+                                    );
+                                  },
                                 ),
                               ),
-                            );
-                          }
-                          return const Text('');
-                        },
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    leftTitles: AxisTitles(
-                      sideTitles: SideTitles(
-                        showTitles: true,
-                        reservedSize: 60,
-                        getTitlesWidget: (value, meta) {
-                          return Text(
-                            Formatters.formatNumber(value.toInt()),
-                            style: const TextStyle(
-                              fontSize: 10,
-                              color: Colors.grey,
-                            ),
+                  )
+                : BarChart(
+                    BarChartData(
+                      alignment: BarChartAlignment.spaceAround,
+                      maxY: topValue.toDouble(),
+                      barTouchData: BarTouchData(
+                        enabled: true,
+                        touchTooltipData: BarTouchTooltipData(
+                          tooltipRoundedRadius: 8,
+                          getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                            final month = group.x.toInt();
+                            final value = rod.toY.toInt();
+                            final monthName = _getMonthName(month);
+                            return BarTooltipItem(
+                              '$monthName\n${Formatters.formatCurrency(value)}',
+                              const TextStyle(
+                                color: Colors.white,
+                                fontSize: 12,
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      titlesData: FlTitlesData(
+                        show: true,
+                        rightTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        topTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        bottomTitles: AxisTitles(
+                          sideTitles: SideTitles(
+                            showTitles: true,
+                                      getTitlesWidget: (value, meta) {
+                                        final month = value.toInt();
+                                        if (month >= 0 && month < widget.yearlyData.length) {
+                                          return Padding(
+                                            padding: const EdgeInsets.only(top: 8.0),
+                                            child: Text(
+                                              _getMonthName(month),
+                                              style: const TextStyle(
+                                                fontSize: 12,
+                                                color: Colors.black,
+                                              ),
+                                            ),
+                                          );
+                                        }
+                                        return const Text('');
+                                      },
+                          ),
+                        ),
+                        leftTitles: AxisTitles(
+                          sideTitles: SideTitles(
+                            showTitles: true,
+                            reservedSize: 60,
+                            interval: topValue / 5, // 補助線と同期
+                            getTitlesWidget: (value, meta) {
+                              return _buildYAxisLabel(value.toInt());
+                            },
+                          ),
+                        ),
+                      ),
+                      borderData: FlBorderData(show: false),
+                      barGroups: _buildBarGroups(),
+                      gridData: FlGridData(
+                        show: true,
+                        drawVerticalLine: false,
+                        horizontalInterval: topValue / 5, // 6本の補助線
+                        getDrawingHorizontalLine: (value) {
+                          return FlLine(
+                            color: Colors.grey.withOpacity(0.2),
+                            strokeWidth: 1,
                           );
                         },
                       ),
                     ),
                   ),
-                  borderData: FlBorderData(show: false),
-                  barGroups: _buildBarGroups(),
-                  gridData: FlGridData(
-                    show: true,
-                    drawVerticalLine: false,
-                    horizontalInterval: _calculateMaxY() / 5,
-                    getDrawingHorizontalLine: (value) {
-                      return FlLine(
-                        color: Colors.grey.withOpacity(0.2),
-                        strokeWidth: 1,
-                      );
-                    },
-                  ),
-                ),
-              ),
             ),
           ],
         ),
@@ -141,33 +290,283 @@ class StackedBarChart extends StatelessWidget {
     );
   }
 
-  double _calculateMaxY() {
-    switch (chartType) {
-      case 'payment':
-        return yearlyData.map((doc) => 
-          doc.paymentMethodSales.map((p) => p.sales).reduce((a, b) => a + b)
-        ).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
-      case 'category':
-        return yearlyData.map((doc) => 
-          doc.categorySales.map((c) => c.sales).reduce((a, b) => a + b)
-        ).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
+  /// 最上位補助線の値を計算（各グラフタイプに応じた単位）
+  int _calculateTopValue() {
+    switch (widget.chartType) {
       case 'sales':
-        return yearlyData.map((doc) => doc.grossSales).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
+        return _calculateSalesTopValue();
+      case 'payment':
+        return _calculatePaymentTopValue();
+      case 'category':
+        return _calculateCategoryTopValue();
       case 'orders':
-        return yearlyData.map((doc) => doc.orderCount).reduce((a, b) => a > b ? a : b).toDouble() * 1.1;
+        return _calculateOrdersTopValue();
       case 'avgValue':
-        return yearlyData.map((doc) => doc.avgOrderValue).reduce((a, b) => a > b ? a : b) * 1.1;
+        return _calculateAvgValueTopValue();
       default:
-        return 1000000.0;
+        return 1000000;
+    }
+  }
+
+  /// 総売上グラフの最上位補助線（50万円単位）
+  int _calculateSalesTopValue() {
+    final maxSales = widget.yearlyData.map((doc) => doc.grossSales).reduce((a, b) => a > b ? a : b);
+    
+    if (maxSales <= 2500000) {
+      return 2500000; // 250万円
+    } else if (maxSales <= 5000000) {
+      return 5000000; // 500万円
+    } else if (maxSales <= 7500000) {
+      return 7500000; // 750万円
+    } else if (maxSales <= 10000000) {
+      return 10000000; // 1000万円
+    } else {
+      return ((maxSales / 2500000).ceil() * 2500000);
+    }
+  }
+
+  /// 決済別グラフの最上位補助線（100万円単位）
+  int _calculatePaymentTopValue() {
+    // 決済別の全項目中の最大値を取得
+    int maxValue = 0;
+    for (final doc in widget.yearlyData) {
+      for (final payment in doc.paymentMethodSales) {
+        if (payment.sales > maxValue) {
+          maxValue = payment.sales;
+        }
+      }
+    }
+    
+    if (maxValue <= 1000000) {
+      return 1000000; // 100万円
+    } else if (maxValue <= 2000000) {
+      return 2000000; // 200万円
+    } else if (maxValue <= 3000000) {
+      return 3000000; // 300万円
+    } else if (maxValue <= 4000000) {
+      return 4000000; // 400万円
+    } else {
+      return ((maxValue / 1000000).ceil() * 1000000);
+    }
+  }
+
+  /// カテゴリ別グラフの最上位補助線（100万円単位）
+  int _calculateCategoryTopValue() {
+    // カテゴリ別の全項目中の最大値を取得
+    int maxValue = 0;
+    for (final doc in widget.yearlyData) {
+      for (final category in doc.categorySales) {
+        if (category.sales > maxValue) {
+          maxValue = category.sales;
+        }
+      }
+    }
+    
+    if (maxValue <= 1000000) {
+      return 1000000; // 100万円
+    } else if (maxValue <= 2000000) {
+      return 2000000; // 200万円
+    } else if (maxValue <= 3000000) {
+      return 3000000; // 300万円
+    } else if (maxValue <= 4000000) {
+      return 4000000; // 400万円
+    } else {
+      return ((maxValue / 1000000).ceil() * 1000000);
+    }
+  }
+
+  /// 来店数グラフの最上位補助線（50人単位）
+  int _calculateOrdersTopValue() {
+    final maxOrders = widget.yearlyData.map((doc) => doc.orderCount).reduce((a, b) => a > b ? a : b);
+    
+    if (maxOrders <= 250) {
+      return 250; // 250人
+    } else if (maxOrders <= 500) {
+      return 500; // 500人
+    } else if (maxOrders <= 750) {
+      return 750; // 750人
+    } else if (maxOrders <= 1000) {
+      return 1000; // 1000人
+    } else {
+      return ((maxOrders / 250).ceil() * 250);
+    }
+  }
+
+  /// 平均客単価グラフの最上位補助線（500円単位）
+  int _calculateAvgValueTopValue() {
+    final maxAvgValue = widget.yearlyData.map((doc) => doc.avgOrderValue).reduce((a, b) => a > b ? a : b);
+    
+    if (maxAvgValue <= 2500) {
+      return 2500; // 2500円
+    } else if (maxAvgValue <= 5000) {
+      return 5000; // 5000円
+    } else if (maxAvgValue <= 7500) {
+      return 7500; // 7500円
+    } else if (maxAvgValue <= 10000) {
+      return 10000; // 10000円
+    } else {
+      return ((maxAvgValue / 2500).ceil() * 2500);
+    }
+  }
+
+  /// スクロール可能なグラフかどうかを判定
+  bool _isScrollableChart() {
+    return widget.chartType == 'payment' || widget.chartType == 'category';
+  }
+
+  /// 月名を取得（YYYY-MM形式のMM部分を参照）
+  String _getMonthName(int monthIndex) {
+    if (monthIndex >= 0 && monthIndex < widget.yearlyData.length) {
+      final doc = widget.yearlyData[monthIndex];
+      // MonthlyDocのmonthIdから月を取得
+      final monthId = doc.monthId; // YYYY-MM形式
+      if (monthId != null && monthId.isNotEmpty) {
+        final parts = monthId.split('-');
+        if (parts.length == 2) {
+          final month = int.parse(parts[1]);
+          return '${month}月';
+        }
+      }
+      // フォールバック: インデックス+1
+      return '${monthIndex + 1}月';
+    }
+    return '${monthIndex + 1}月';
+  }
+
+  /// 凡例を構築（決済別・カテゴリ別グラフ用）
+  Widget _buildLegend() {
+    if (widget.yearlyData.isEmpty) return const SizedBox.shrink();
+    
+    final firstDoc = widget.yearlyData.first;
+    List<Map<String, dynamic>> legendItems = [];
+    
+    if (widget.chartType == 'payment') {
+      final colors = [Colors.blue, Colors.green, Colors.orange, Colors.purple, Colors.red, Colors.teal];
+      legendItems = firstDoc.paymentMethodSales.asMap().entries.map((entry) {
+        final index = entry.key;
+        final payment = entry.value;
+        return {
+          'color': colors[index % colors.length],
+          'name': payment.method,
+        };
+      }).toList();
+    } else if (widget.chartType == 'category') {
+      final colors = [Colors.blue, Colors.green, Colors.orange, Colors.purple];
+      legendItems = firstDoc.categorySales.asMap().entries.map((entry) {
+        final index = entry.key;
+        final category = entry.value;
+        return {
+          'color': colors[index % colors.length],
+          'name': category.category,
+        };
+      }).toList();
+    }
+    
+    return Container(
+      height: 30,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: legendItems.map((item) {
+            return Container(
+              margin: const EdgeInsets.only(right: 16),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: item['color'],
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    item['name'],
+                    style: const TextStyle(
+                      fontSize: 10,
+                      color: Colors.black,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  /// Y軸ラベルを構築
+  Widget _buildYAxisLabel(int value) {
+    if (value == 0) {
+      return const Text(
+        '0',
+        style: TextStyle(
+          fontSize: 10,
+          color: Colors.black,
+        ),
+      );
+    }
+
+    switch (widget.chartType) {
+      case 'sales':
+        // 万円表記
+        final manValue = value ~/ 10000;
+        return Text(
+          '${manValue}万',
+          style: const TextStyle(
+            fontSize: 10,
+            color: Colors.black,
+          ),
+        );
+      case 'payment':
+      case 'category':
+        // 万円表記
+        final manValue = value ~/ 10000;
+        return Text(
+          '${manValue}万',
+          style: const TextStyle(
+            fontSize: 10,
+            color: Colors.black,
+          ),
+        );
+      case 'orders':
+        // 人数表記
+        return Text(
+          Formatters.formatNumber(value),
+          style: const TextStyle(
+            fontSize: 10,
+            color: Colors.black,
+          ),
+        );
+      case 'avgValue':
+        // 円表記
+        return Text(
+          Formatters.formatNumber(value),
+          style: const TextStyle(
+            fontSize: 10,
+            color: Colors.black,
+          ),
+        );
+      default:
+        return Text(
+          Formatters.formatNumber(value),
+          style: const TextStyle(
+            fontSize: 10,
+            color: Colors.black,
+          ),
+        );
     }
   }
 
   List<BarChartGroupData> _buildBarGroups() {
-    return yearlyData.asMap().entries.map((entry) {
+    return widget.yearlyData.asMap().entries.map((entry) {
       final index = entry.key;
       final data = entry.value;
       
-      switch (chartType) {
+      switch (widget.chartType) {
         case 'payment':
           return _buildPaymentBarGroup(index, data);
         case 'category':

--- a/lib/dashboard/yearly/yearly_overview_page.dart
+++ b/lib/dashboard/yearly/yearly_overview_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/repo/analytics_repository.dart';
 import '../../data/models/analytics_models.dart';
+import '../../app_config/dashboard_config.dart';
 import '../widgets/stacked_bar_chart.dart';
 import '../../core/widgets/skeleton.dart';
 
@@ -72,17 +73,67 @@ class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
   @override
   Widget build(BuildContext context) {
     final yearlyDataAsync = ref.watch(yearlyDataProvider(_selectedYear));
+    final config = DashboardConfig();
 
     return Scaffold(
+      backgroundColor: config.bodyBackgroundColor,
       appBar: AppBar(
         title: Text('${_selectedYear}年 年間比較'),
-        backgroundColor: Colors.blue[700],
-        foregroundColor: Colors.white,
+        backgroundColor: config.appBarColor,
+        foregroundColor: config.appBarTextColor,
         centerTitle: true,
-        bottom: TabBar(
-          controller: _tabController,
-          isScrollable: true,
-          tabs: _tabs.map((tab) => Tab(text: tab)).toList(),
+        actions: [
+          // 年選択をAppBar右端に配置
+          Container(
+            margin: const EdgeInsets.only(right: 16),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  '対象年: ',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                  ),
+                ),
+                DropdownButton<String>(
+                  value: _selectedYear,
+                  dropdownColor: Colors.blue[700],
+                  underline: Container(), // 下線を削除
+                  icon: const Icon(
+                    Icons.arrow_drop_down,
+                    color: Colors.white,
+                  ),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                  ),
+                  onChanged: (String? newValue) {
+                    if (newValue != null) {
+                      setState(() {
+                        _selectedYear = newValue;
+                      });
+                    }
+                  },
+                  items: _generateYearItems(),
+                ),
+              ],
+            ),
+          ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: Container(
+            color: config.tabBackgroundColor,
+            child: TabBar(
+              controller: _tabController,
+              isScrollable: true,
+              labelColor: config.tabTextColor,
+              unselectedLabelColor: Colors.grey[400],
+              indicatorColor: config.tabColor,
+              tabs: _tabs.map((tab) => Tab(text: tab)).toList(),
+            ),
+          ),
         ),
       ),
       body: yearlyDataAsync.when(
@@ -119,64 +170,43 @@ class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
   }
 
   Widget _buildYearlyContent(BuildContext context, List<MonthlyDoc> yearlyData) {
-    return Column(
+    return TabBarView(
+      controller: _tabController,
       children: [
-        // 年選択
-        _buildYearSelector(context),
-        // タブコンテンツ
-        Expanded(
-          child: TabBarView(
-            controller: _tabController,
-            children: [
-              // 総売上
-              _buildSalesChart(yearlyData),
-              // 決済別
-              _buildPaymentChart(yearlyData),
-              // カテゴリ別
-              _buildCategoryChart(yearlyData),
-              // 来店数
-              _buildOrdersChart(yearlyData),
-              // 平均客単価
-              _buildAvgValueChart(yearlyData),
-            ],
-          ),
-        ),
+        // 総売上
+        _buildSalesChart(yearlyData),
+        // 決済別
+        _buildPaymentChart(yearlyData),
+        // カテゴリ別
+        _buildCategoryChart(yearlyData),
+        // 来店数
+        _buildOrdersChart(yearlyData),
+        // 平均客単価
+        _buildAvgValueChart(yearlyData),
       ],
     );
   }
 
-  Widget _buildYearSelector(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      child: Row(
-        children: [
-          const Text(
-            '対象年: ',
-            style: TextStyle(
+  /// 年選択のアイテムを生成（2025年~現在年まで）
+  List<DropdownMenuItem<String>> _generateYearItems() {
+    final currentYear = DateTime.now().year;
+    final startYear = 2025;
+    
+    return List.generate(
+      currentYear - startYear + 1,
+      (index) {
+        final year = startYear + index;
+        return DropdownMenuItem<String>(
+          value: year.toString(),
+          child: Text(
+            '${year}年',
+            style: const TextStyle(
+              color: Colors.white,
               fontSize: 16,
-              fontWeight: FontWeight.bold,
             ),
           ),
-          const SizedBox(width: 8),
-          DropdownButton<String>(
-            value: _selectedYear,
-            onChanged: (String? newValue) {
-              if (newValue != null) {
-                setState(() {
-                  _selectedYear = newValue;
-                });
-              }
-            },
-            items: List.generate(5, (index) {
-              final year = DateTime.now().year - index;
-              return DropdownMenuItem<String>(
-                value: year.toString(),
-                child: Text('${year}年'),
-              );
-            }),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 
@@ -186,7 +216,7 @@ class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
       child: StackedBarChart(
         yearlyData: yearlyData,
         chartType: 'sales',
-        title: '年間総売上推移',
+        title: '月間総売上推移',
         onTap: () {
           // 詳細アクション（必要に応じて実装）
         },
@@ -200,7 +230,7 @@ class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
       child: StackedBarChart(
         yearlyData: yearlyData,
         chartType: 'payment',
-        title: '年間決済別推移',
+        title: '月間決済別推移',
         onTap: () {
           // 詳細アクション（必要に応じて実装）
         },
@@ -214,7 +244,7 @@ class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
       child: StackedBarChart(
         yearlyData: yearlyData,
         chartType: 'category',
-        title: '年間カテゴリ別推移',
+        title: '月間カテゴリ別推移',
         onTap: () {
           // 詳細アクション（必要に応じて実装）
         },
@@ -228,7 +258,7 @@ class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
       child: StackedBarChart(
         yearlyData: yearlyData,
         chartType: 'orders',
-        title: '年間来店数推移',
+        title: '月間来店数推移',
         onTap: () {
           // 詳細アクション（必要に応じて実装）
         },
@@ -242,7 +272,7 @@ class _YearlyOverviewPageState extends ConsumerState<YearlyOverviewPage>
       child: StackedBarChart(
         yearlyData: yearlyData,
         chartType: 'avgValue',
-        title: '年間平均客単価推移',
+        title: '月間平均客単価推移',
         onTap: () {
           // 詳細アクション（必要に応じて実装）
         },

--- a/lib/data/models/analytics_models.dart
+++ b/lib/data/models/analytics_models.dart
@@ -10,6 +10,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 /// 参照パス: analyticsMonthly/{YYYY-MM}
 /// 使用フィールド: grossSales, orderCount, avgOrderValue, itemsSales, sideGameChipSales, tournamentsSales, extraCostSales, dailySales, paymentTotals
 class MonthlyDoc {
+  final String monthId; // YYYY-MM形式
   final int grossSales;
   final int orderCount;
   final double avgOrderValue;
@@ -23,6 +24,7 @@ class MonthlyDoc {
   final DateTime updatedAt;
 
   MonthlyDoc({
+    required this.monthId,
     required this.grossSales,
     required this.orderCount,
     required this.avgOrderValue,
@@ -39,6 +41,7 @@ class MonthlyDoc {
   factory MonthlyDoc.fromFirestore(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
     return MonthlyDoc(
+      monthId: doc.id, // ドキュメントID（YYYY-MM形式）
       grossSales: data['grossSales'] ?? 0,
       orderCount: data['orderCount'] ?? 0,
       avgOrderValue: (data['avgOrderValue'] ?? 0).toDouble(),

--- a/lib/data/repo/analytics_repository.dart
+++ b/lib/data/repo/analytics_repository.dart
@@ -31,7 +31,7 @@ class AnalyticsRepository {
   /// 指定年（YYYY）に存在する月次Docをすべて取得（1〜12のうち存在分）
   /// 参照パス: analyticsMonthly/{YYYY-01} 〜 analyticsMonthly/{YYYY-12}
   /// 使用フィールド: grossSales, orderCount, avgOrderValue, paymentTotals
-  /// 戻り値の構造: List<MonthlyDoc>（存在する月のみ、日付昇順）
+  /// 戻り値の構造: List<MonthlyDoc>（12ヶ月分、データなしの月は空のMonthlyDoc）
   Future<List<MonthlyDoc>> fetchYearlyMonthlyDocs(String yyyy) async {
     try {
       final months = <String>[];
@@ -42,7 +42,34 @@ class AnalyticsRepository {
       final futures = months.map((month) => fetchMonthlyDoc(month));
       final results = await Future.wait(futures);
       
-      return results.where((doc) => doc != null).cast<MonthlyDoc>().toList();
+      // 12ヶ月分のデータを作成（データなしの月は空のMonthlyDoc）
+      final yearlyDocs = <MonthlyDoc>[];
+      for (int i = 0; i < 12; i++) {
+        final monthId = months[i];
+        final doc = results[i];
+        
+        if (doc != null) {
+          yearlyDocs.add(doc);
+        } else {
+          // データなしの月は空のMonthlyDocを作成
+          yearlyDocs.add(MonthlyDoc(
+            monthId: monthId,
+            grossSales: 0,
+            orderCount: 0,
+            avgOrderValue: 0.0,
+            itemsSales: 0,
+            sideGameChipSales: 0,
+            tournamentsSales: 0,
+            extraCostSales: 0,
+            dailySales: {},
+            paymentTotals: {},
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ));
+        }
+      }
+      
+      return yearlyDocs;
     } catch (e) {
       throw Exception('年間データの取得に失敗しました: $e');
     }


### PR DESCRIPTION
- 月選択機能を全ページに追加（daily_trend, category_overview, category_item, payment_breakdown）
- 月表示形式をYYYY/MM形式に統一
- タブ機能をpayment_breakdownとcategory_overviewに追加
- DashboardConfigでUIカラーを一元管理
- 円グラフを12時開始、時計回り、売上降順に表示
- Y軸ラベルを固定、X軸をスクロール可能に
- AppBarと各カード間にマージンを追加