### PR TITLE
feat: トーナメント終了処理の検証機能とプライズ確定処理の改善

### DIFF
--- a/functions/src/callables/index.ts
+++ b/functions/src/callables/index.ts
@@ -24,6 +24,7 @@ export { setPrizeData } from './setPrizeData';
 export { getRankingData } from './getRankingData';
 export { setRankingData } from './setRankingData';
 export { endTournament } from './endTournament';
+export { validateEndTournament } from './validateEndTournament';
 export { startAccounting, completeAccounting } from './accounting';
 export { verifyPaymentSplit } from './verifyPaymentSplit';
 export { updateActiveBill } from './updateActiveBill';

--- a/functions/src/callables/validateEndTournament.ts
+++ b/functions/src/callables/validateEndTournament.ts
@@ -1,0 +1,185 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const validateEndTournament = onCall(async (request) => {
+  try {
+    const { tournamentId } = request.data;
+    
+    if (!tournamentId) {
+      throw new HttpsError('invalid-argument', 'tournamentId is required');
+    }
+    
+    const db = getFirestore();
+    
+    // 1. scheduledTournamentsコレクションのstatusをチェック
+    const tournamentDoc = await db.collection('scheduledTournaments').doc(tournamentId).get();
+    
+    if (!tournamentDoc.exists) {
+      throw new HttpsError('not-found', 'Tournament not found');
+    }
+    
+    const tournamentData = tournamentDoc.data();
+    const status = tournamentData?.status;
+    
+    let validationResult = {
+      isValid: false,
+      status,
+      requiresPrize: false,
+      requiresRanking: false,
+      prizeData: null as any,
+      rankingData: null as any,
+      message: '',
+      errorType: '' as 'ended' | 'not_registered' | 'no_prize' | 'no_ranking' | 'complete',
+    };
+    
+    // ステータスチェック
+    if (status === 'ended') {
+      validationResult.errorType = 'ended';
+      validationResult.message = 'このトーナメントは既に終了済みです';
+      return { success: false, ...validationResult };
+    }
+    
+    if (status !== 'registered') {
+      validationResult.errorType = 'not_registered';
+      validationResult.message = `レジスト前であるため終了処理を行うべきではない可能性が高いです。\n現在のステータス: ${status}`;
+      validationResult.status = status;
+      return { success: false, ...validationResult };
+    }
+    
+    // 2. プライズ確定のチェック
+    const mainViewDoc = await db
+      .collection('scheduledTournaments')
+      .doc(tournamentId)
+      .collection('views')
+      .doc('main')
+      .get();
+    
+    if (!mainViewDoc.exists) {
+      throw new HttpsError('not-found', 'Main view data not found');
+    }
+    
+    const mainViewData = mainViewDoc.data();
+    
+    // pointTypeを取得（mainViewDataまたはtournamentData.snapshotから）
+    const pointType = mainViewData?.pointType || tournamentData?.snapshot?.pointType || 'pointA';
+    
+    // プライズプールの存在確認（1stPrizeフィールドの存在確認）
+    if (!mainViewData?.prizePool || mainViewData['1stPrize'] === undefined) {
+      validationResult.errorType = 'no_prize';
+      validationResult.message = 'プライズの確定が行われていない状態です。プライズの確定を行ってください';
+      validationResult.requiresPrize = true;
+      return { success: false, ...validationResult };
+    }
+    
+    // プライズ情報を保存
+    validationResult.prizeData = mainViewData;
+    
+    // 3. 順位確定のチェック
+    // XstPlayerUid, XstPlayerName, XstPrize のフィールドを確認
+    const rankingFields = {
+      playerUids: [] as Array<{ key: string; value: any; rank: number }>,
+      playerNames: [] as Array<{ key: string; value: any; rank: number }>,
+      prizes: [] as Array<{ key: string; value: any; rank: number }>,
+    };
+    
+    for (const [key, value] of Object.entries(mainViewData || {})) {
+      if (key.endsWith('stPlayerUid')) {
+        const rank = parseInt(key.replace('stPlayerUid', ''));
+        rankingFields.playerUids.push({ key, value, rank });
+      } else if (key.endsWith('stPlayerName')) {
+        const rank = parseInt(key.replace('stPlayerName', ''));
+        rankingFields.playerNames.push({ key, value, rank });
+      } else if (key.endsWith('stPrize')) {
+        const rank = parseInt(key.replace('stPrize', ''));
+        rankingFields.prizes.push({ key, value, rank });
+      }
+    }
+    
+    // 各フィールドの個数を確認し、値が入っているかチェック
+    const playerUidsCount = rankingFields.playerUids.length;
+    const playerNamesCount = rankingFields.playerNames.length;
+    const prizesCount = rankingFields.prizes.length;
+    
+    // いずれかのフィールドが不完全な場合
+    if (playerUidsCount === 0 || playerNamesCount === 0 || prizesCount === 0) {
+      validationResult.errorType = 'no_ranking';
+      validationResult.message = '順位情報が不完全です';
+      validationResult.requiresRanking = true;
+      validationResult.rankingData = {
+        pointType: pointType,
+        fields: rankingFields,
+      };
+      return { success: false, ...validationResult };
+    }
+    
+    // 各順位について、Uid, Name, Prizeが全て存在し、値が入っているか確認
+    const missingFields = [];
+    const missingRanks: number[] = []; // 未確定の順位リスト
+    const existingRankings = [];
+    const maxRank = Math.max(playerUidsCount, playerNamesCount, prizesCount);
+    
+    for (let i = 1; i <= maxRank; i++) {
+      const uidKey = `${i}stPlayerUid`;
+      const nameKey = `${i}stPlayerName`;
+      const prizeKey = `${i}stPrize`;
+      
+      const uid = mainViewData?.[uidKey];
+      const name = mainViewData?.[nameKey];
+      const prize = mainViewData?.[prizeKey];
+      
+      if (uid && name && prize !== undefined && prize !== null) {
+        existingRankings.push({
+          rank: i,
+          playerName: name,
+          prize: prize,
+        });
+      } else {
+        // XstPlayerUidまたはXstPlayerNameがnullの場合、その順位を未確定リストに追加
+        if (!uid || !name) {
+          if (!missingRanks.includes(i)) {
+            missingRanks.push(i);
+          }
+        }
+        if (!uid) missingFields.push(`${i}stPlayerUid`);
+        if (!name) missingFields.push(`${i}stPlayerName`);
+        if (prize === undefined || prize === null) missingFields.push(`${i}stPrize`);
+      }
+    }
+    
+    if (missingFields.length > 0) {
+      validationResult.errorType = 'no_ranking';
+      validationResult.message = '一部の順位情報が未確定です';
+      validationResult.requiresRanking = true;
+      validationResult.rankingData = {
+        pointType: pointType,
+        existingRankings,
+        missingFields,
+        missingRanks: missingRanks.sort((a, b) => a - b), // 順位順にソート
+      };
+      return { success: false, ...validationResult };
+    }
+    
+    // 4. 全ての確認が完了
+    validationResult.isValid = true;
+    validationResult.errorType = 'complete';
+    validationResult.rankingData = {
+      pointType: pointType,
+      rankings: existingRankings,
+    };
+    
+    return {
+      success: true,
+      ...validationResult,
+    };
+    
+  } catch (error) {
+    console.error('validateEndTournament error:', error);
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'Internal server error');
+  }
+});
+

