### PR TITLE
LIFFアプリにURLハッシュナビゲーション機能を追加

### DIFF
--- a/public/user/index.html
+++ b/public/user/index.html
@@ -410,6 +410,27 @@
         pageElement.classList.add('active');
       }
 
+      // URLハッシュナビゲーション処理
+      function handleHashNavigation() {
+        const hash = window.location.hash;
+        
+        // ハッシュに応じてページ遷移
+        if (hash === '#qr') {
+          showQRCode();
+        } else if (hash === '#order') {
+          showOrderPage();
+        } else if (hash === '#history') {
+          window.showOrderHistory();
+        } else if (hash === '#tournament') {
+          window.showTournament();
+        } else if (hash === '#profile') {
+          window.showProfilePage();
+        } else {
+          // ハッシュがない場合はホームページを表示
+          showPage(homePageEl);
+        }
+      }
+
       // store登録確認関数
       async function checkStoreRegistration() {
         try {
@@ -450,12 +471,19 @@
             
             await updateUserLoginStatus(user.uid);
             
-            showPage(homePageEl);
-            
             // 入店状態を定期的に更新（永続化のため）
             setInterval(() => {
               updateCheckinStatusUI(user.uid);
             }, 30000); // 30秒ごとに更新
+            
+            // URLハッシュをチェックして適切なページに遷移
+            try {
+              handleHashNavigation();
+            } catch (error) {
+              // ハッシュナビゲーションでエラーが発生した場合はホームページを表示
+              console.error('Hash navigation error:', error);
+              showPage(homePageEl);
+            }
           } else {
             // 未登録の場合
             showPage(registrationPageEl);
@@ -609,7 +637,18 @@
       // ページ遷移関数
       window.showHomePage = () => showPage(homePageEl);
       window.showQRPage = () => showPage(qrPageEl);
-      window.showOrderPage = () => showPage(orderPageEl);
+      window.showOrderPage = async () => {
+        showPage(orderPageEl);
+        
+        // カテゴリー情報とメニューデータを動的に取得
+        const menuData = await loadCategoriesAndMenuData();
+        
+        if (menuData && menuData.categories.length > 0) {
+          // デフォルトで最初のカテゴリを表示
+          const defaultCategory = menuData.categories[0];
+          loadMenuItems(defaultCategory, menuData.allMenuItems);
+        }
+      };
       window.showOrderHistory = () => {
         showPage(orderHistoryPageEl);
         loadOrderHistory();


### PR DESCRIPTION
- URLハッシュ(#qr, #order, #history等)から直接ページ遷移可能に
- showOrderPage()でメニューデータ読み込み処理を追加
- エラーハンドリングを追加してハッシュナビゲーション失敗時はホームページを表示