### PR TITLE
refactor: todaysBills作成時の支払い方法をpaymentMethodsByAmountに統一

### DIFF
--- a/functions/src/userLogin/manualCheckIn.ts
+++ b/functions/src/userLogin/manualCheckIn.ts
@@ -124,7 +124,7 @@ export const manualCheckIn = onCall(async (request) => {
       date: today, // JST日付
       // 共通フィールド
       sideGameChip: [],
-      paymentMethodsByCategory: [],
+      paymentMethodsByAmount: {},
       schemaVersion: "1.0", // globalConstant.dartのschemaVersionを参照
     } as Record<string, unknown>;
 

--- a/functions/src/userLogin/processVisitByQR.ts
+++ b/functions/src/userLogin/processVisitByQR.ts
@@ -152,7 +152,7 @@ export const processVisitByQR = onCall(async (request) => {
               date: today, // JST日付
               // 共通フィールド
               sideGameChip: [],
-              paymentMethodsByCategory: [],
+              paymentMethodsByAmount: {},
               schemaVersion: "1.0", // globalConstant.dartのschemaVersionを参照
             } as Record<string, unknown>;
 


### PR DESCRIPTION
- manualCheckIn.tsとprocessVisitByQR.tsでpaymentMethodsByCategoryをpaymentMethodsByAmountに変更
- 新規作成されるtodaysBillsドキュメントは全てpaymentMethodsByAmount形式を使用
- 既存データの読み取りは後方互換性のため両方式に対応を維持