--- a/functions/src/close_process/index.ts
+++ b/functions/src/close_process/index.ts
@@ -1,0 +1,3 @@
+export { resetAllTables } from './resetAllTables';
+export { resetAllSideGames } from './resetAllSideGames';
+

--- a/functions/src/close_process/resetAllSideGames.ts
+++ b/functions/src/close_process/resetAllSideGames.ts
@@ -1,0 +1,74 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const resetAllSideGames = onCall(async (request) => {
+  try {
+    const db = getFirestore();
+    
+    console.log('=== 全サイドゲームリセット開始 ===');
+    
+    // 1. sideGameコレクションの全ドキュメントを取得
+    const sideGamesSnapshot = await db.collection('sideGame').get();
+    
+    if (sideGamesSnapshot.empty) {
+      return {
+        success: true,
+        message: 'サイドゲームが存在しません',
+        count: 0,
+      };
+    }
+    
+    // 2. 各ドキュメントを更新
+    const batch = db.batch();
+    let count = 0;
+    
+    sideGamesSnapshot.forEach((doc) => {
+      const sideGameRef = db.collection('sideGame').doc(doc.id);
+      const data = doc.data();
+      
+      // 更新データを準備
+      const updateData: { [key: string]: any } = {
+        active: false,
+        updatedAt: new Date(),
+      };
+      
+      // seatsフィールドの存在確認
+      if (data.seats && typeof data.seats === 'object') {
+        const seats = data.seats as { [key: string]: any };
+        
+        // seatXXPokerNameとseatXXUserIdを検索してnullにする
+        for (const key in seats) {
+          if (key.includes('PokerName') || key.includes('UserId')) {
+            updateData[`seats.${key}`] = null;
+          }
+        }
+      }
+      
+      // gameNameフィールドをnullにする（存在する場合）
+      if (data.gameName !== undefined) {
+        updateData.gameName = null;
+      }
+      
+      batch.update(sideGameRef, updateData);
+      count++;
+    });
+    
+    await batch.commit();
+    
+    console.log(`全サイドゲームリセット完了: ${count}件`);
+    
+    return {
+      success: true,
+      message: `${count}件のサイドゲームをリセットしました`,
+      count,
+    };
+    
+  } catch (error) {
+    console.error('resetAllSideGamesエラー:', error);
+    throw new HttpsError(
+      'internal',
+      `全サイドゲームリセットに失敗しました: ${error}`
+    );
+  }
+});
+

--- a/functions/src/close_process/resetAllTables.ts
+++ b/functions/src/close_process/resetAllTables.ts
@@ -1,0 +1,52 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore } from 'firebase-admin/firestore';
+
+export const resetAllTables = onCall(async (request) => {
+  try {
+    const db = getFirestore();
+    
+    console.log('=== 全テーブルリセット開始 ===');
+    
+    // 1. tablesコレクションの全ドキュメントを取得
+    const tablesSnapshot = await db.collection('tables').get();
+    
+    if (tablesSnapshot.empty) {
+      return {
+        success: true,
+        message: 'テーブルが存在しません',
+        count: 0,
+      };
+    }
+    
+    // 2. バッチ更新を実行
+    const batch = db.batch();
+    let count = 0;
+    
+    tablesSnapshot.forEach((doc) => {
+      const tableRef = db.collection('tables').doc(doc.id);
+      batch.update(tableRef, {
+        status: 'open',
+        updatedAt: new Date(),
+      });
+      count++;
+    });
+    
+    await batch.commit();
+    
+    console.log(`全テーブルリセット完了: ${count}件`);
+    
+    return {
+      success: true,
+      message: `${count}件のテーブルを開店状態にリセットしました`,
+      count,
+    };
+    
+  } catch (error) {
+    console.error('resetAllTablesエラー:', error);
+    throw new HttpsError(
+      'internal',
+      `全テーブルリセットに失敗しました: ${error}`
+    );
+  }
+});
+

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,6 +34,8 @@ export * from "./attendance";
 export * from "./callables";
 // アナリティクス関連関数
 export * from "./analytics";
+// クロージング処理関連関数
+export * from "./close_process";
 
 // トーナメント時間管理システム（Phase1）
 import { onRequest } from 'firebase-functions/v2/https';

--- a/lib/Home/systemSettingsPage.dart
+++ b/lib/Home/systemSettingsPage.dart
@@ -91,6 +91,42 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
               ),
             ),
             const SizedBox(height: 16),
+            
+            // 全テーブルリセット機能
+            Card(
+              child: ListTile(
+                leading: const Icon(Icons.refresh, color: Colors.teal),
+                title: const Text('全テーブルリセット'),
+                subtitle: const Text('全テーブルのステータスをopenに戻します'),
+                trailing: _isProcessing
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.arrow_forward_ios),
+                onTap: _isProcessing ? null : _showResetTablesDialog,
+              ),
+            ),
+            const SizedBox(height: 16),
+            
+            // 全サイドゲームリセット機能
+            Card(
+              child: ListTile(
+                leading: const Icon(Icons.casino, color: Colors.indigo),
+                title: const Text('全サイドゲームリセット'),
+                subtitle: const Text('全サイドゲームをクリアします'),
+                trailing: _isProcessing
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.arrow_forward_ios),
+                onTap: _isProcessing ? null : _showResetSideGamesDialog,
+              ),
+            ),
+            const SizedBox(height: 16),
             const Text(
               '注意事項',
               style: TextStyle(
@@ -104,6 +140,8 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
               '• 一時テーブル作成: トーナメント用のテーブルを動的に作成\n'
               '• settledBills移管: 本機能は開発用です\n'
               '• ダミーデータ生成: テスト用のダミーデータを生成します\n'
+              '• 全テーブルリセット: 全テーブルのステータスをopenにリセット\n'
+              '• 全サイドゲームリセット: 全サイドゲームをクリア\n'
               '• 本番環境では自動バッチ処理で実行されます\n'
               '• 処理中は他の操作を行わないでください',
               style: TextStyle(color: Colors.red),
@@ -318,6 +356,210 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
         _showErrorDialog('認証エラー: ログインしてから再度お試しください。');
       } else {
         _showErrorDialog('4ヶ月分のダミーデータ生成に失敗しました: $e');
+      }
+    } finally {
+      setState(() {
+        _isProcessing = false;
+      });
+    }
+  }
+
+  void _showResetTablesDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('最終確認'),
+          content: const Text(
+            '全テーブルのステータスをopenにリセットしますか？\n\n'
+            'すべてのテーブルが開店状態に戻ります。\n'
+            '処理中は他の操作を行わないでください。',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('キャンセル'),
+            ),
+            ElevatedButton(
+              onPressed: _executeResetTables,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.teal,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('実行'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _executeResetTables() async {
+    Navigator.of(context).pop(); // ダイアログを閉じる
+    
+    // 認証状態を確認
+    final user = _auth.currentUser;
+    if (user == null) {
+      _showErrorDialog('認証が必要です。ログインしてから再度お試しください。');
+      return;
+    }
+    
+    setState(() {
+      _isProcessing = true;
+    });
+
+    // ローディングダイアログを表示
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return const AlertDialog(
+          content: Row(
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(width: 16),
+              Text('全テーブルリセット中...'),
+            ],
+          ),
+        );
+      },
+    );
+
+    try {
+      debugPrint('全テーブルリセット開始');
+      
+      final callable = _functions.httpsCallable('resetAllTables');
+      final result = await callable.call();
+
+      debugPrint('全テーブルリセット結果: $result');
+
+      // ローディングダイアログを閉じる
+      Navigator.of(context).pop();
+
+      if (result.data['success'] == true) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('全テーブルリセット完了: ${result.data['message'] ?? ''}'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
+      } else {
+        _showErrorDialog(result.data['error'] ?? '全テーブルリセットに失敗しました');
+      }
+    } catch (e) {
+      debugPrint('全テーブルリセットエラー: $e');
+      
+      // ローディングダイアログを閉じる
+      Navigator.of(context).pop();
+      
+      if (e.toString().contains('UNAUTHENTICATED')) {
+        _showErrorDialog('認証エラー: ログインしてから再度お試しください。');
+      } else {
+        _showErrorDialog('全テーブルリセットに失敗しました: $e');
+      }
+    } finally {
+      setState(() {
+        _isProcessing = false;
+      });
+    }
+  }
+
+  void _showResetSideGamesDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('最終確認'),
+          content: const Text(
+            '全サイドゲームをリセットしますか？\n\n'
+            'すべてのサイドゲームの座席情報とゲーム情報がクリアされます。\n'
+            '処理中は他の操作を行わないでください。',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('キャンセル'),
+            ),
+            ElevatedButton(
+              onPressed: _executeResetSideGames,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.indigo,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('実行'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _executeResetSideGames() async {
+    Navigator.of(context).pop(); // ダイアログを閉じる
+    
+    // 認証状態を確認
+    final user = _auth.currentUser;
+    if (user == null) {
+      _showErrorDialog('認証が必要です。ログインしてから再度お試しください。');
+      return;
+    }
+    
+    setState(() {
+      _isProcessing = true;
+    });
+
+    // ローディングダイアログを表示
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return const AlertDialog(
+          content: Row(
+            children: [
+              CircularProgressIndicator(),
+              SizedBox(width: 16),
+              Text('全サイドゲームリセット中...'),
+            ],
+          ),
+        );
+      },
+    );
+
+    try {
+      debugPrint('全サイドゲームリセット開始');
+      
+      final callable = _functions.httpsCallable('resetAllSideGames');
+      final result = await callable.call();
+
+      debugPrint('全サイドゲームリセット結果: $result');
+
+      // ローディングダイアログを閉じる
+      Navigator.of(context).pop();
+
+      if (result.data['success'] == true) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('全サイドゲームリセット完了: ${result.data['message'] ?? ''}'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
+      } else {
+        _showErrorDialog(result.data['error'] ?? '全サイドゲームリセットに失敗しました');
+      }
+    } catch (e) {
+      debugPrint('全サイドゲームリセットエラー: $e');
+      
+      // ローディングダイアログを閉じる
+      Navigator.of(context).pop();
+      
+      if (e.toString().contains('UNAUTHENTICATED')) {
+        _showErrorDialog('認証エラー: ログインしてから再度お試しください。');
+      } else {
+        _showErrorDialog('全サイドゲームリセットに失敗しました: $e');
       }
     } finally {
       setState(() {

--- a/lib/tournament/active/pages/prize_setup_page.dart
+++ b/lib/tournament/active/pages/prize_setup_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_functions/cloud_functions.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:amuse_app_template/globalConstant.dart';
 
 class PrizeSetupPage extends StatefulWidget {
@@ -33,6 +34,9 @@ class _PrizeSetupPageState extends State<PrizeSetupPage> {
   // 計算結果
   int _totalRevenue = 0; // 売上合計
   int _totalPrizePool = 0; // プライズプール合計
+  
+  // 既存プライズ情報
+  Map<String, int>? _existingPrizes; // 既存のXstPrize情報
   
   @override
   void initState() {
@@ -90,6 +94,7 @@ class _PrizeSetupPageState extends State<PrizeSetupPage> {
           }
           
           _calculateInitialValues();
+          _checkExistingPrizes();
         });
         print('=== End PrizeSetup データ型デバッグ ===');
       } else {
@@ -206,6 +211,21 @@ class _PrizeSetupPageState extends State<PrizeSetupPage> {
     _updatePrizeDistribution();
   }
   
+  void _checkExistingPrizes() {
+    // XstPrizeフィールドの存在確認
+    _existingPrizes = {};
+    
+    if (_mainViewData != null) {
+      for (int i = 1; i <= 10; i++) {
+        final prizeKey = '${i}stPrize';
+        final prizeValue = _mainViewData![prizeKey];
+        if (prizeValue != null && prizeValue is num) {
+          _existingPrizes![prizeKey] = prizeValue.toInt();
+        }
+      }
+    }
+  }
+  
   void _updatePrizeDistribution() {
     print('=== _updatePrizeDistribution デバッグ ===');
     print('_totalRevenue: $_totalRevenue');
@@ -249,6 +269,50 @@ class _PrizeSetupPageState extends State<PrizeSetupPage> {
         _isLoading = true;
         _errorMessage = null;
       });
+      
+      // プライズ受け取り人数とusersフィールドの個数をチェック
+      final usersListDoc = await FirebaseFirestore.instance
+          .collection('scheduledTournaments')
+          .doc(widget.tournamentId)
+          .collection('views')
+          .doc('usersList')
+          .get();
+      
+      if (usersListDoc.exists) {
+        final usersListData = usersListDoc.data();
+        final users = usersListData?['users'];
+        
+        if (users is Map) {
+          final usersCount = users.length;
+          
+          if (_prizeReceiverCount > usersCount) {
+            // エラーダイアログを表示
+            if (mounted) {
+              await showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('エラー'),
+                  content: Text(
+                    'プライズ受け取り人数（$_prizeReceiverCount人）が'
+                    '参加者数（$usersCount人）を上回っています。\n'
+                    'プライズ受け取り人数を参加者数以下に設定してください。',
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('OK'),
+                    ),
+                  ],
+                ),
+              );
+            }
+            setState(() {
+              _isLoading = false;
+            });
+            return;
+          }
+        }
+      }
       
       // プライズデータを準備
       Map<String, dynamic> prizeData = {
@@ -332,6 +396,11 @@ class _PrizeSetupPageState extends State<PrizeSetupPage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      // 既存プライズ警告
+                      if (_existingPrizes != null && _existingPrizes!.isNotEmpty)
+                        _buildExistingPrizeWarning(),
+                      if (_existingPrizes != null && _existingPrizes!.isNotEmpty)
+                        const SizedBox(height: 16),
                       // 売上情報
                       _buildRevenueSection(),
                       const SizedBox(height: 24),
@@ -544,6 +613,56 @@ class _PrizeSetupPageState extends State<PrizeSetupPage> {
                 ),
               );
             }),
+          ],
+        ),
+      ),
+    );
+  }
+  
+  Widget _buildExistingPrizeWarning() {
+    // 既存のプライズ情報を順番に表示
+    final sortedPrizes = _existingPrizes!.entries.toList()
+      ..sort((a, b) {
+        // "1stPrize", "2stPrize" などの順位を抽出してソート
+        final aRank = int.tryParse(a.key.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0;
+        final bRank = int.tryParse(b.key.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0;
+        return aRank.compareTo(bRank);
+      });
+    
+    String prizeText = 'すでにプライズが確定しています。\n'
+        '※修正する場合にのみ、パラメータ等を修正し確定ボタンを押下してください。\n\n';
+    
+    for (final entry in sortedPrizes) {
+      final rank = entry.key.replaceAll(RegExp(r'[^0-9]'), '');
+      prizeText += '${rank}st: ${entry.value}\n';
+    }
+    
+    return Card(
+      color: Colors.orange.shade50,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.warning, color: Colors.orange.shade700),
+                const SizedBox(width: 8),
+                Text(
+                  '既存プライズ情報',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.orange.shade700,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              prizeText,
+              style: TextStyle(color: Colors.orange.shade900),
+            ),
           ],
         ),
       ),

--- a/lib/tournament/active/pages/tournament_home_page.dart
+++ b/lib/tournament/active/pages/tournament_home_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
-
 import 'package:amuse_app_template/tournament/active/widgets/dialogs/add_table_dialog.dart';
 import 'package:amuse_app_template/tournament/active/widgets/dialogs/assign_seat_dialog.dart';
 import 'package:amuse_app_template/tournament/active/widgets/dialogs/reseat_all_dialog.dart';
@@ -215,14 +214,81 @@ class _TournamentHomePageState extends State<TournamentHomePage> {
     );
   }
 
-  void _confirmPrizes() {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => PrizeSetupPage(
-          tournamentId: widget.tournamentId,
+  void _confirmPrizes() async {
+    // 遷移前にstatusをチェック
+    try {
+      final tournamentDoc = await FirebaseFirestore.instance
+          .collection('scheduledTournaments')
+          .doc(widget.tournamentId)
+          .get();
+      
+      if (!tournamentDoc.exists) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('トーナメントデータが見つかりません')),
+        );
+        return;
+      }
+      
+      final tournamentData = tournamentDoc.data();
+      final status = tournamentData?['status'] ?? '';
+      
+      if (status == 'ended') {
+        // 既に終了済み
+        await showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('エラー'),
+            content: const Text(
+              'すでに終了済みのためプライズを変更できません。\n'
+              '付与するポイントを修正する場合は該当のuser情報を直接修正してください',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+        return;
+      } else if (status == 'scheduled' || status == 'running') {
+        // レジスト前または実行中の確認
+        final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('確認'),
+            content: const Text('レジスト前ですがプライズを確定してよろしいですか？'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('キャンセル'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('確認'),
+              ),
+            ],
+          ),
+        );
+        
+        if (confirmed != true) {
+          return;
+        }
+      }
+      // status == 'registered' の場合はそのまま遷移
+      
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => PrizeSetupPage(
+            tournamentId: widget.tournamentId,
+          ),
         ),
-      ),
-    );
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('エラーが発生しました: $e')),
+      );
+    }
   }
 
   void _confirmRankings() async {
@@ -267,13 +333,191 @@ class _TournamentHomePageState extends State<TournamentHomePage> {
     }
   }
 
+  bool _isEndingTournament = false;
+
   void _endTournament() async {
-    // 確認ダイアログを表示
-    final confirmed = await showDialog<bool>(
+    // 二重押下防止
+    if (_isEndingTournament) return;
+    
+    // 検証処理を実行
+    await _validateAndEndTournament();
+  }
+
+  Future<void> _validateAndEndTournament() async {
+    setState(() {
+      _isEndingTournament = true;
+    });
+
+    try {
+      // 検証ダイアログを表示（画面中央）
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+
+      // 1. 終了前検証
+      final functions = FirebaseFunctions.instance;
+      final validateCallable = functions.httpsCallable('validateEndTournament');
+      final validateResult = await validateCallable.call({
+        'tournamentId': widget.tournamentId,
+      });
+      
+      Navigator.of(context).pop(); // 検証ダイアログを閉じる
+      
+      if (validateResult.data['success'] != true) {
+        final errorType = validateResult.data['errorType'];
+        final message = validateResult.data['message'] ?? '検証に失敗しました';
+        
+        if (errorType == 'ended') {
+          // 既に終了済み
+          await showDialog(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('エラー'),
+              content: Text(message),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('OK'),
+                ),
+              ],
+            ),
+          );
+          return;
+        } else if (errorType == 'not_registered') {
+          // レジスト前の確認
+          final shouldForceEnd = await _showNotRegisteredDialog(message, validateResult.data['status']);
+          if (!shouldForceEnd) {
+            return;
+          }
+          // 強制終了の場合、さらに確認
+          final confirmed = await _showForceEndConfirmationDialog(
+            'レジスト前のトーナメントの終了処理を行って問題ないでしょうか？',
+          );
+          if (!confirmed) {
+            return;
+          }
+        } else if (errorType == 'no_prize') {
+          // プライズ未確定
+          final action = await _showNoPrizeDialog();
+          if (action == 'cancel') {
+            return;
+          } else if (action == 'prize') {
+            // プライズ確定画面へ遷移
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => PrizeSetupPage(
+                  tournamentId: widget.tournamentId,
+                ),
+              ),
+            );
+            return;
+          }
+          // action == 'force_end' の場合は処理を続ける
+          final confirmed = await _showForceEndConfirmationDialog(
+            'プライズ未確定のトーナメントの強制終了処理を実行しますか？',
+          );
+          if (!confirmed) {
+            return;
+          }
+        } else if (errorType == 'no_ranking') {
+          // 順位未確定
+          final rankingData = validateResult.data['rankingData'];
+          final action = await _showNoRankingDialog(rankingData);
+          if (action == 'cancel') {
+            return;
+          } else if (action == 'ranking') {
+            // 順位確定画面へ遷移
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => RankingSetupPage(
+                  tournamentId: widget.tournamentId,
+                ),
+              ),
+            );
+            return;
+          }
+          // action == 'force_end' の場合は処理を続ける
+          final confirmed = await _showForceEndConfirmationDialog(
+            '順位未確定のトーナメントの強制終了処理を実行しますか？',
+          );
+          if (!confirmed) {
+            return;
+          }
+        } else {
+          // その他のエラー
+          await showDialog(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('エラー'),
+              content: Text(message),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('OK'),
+                ),
+              ],
+            ),
+          );
+          return;
+        }
+      } else {
+        // 検証成功 - 順位情報を表示して最終確認
+        final rankingData = validateResult.data['rankingData'];
+        final confirmed = await _showFinalConfirmationDialog(rankingData);
+        if (!confirmed) {
+          return;
+        }
+      }
+      
+      // 処理中ダイアログを表示（画面中央）
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+      
+      // 終了処理を実行
+      final endCallable = functions.httpsCallable('endTournament');
+      final endResult = await endCallable.call({
+        'tournamentId': widget.tournamentId,
+      });
+      
+      Navigator.of(context).pop(); // 処理中ダイアログを閉じる
+      
+      if (endResult.data['success'] == true) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('トーナメントを終了しました')),
+        );
+        Navigator.of(context).pop();
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(endResult.data['error'] ?? '終了処理に失敗しました')),
+        );
+      }
+    } catch (e) {
+      Navigator.of(context).pop(); // ダイアログを閉じる
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('エラーが発生しました: $e')),
+      );
+    } finally {
+      setState(() {
+        _isEndingTournament = false;
+      });
+    }
+  }
+
+  Future<bool> _showNotRegisteredDialog(String message, String status) async {
+    return await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('トーナメント終了'),
-        content: const Text('トーナメントの終了処理を行いますか？'),
+        title: const Text('確認'),
+        content: Text('$message\n\n強制終了しますか？'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -281,37 +525,138 @@ class _TournamentHomePageState extends State<TournamentHomePage> {
           ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('終了処理を行う'),
+            child: const Text('強制終了'),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
           ),
         ],
       ),
-    );
+    ) ?? false;
+  }
+
+  Future<bool> _showForceEndConfirmationDialog(String message) async {
+    return await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('最終確認'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('確認'),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+          ),
+        ],
+      ),
+    ) ?? false;
+  }
+
+  Future<String> _showNoPrizeDialog() async {
+    return await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('プライズ未確定'),
+        content: const Text('プライズの確定が行われていない状態です。\nプライズの確定を行ってください'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop('cancel'),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop('prize'),
+            child: const Text('プライズ確定画面へ'),
+            style: TextButton.styleFrom(foregroundColor: Colors.purple),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop('force_end'),
+            child: const Text('強制終了'),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+          ),
+        ],
+      ),
+    ) ?? 'cancel';
+  }
+
+  Future<String> _showNoRankingDialog(dynamic rankingData) async {
+    final pointType = rankingData?['pointType'] ?? 'pointA';
+    final existingRankings = rankingData?['existingRankings'] ?? [];
+    final missingRanks = rankingData?['missingRanks'] ?? [];
     
-    if (confirmed != true) return;
+    String content = '順位情報が未確定です。\n\n';
     
-    try {
-      // 終了処理を実行
-      final functions = FirebaseFunctions.instance;
-      final callable = functions.httpsCallable('endTournament');
-      final result = await callable.call({
-        'tournamentId': widget.tournamentId,
-      });
-      
-      if (result.data['success'] == true) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('トーナメントを終了しました')),
-        );
-        Navigator.of(context).pop();
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(result.data['error'] ?? '終了処理に失敗しました')),
-        );
+    if (existingRankings.isNotEmpty) {
+      content += '確定済み順位:\n';
+      for (final ranking in existingRankings) {
+        final playerName = ranking['playerName'] ?? '（未設定）';
+        content += '${ranking['rank']}位: $playerName　$pointType: ${ranking['prize']}\n';
       }
-    } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('エラーが発生しました: $e')),
-      );
     }
+    
+    if (missingRanks.isNotEmpty) {
+      final rankTexts = missingRanks.map((rank) => '${rank}位').join('、');
+      content += '\n$rankTextsのプレイヤーが未確定です。';
+    }
+    
+    return await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('順位未確定'),
+        content: SingleChildScrollView(
+          child: Text(content),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop('cancel'),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop('ranking'),
+            child: const Text('順位確定'),
+            style: TextButton.styleFrom(foregroundColor: Colors.indigo),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop('force_end'),
+            child: const Text('強制終了'),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+          ),
+        ],
+      ),
+    ) ?? 'cancel';
+  }
+
+  Future<bool> _showFinalConfirmationDialog(dynamic rankingData) async {
+    final pointType = rankingData?['pointType'] ?? 'pointA';
+    final rankings = rankingData?['rankings'] ?? [];
+    
+    String content = 'pointを付与し、トーナメントの終了処理を進めますか？\n\n';
+    content += '順位:\n';
+    for (final ranking in rankings) {
+      final playerName = ranking['playerName'] ?? '（未設定）';
+      content += '${ranking['rank']}位: $playerName　$pointType: ${ranking['prize']}\n';
+    }
+    
+    return await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('最終確認'),
+        content: SingleChildScrollView(
+          child: Text(content),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('確認'),
+          ),
+        ],
+      ),
+    ) ?? false;
   }
 
   /// 統計アイテムを構築
@@ -645,7 +990,7 @@ class _TournamentHomePageState extends State<TournamentHomePage> {
                   ),
                   const SizedBox(height: 8),
                   ElevatedButton.icon(
-                    onPressed: () => _endTournament(),
+                    onPressed: _isEndingTournament ? null : () => _endTournament(),
                     icon: const Icon(Icons.stop),
                     label: const Text('終了処理'),
                     style: ElevatedButton.styleFrom(


### PR DESCRIPTION
- トーナメント終了前の多段階検証機能を追加（validateEndTournament Cloud Function）
  - ステータスチェック（ended/registered/scheduled/running）
  - プライズ確定チェック（1stPrizeフィールド）
  - 順位確定チェック（XstPlayerUid/XstPlayerName/XstPrize）
  - 順位未確定ダイアログの表示を改善（「X位、Y位...のプレイヤーが未確定です」）

- プライズ確定処理の改善
  - 遷移前のstatusチェック（ended/scheduled/running/registered）
  - 既存プライズ情報の警告表示
  - プライズ受け取り人数と参加者数のバリデーション

- システム設定ページにリセット機能を追加
  - 全テーブルリセット機能（resetAllTables）
  - 全サイドゲームリセット機能（resetAllSideGames）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pre-end validation for tournaments, new system reset callables, and UI flows improving prize setup and end processing.
> 
> - **Backend (Cloud Functions)**:
>   - **End Validation**: Add `validateEndTournament` callable to check `status`, prize pool (`1stPrize`), and ranking fields (`XstPlayerUid/Name/Prize`) before ending.
>   - **Closing Tools**: Introduce `close_process` with `resetAllTables` (sets `tables/*:status=open`) and `resetAllSideGames` (clears `sideGame/*` seats, `gameName`, sets `active=false`).
>   - **Exports**: Export new callables via `functions/src/callables/index.ts` and `functions/src/index.ts`.
> - **Frontend (Flutter)**:
>   - **System Settings**: Add actions to trigger `resetAllTables` and `resetAllSideGames` with confirmation and progress dialogs in `Home/systemSettingsPage.dart`.
>   - **Prize Setup** (`prize_setup_page.dart`):
>     - Show existing prize warning; load existing `XstPrize` values.
>     - Validate prize receiver count against participants (`views/usersList.users`).
>   - **Tournament Home** (`tournament_home_page.dart`):
>     - Check tournament `status` before navigating to prize setup.
>     - Replace end flow with pre-validation via `validateEndTournament`, detailed dialogs for `ended/not_registered/no_prize/no_ranking`, final confirmation, and double-submit guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f56c486f63699d389bb5c42973c992d48664bef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->