### PR TITLE
feat: すべてのCloud Functionsにサーバサイドガードを実装、tournamentsフィールドの型チェック修正、table…

### DIFF
--- a/functions/src/attendance/createClockInRecord.ts
+++ b/functions/src/attendance/createClockInRecord.ts
@@ -1,8 +1,27 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { CallableRequest } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const createClockInRecord = onCall(async (request: CallableRequest) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.staff_entry_exit: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'staff_entry_exit');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'スタッフ出退勤操作の権限がありません');
+  }
+
   try {
     const { data } = request;
     

--- a/functions/src/attendance/createManualClockInRecord.ts
+++ b/functions/src/attendance/createManualClockInRecord.ts
@@ -1,8 +1,27 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { CallableRequest } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const createManualClockInRecord = onCall(async (request: CallableRequest) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.staff_entry_exit: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'staff_entry_exit');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'スタッフ出退勤操作の権限がありません');
+  }
+
   try {
     const { data } = request;
     

--- a/functions/src/attendance/updateClockOutRecord.ts
+++ b/functions/src/attendance/updateClockOutRecord.ts
@@ -1,8 +1,27 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { CallableRequest } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const updateClockOutRecord = onCall(async (request: CallableRequest) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.staff_entry_exit: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'staff_entry_exit');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'スタッフ出退勤操作の権限がありません');
+  }
+
   try {
     const { data } = request;
     

--- a/functions/src/attendance/updateManualClockOutRecord.ts
+++ b/functions/src/attendance/updateManualClockOutRecord.ts
@@ -1,8 +1,27 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { CallableRequest } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const updateManualClockOutRecord = onCall(async (request: CallableRequest) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.staff_entry_exit: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'staff_entry_exit');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'スタッフ出退勤操作の権限がありません');
+  }
+
   try {
     const { data } = request;
     

--- a/functions/src/callables/accounting.ts
+++ b/functions/src/callables/accounting.ts
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const db = admin.firestore();
 
@@ -98,7 +99,7 @@ const CompleteAccountingSchema = z.object({
 
 /**
  * 会計開始処理
- * 管理者権限を持つユーザーのみが実行可能
+ * 管理者権限またはaccountingオプションを持つデバイスのみが実行可能
  */
 export const startAccounting = onCall(async (request) => {
   // 認証チェック
@@ -106,18 +107,18 @@ export const startAccounting = onCall(async (request) => {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
 
-  const adminId = request.auth.uid;
+  const callerUid = request.auth.uid;
 
   try {
-    // デバイス権限の確認（role: adminのみ）
-    const deviceQuery = await db.collection('devices')
-      .where('uid', '==', adminId)
-      .where('role', '==', 'admin')
-      .limit(1)
-      .get();
+    // デバイス権限の確認（role: admin または options.accounting: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
 
-    if (deviceQuery.empty) {
-      throw new HttpsError('permission-denied', '管理者権限がありません');
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'accounting');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '会計管理の権限がありません');
     }
 
     // 入力データの検証
@@ -238,7 +239,7 @@ export const startAccounting = onCall(async (request) => {
     // 会計開始時刻とカテゴリ別支払い方法を記録（statusは変更しない）
     await billRef.update({
       accountingStartedAt: admin.firestore.FieldValue.serverTimestamp(),
-      accountingStartedBy: adminId,
+      accountingStartedBy: callerUid,
       paymentMethodsByAmount: normalizedPaymentMethods,
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
     });
@@ -263,7 +264,7 @@ export const startAccounting = onCall(async (request) => {
 
 /**
  * 会計完了処理
- * 管理者権限を持つユーザーのみが実行可能
+ * 管理者権限またはaccountingオプションを持つデバイスのみが実行可能
  */
 export const completeAccounting = onCall(async (request) => {
   // 認証チェック
@@ -271,18 +272,18 @@ export const completeAccounting = onCall(async (request) => {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
 
-  const adminId = request.auth.uid;
+  const callerUid = request.auth.uid;
 
   try {
-    // デバイス権限の確認（role: adminのみ）
-    const deviceQuery = await db.collection('devices')
-      .where('uid', '==', adminId)
-      .where('role', '==', 'admin')
-      .limit(1)
-      .get();
+    // デバイス権限の確認（role: admin または options.accounting: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
 
-    if (deviceQuery.empty) {
-      throw new HttpsError('permission-denied', '管理者権限がありません');
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'accounting');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '会計管理の権限がありません');
     }
 
     // 入力データの検証
@@ -319,7 +320,7 @@ export const completeAccounting = onCall(async (request) => {
       accountingStartedAt: billData.accountingStartedAt,
       accountingCompletedAt: admin.firestore.FieldValue.serverTimestamp(),
       accountingStartedBy: billData.accountingStartedBy,
-      accountingCompletedBy: adminId,
+      accountingCompletedBy: callerUid,
       paymentMethodsByAmount: billData.paymentMethodsByAmount || {},
       // カテゴリ別の詳細データも保存
       extraCost: billData.extraCost || [],
@@ -334,7 +335,7 @@ export const completeAccounting = onCall(async (request) => {
       status: 'settled',
       settledAt: admin.firestore.FieldValue.serverTimestamp(),
       accountingCompletedAt: admin.firestore.FieldValue.serverTimestamp(),
-      accountingCompletedBy: adminId,
+      accountingCompletedBy: callerUid,
       accountingHistoryId: accountingHistoryRef.id,
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
     });

--- a/functions/src/callables/addTableToTournament.ts
+++ b/functions/src/callables/addTableToTournament.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 // 入力スキーマ
 const addTableToTournamentSchema = z.object({
@@ -9,7 +10,25 @@ const addTableToTournamentSchema = z.object({
   maxSeats: z.number().int().positive(),
 });
 
-export const addTableToTournament = functions.https.onCall(async (data, context) => {
+export const addTableToTournament = functions.https.onCall(async (data, context: any) => {
+  // 認証チェック
+  if (!context || !context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = context.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new functions.https.HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new functions.https.HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     console.log('=== 卓追加: 受信データ ===');
     console.log('data:', data);

--- a/functions/src/callables/addon.ts
+++ b/functions/src/callables/addon.ts
@@ -1,6 +1,7 @@
-import { onCall } from 'firebase-functions/v2/https';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const addonSchema = z.object({
   tournamentId: z.string(),
@@ -9,7 +10,25 @@ const addonSchema = z.object({
 });
 
 export const addon = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     console.log('=== Addon処理開始 ===');
     // 循環参照を避けるため、必要なデータのみをログ出力
     const { data } = request;

--- a/functions/src/callables/api.pause.ts
+++ b/functions/src/callables/api.pause.ts
@@ -1,6 +1,7 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { z } from "zod";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 // 入力スキーマの定義
 const pauseTournamentSchema = z.object({
@@ -8,7 +9,25 @@ const pauseTournamentSchema = z.object({
 });
 
 export const pauseTournament = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     // 入力データの検証
     const validatedData = pauseTournamentSchema.parse(request.data);
     const { tournamentId } = validatedData;

--- a/functions/src/callables/api.resume.ts
+++ b/functions/src/callables/api.resume.ts
@@ -1,6 +1,7 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { z } from "zod";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 // 入力スキーマの定義
 const resumeTournamentSchema = z.object({
@@ -8,7 +9,25 @@ const resumeTournamentSchema = z.object({
 });
 
 export const resumeTournament = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     // 入力データの検証
     const validatedData = resumeTournamentSchema.parse(request.data);
     const { tournamentId } = validatedData;

--- a/functions/src/callables/assignSeatToPlayer.ts
+++ b/functions/src/callables/assignSeatToPlayer.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 // 入力スキーマ
 const assignSeatToPlayerSchema = z.object({
@@ -10,7 +11,25 @@ const assignSeatToPlayerSchema = z.object({
   seatNumber: z.number().int().positive(),
 });
 
-export const assignSeatToPlayer = functions.https.onCall(async (data, context) => {
+export const assignSeatToPlayer = functions.https.onCall(async (data, context: any) => {
+  // 認証チェック
+  if (!context || !context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = context.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new functions.https.HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new functions.https.HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     // 正しいデータの場所を取得
     const actualData = data.data || data;

--- a/functions/src/callables/bulkAddon.ts
+++ b/functions/src/callables/bulkAddon.ts
@@ -1,6 +1,7 @@
-import { onCall } from 'firebase-functions/v2/https';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const bulkAddonSchema = z.object({
   tournamentId: z.string(),
@@ -11,7 +12,25 @@ const bulkAddonSchema = z.object({
 });
 
 export const bulkAddon = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     console.log('=== まとめてAddon処理開始 ===');
     // 循環参照を避けるため、必要なデータのみをログ出力
     const { data } = request;

--- a/functions/src/callables/bustAndExit.ts
+++ b/functions/src/callables/bustAndExit.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 // 入力データの検証スキーマ
 const bustAndExitSchema = z.object({
@@ -10,7 +11,25 @@ const bustAndExitSchema = z.object({
   userId: z.string().min(1),
 });
 
-export const bustAndExit = functions.https.onCall(async (data, context) => {
+export const bustAndExit = functions.https.onCall(async (data, context: any) => {
+  // 認証チェック
+  if (!context || !context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = context.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new functions.https.HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new functions.https.HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     console.log('=== Bust&退席処理開始 ===');
     console.log('受信データ:', data);

--- a/functions/src/callables/bustAndReentry.ts
+++ b/functions/src/callables/bustAndReentry.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 // 入力スキーマ
 const bustAndReentrySchema = z.object({
@@ -10,7 +11,25 @@ const bustAndReentrySchema = z.object({
   seatNumber: z.number().int().positive(),
 });
 
-export const bustAndReentry = functions.https.onCall(async (data, context) => {
+export const bustAndReentry = functions.https.onCall(async (data, context: any) => {
+  // 認証チェック
+  if (!context || !context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = context.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new functions.https.HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new functions.https.HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     // 正しいデータの場所を取得
     const actualData = data.data || data;

--- a/functions/src/callables/cancelAccounting.ts
+++ b/functions/src/callables/cancelAccounting.ts
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const db = admin.firestore();
 
@@ -24,18 +25,18 @@ export const cancelAccounting = onCall(async (request) => {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
 
-  const adminId = request.auth.uid;
+  const callerUid = request.auth.uid;
 
   try {
-    // デバイス権限の確認（role: adminのみ）
-    const deviceQuery = await db.collection('devices')
-      .where('uid', '==', adminId)
-      .where('role', '==', 'admin')
-      .limit(1)
-      .get();
+    // デバイス権限の確認（role: admin または options.accounting: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
 
-    if (deviceQuery.empty) {
-      throw new HttpsError('permission-denied', '管理者権限がありません');
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'accounting');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '会計管理の権限がありません');
     }
 
     // 入力データの検証
@@ -80,7 +81,7 @@ export const cancelAccounting = onCall(async (request) => {
         const cancelRecord = {
           type: 'cancel',
           reason: reason,
-          cancelledBy: adminId,
+          cancelledBy: callerUid,
           cancelledAt: admin.firestore.FieldValue.serverTimestamp(),
           includeRefund: includeRefund,
           refundAmount: includeRefund ? refundAmount : 0,
@@ -193,7 +194,7 @@ export const cancelAccounting = onCall(async (request) => {
         transaction.update(billRef, {
           refundAmount: refundAmount,
           refundedAt: admin.firestore.FieldValue.serverTimestamp(),
-          refundedBy: adminId,
+          refundedBy: callerUid,
         });
 
         // accountingHistoryに返金記録を追加
@@ -202,7 +203,7 @@ export const cancelAccounting = onCall(async (request) => {
           const refundRecord = {
             type: 'refund',
             amount: refundAmount,
-            refundedBy: adminId,
+            refundedBy: callerUid,
             refundedAt: admin.firestore.FieldValue.serverTimestamp(),
             reason: `キャンセルに伴う返金: ${reason}`,
           };

--- a/functions/src/callables/createScheduledTournament.ts
+++ b/functions/src/callables/createScheduledTournament.ts
@@ -2,6 +2,7 @@ import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { z } from "zod";
 import { enqueueStartTask, enqueueRegistTask } from "../lib/tasks";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 // 入力スキーマの定義
 const createScheduledTournamentSchema = z.object({
@@ -30,7 +31,25 @@ const createScheduledTournamentSchema = z.object({
 // type CreateScheduledTournamentInput = z.infer<typeof createScheduledTournamentSchema>;
 
 export const createScheduledTournament = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     // デバッグ: 受信データをログ出力
     console.log('受信データ:', JSON.stringify(request.data, null, 2));
     

--- a/functions/src/callables/createTemporaryTable.ts
+++ b/functions/src/callables/createTemporaryTable.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 // 入力スキーマ
 const createTemporaryTableSchema = z.object({
@@ -8,7 +9,25 @@ const createTemporaryTableSchema = z.object({
   maxSeats: z.number().int().positive().max(20, '最大座席数は20までです'),
 });
 
-export const createTemporaryTable = functions.https.onCall(async (data, context) => {
+export const createTemporaryTable = functions.https.onCall(async (data, context: any) => {
+  // 認証チェック
+  if (!context || !context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = context.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new functions.https.HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new functions.https.HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     // 正しいデータの場所を取得
     const actualData = data.data || data;

--- a/functions/src/callables/createTournamentRecurrence.ts
+++ b/functions/src/callables/createTournamentRecurrence.ts
@@ -2,6 +2,7 @@ import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { z } from "zod";
 import { enqueueStartTask, enqueueRegistTask } from "../lib/tasks";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 // 入力スキーマの定義
 const createTournamentRecurrenceSchema = z.object({
@@ -26,6 +27,24 @@ const createTournamentRecurrenceSchema = z.object({
 });
 
 export const createTournamentRecurrence = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     console.log('=== 定期開催トーナメント作成開始 ===');
     console.log('受信データ:', JSON.stringify(request.data, null, 2));

--- a/functions/src/callables/deleteTournamentRecurrence.ts
+++ b/functions/src/callables/deleteTournamentRecurrence.ts
@@ -1,6 +1,7 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
 import { z } from "zod";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 // 入力スキーマの定義
 const deleteTournamentRecurrenceSchema = z.object({
@@ -8,6 +9,24 @@ const deleteTournamentRecurrenceSchema = z.object({
 });
 
 export const deleteTournamentRecurrence = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     console.log('=== 定期開催トーナメント削除開始 ===');
     console.log('受信データ:', JSON.stringify(request.data, null, 2));

--- a/functions/src/callables/endTournament.ts
+++ b/functions/src/callables/endTournament.ts
@@ -1,8 +1,27 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const endTournament = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     const { tournamentId } = request.data;
     
     if (!tournamentId) {

--- a/functions/src/callables/getScheduledTournamentsForEdit.ts
+++ b/functions/src/callables/getScheduledTournamentsForEdit.ts
@@ -1,6 +1,7 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
 import { z } from "zod";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 const getScheduledTournamentsForEditSchema = z.object({
   type: z.enum(['recurrence', 'template']),
@@ -8,6 +9,24 @@ const getScheduledTournamentsForEditSchema = z.object({
 });
 
 export const getScheduledTournamentsForEdit = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     const { type, id } = getScheduledTournamentsForEditSchema.parse(request.data);
 

--- a/functions/src/callables/index.ts
+++ b/functions/src/callables/index.ts
@@ -47,4 +47,6 @@ export { registerForSideGame } from '../sideGame/registerForSideGame';
 export { leaveSeat } from '../sideGame/leaveSeat';
 export { withdrawTip } from '../sideGame/withdrawTip';
 export { depositTip } from '../sideGame/depositTip';
-
+export { updateDeviceOptions } from './updateDeviceOptions';
+export { getActionLogs } from './getActionLogs';
+export { rollbackAction } from './rollbackAction';

--- a/functions/src/callables/refundProcessing.ts
+++ b/functions/src/callables/refundProcessing.ts
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const db = admin.firestore();
 
@@ -26,18 +27,18 @@ export const processRefund = onCall(async (request) => {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
 
-  const adminId = request.auth.uid;
+  const callerUid = request.auth.uid;
 
   try {
-    // デバイス権限の確認（role: adminのみ）
-    const deviceQuery = await db.collection('devices')
-      .where('uid', '==', adminId)
-      .where('role', '==', 'admin')
-      .limit(1)
-      .get();
+    // デバイス権限の確認（role: admin または options.accounting: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
 
-    if (deviceQuery.empty) {
-      throw new HttpsError('permission-denied', '管理者権限がありません');
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'accounting');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '会計管理の権限がありません');
     }
 
     // 入力データの検証
@@ -74,7 +75,7 @@ export const processRefund = onCall(async (request) => {
         refundAmount: refundAmount,
         refundReason: refundReason,
         refundMethod: refundMethod,
-        refundProcessedBy: adminId,
+        refundProcessedBy: callerUid,
         refundProcessedAt: admin.firestore.FieldValue.serverTimestamp(),
         updatedAt: admin.firestore.FieldValue.serverTimestamp(),
       });
@@ -171,7 +172,7 @@ export const processRefund = onCall(async (request) => {
           refundReason: refundReason,
           refundMethod: refundMethod,
           refundCategories: refundCategories || [],
-          processedBy: adminId,
+          processedBy: callerUid,
           processedAt: admin.firestore.FieldValue.serverTimestamp(),
         };
 
@@ -191,7 +192,7 @@ export const processRefund = onCall(async (request) => {
         refundReason: refundReason,
         refundMethod: refundMethod,
         refundCategories: refundCategories || [],
-        processedBy: adminId,
+        processedBy: callerUid,
         processedAt: admin.firestore.FieldValue.serverTimestamp(),
         createdAt: admin.firestore.FieldValue.serverTimestamp(),
       });
@@ -230,18 +231,18 @@ export const getRefundHistory = onCall(async (request) => {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
 
-  const adminId = request.auth.uid;
+  const callerUid = request.auth.uid;
 
   try {
-    // デバイス権限の確認（role: adminのみ）
-    const deviceQuery = await db.collection('devices')
-      .where('uid', '==', adminId)
-      .where('role', '==', 'admin')
-      .limit(1)
-      .get();
+    // デバイス権限の確認（role: admin または options.accounting: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
 
-    if (deviceQuery.empty) {
-      throw new HttpsError('permission-denied', '管理者権限がありません');
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'accounting');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '会計管理の権限がありません');
     }
 
     // 日付範囲の取得（デフォルトは過去30日）

--- a/functions/src/callables/registerParticipants.ts
+++ b/functions/src/callables/registerParticipants.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 // 入力スキーマ
 const registerParticipantsSchema = z.object({
@@ -14,7 +15,25 @@ interface RegistrationResult {
   error?: string;
 }
 
-export const registerParticipants = functions.https.onCall(async (data, context) => {
+export const registerParticipants = functions.https.onCall(async (data, context: any) => {
+  // 認証チェック
+  if (!context || !context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = context.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new functions.https.HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new functions.https.HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     // 正しいデータの場所を取得
     const actualData = data.data || data;

--- a/functions/src/callables/reseatAllPlayers.ts
+++ b/functions/src/callables/reseatAllPlayers.ts
@@ -1,6 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 // 入力スキーマ
 const reseatAllPlayersSchema = z.object({
@@ -12,7 +13,25 @@ const reseatAllPlayersSchema = z.object({
   })),
 });
 
-export const reseatAllPlayers = functions.https.onCall(async (data, context) => {
+export const reseatAllPlayers = functions.https.onCall(async (data, context: any) => {
+  // 認証チェック
+  if (!context || !context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = context.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new functions.https.HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new functions.https.HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     // 正しいデータの場所を取得
     const actualData = data.data || data;

--- a/functions/src/callables/setPrizeData.ts
+++ b/functions/src/callables/setPrizeData.ts
@@ -1,6 +1,7 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const setPrizeDataSchema = z.object({
   tournamentId: z.string().min(1, 'tournamentId is required'),
@@ -12,7 +13,25 @@ const setPrizeDataSchema = z.object({
 });
 
 export const setPrizeData = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     // 入力検証
     const { tournamentId, prizeData } = setPrizeDataSchema.parse(request.data);
     

--- a/functions/src/callables/setRankingData.ts
+++ b/functions/src/callables/setRankingData.ts
@@ -1,9 +1,28 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
 import { addLogEntry } from '../utils/logUtils';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const setRankingData = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     const { tournamentId, rankingData } = request.data;
     
     console.log('=== setRankingData 開始 ===');

--- a/functions/src/callables/updateAccounting.ts
+++ b/functions/src/callables/updateAccounting.ts
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { z } from 'zod';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const db = admin.firestore();
 
@@ -41,7 +42,7 @@ const UpdateAccountingSchema = z.object({
 
 /**
  * 会計内容を修正するCloud Function
- * 管理者権限を持つユーザーのみが実行可能
+ * 管理者権限またはaccountingオプションを持つデバイスのみが実行可能
  */
 export const updateAccounting = onCall(async (request) => {
   // 認証チェック
@@ -49,18 +50,18 @@ export const updateAccounting = onCall(async (request) => {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
 
-  const adminId = request.auth.uid;
+  const callerUid = request.auth.uid;
 
   try {
-    // デバイス権限の確認（role: adminのみ）
-    const deviceQuery = await db.collection('devices')
-      .where('uid', '==', adminId)
-      .where('role', '==', 'admin')
-      .limit(1)
-      .get();
+    // デバイス権限の確認（role: admin または options.accounting: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
 
-    if (deviceQuery.empty) {
-      throw new HttpsError('permission-denied', '管理者権限がありません');
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'accounting');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '会計管理の権限がありません');
     }
 
     // 入力データの検証
@@ -168,7 +169,7 @@ export const updateAccounting = onCall(async (request) => {
             totalPrice: newTotalPrice,
           },
           reason: reason,
-          correctedBy: adminId,
+          correctedBy: callerUid,
           correctedAt: new Date(), // FieldValue.serverTimestamp()の代わりにDateオブジェクトを使用
         };
 

--- a/functions/src/callables/updateActiveBill.ts
+++ b/functions/src/callables/updateActiveBill.ts
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin';
 import { z } from 'zod';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 const db = admin.firestore();
 
@@ -49,18 +50,18 @@ export const updateActiveBill = onCall(async (request) => {
     throw new HttpsError('unauthenticated', '認証が必要です');
   }
 
-  const adminId = request.auth.uid;
+  const callerUid = request.auth.uid;
 
   try {
-    // デバイス権限の確認（role: adminのみ）
-    const deviceQuery = await db.collection('devices')
-      .where('uid', '==', adminId)
-      .where('role', '==', 'admin')
-      .limit(1)
-      .get();
+    // デバイス権限の確認（role: admin または options.accounting: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
 
-    if (deviceQuery.empty) {
-      throw new HttpsError('permission-denied', '管理者権限がありません');
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'accounting');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '会計管理の権限がありません');
     }
 
     // 入力データの検証

--- a/functions/src/callables/updateDeviceOptions.ts
+++ b/functions/src/callables/updateDeviceOptions.ts
@@ -1,0 +1,100 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { z } from "zod";
+
+const db = getFirestore();
+
+// optionParams の各エントリは { tableId?: string } などの形式
+const optionParamsEntrySchema = z.object({
+  tableId: z.string().optional(),
+}).passthrough(); // 将来的に他のパラメータも許容
+
+const payloadSchema = z.object({
+  deviceId: z.string().min(1),
+  options: z.record(z.boolean()),
+  optionParams: z.record(optionParamsEntrySchema).optional(),
+});
+
+// 排他グループ: 同時にtrueにできないオプションのグループ
+const EXCLUSIVE_GROUPS: string[][] = [
+  ["tournament", "tournament_table"],
+];
+
+// 排他チェック
+function validateExclusiveOptions(options: Record<string, boolean>): void {
+  for (const group of EXCLUSIVE_GROUPS) {
+    const enabledInGroup = group.filter((key) => options[key] === true);
+    if (enabledInGroup.length > 1) {
+      throw new HttpsError(
+        "invalid-argument",
+        `${enabledInGroup.join(" と ")} は同時に選択できません`
+      );
+    }
+  }
+}
+
+export const updateDeviceOptions = onCall(async (request) => {
+  try {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "認証が必要です");
+    }
+
+    const { deviceId, options, optionParams } = payloadSchema.parse(request.data);
+
+    // 排他チェック
+    validateExclusiveOptions(options);
+
+    // 呼び出し元がadmin端末か検証（呼び出し元uidのdevicesドキュメントを参照）
+    const callerUid = request.auth.uid;
+    const callerSnap = await db
+      .collection("devices")
+      .where("uid", "==", callerUid)
+      .limit(1)
+      .get();
+
+    if (callerSnap.empty) {
+      throw new HttpsError("permission-denied", "呼び出し元デバイスが見つかりません");
+    }
+    const caller = callerSnap.docs[0].data();
+    if (caller.role !== "admin") {
+      throw new HttpsError("permission-denied", "管理者のみが実行できます");
+    }
+
+    // 対象デバイスの存在確認
+    const targetRef = db.collection("devices").doc(deviceId);
+    const targetDoc = await targetRef.get();
+    if (!targetDoc.exists) {
+      throw new HttpsError("not-found", "対象デバイスが存在しません");
+    }
+
+    // 更新データを構築
+    const updateData: Record<string, unknown> = {
+      options,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+
+    // optionParams が渡された場合は更新
+    if (optionParams !== undefined) {
+      updateData.optionParams = optionParams;
+    }
+
+    await targetRef.update(updateData);
+
+    return {
+      success: true,
+      deviceId,
+      options,
+      optionParams: optionParams ?? null,
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new HttpsError("invalid-argument", "入力データが無効です");
+    }
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    throw new HttpsError("internal", "デバイスオプション更新に失敗しました");
+  }
+});
+
+

--- a/functions/src/callables/updateTournamentRecurrence.ts
+++ b/functions/src/callables/updateTournamentRecurrence.ts
@@ -1,6 +1,7 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
 import { z } from "zod";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 const updateTournamentRecurrenceSchema = z.object({
   recurrenceId: z.string(),
@@ -13,6 +14,24 @@ const updateTournamentRecurrenceSchema = z.object({
 });
 
 export const updateTournamentRecurrence = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     const { recurrenceId, isActive, templateId, interval, byWeekday, startTime, selectedTournamentIds } = 
       updateTournamentRecurrenceSchema.parse(request.data);

--- a/functions/src/callables/updateTournamentTemplate.ts
+++ b/functions/src/callables/updateTournamentTemplate.ts
@@ -1,6 +1,7 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
 import { z } from "zod";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 const updateTournamentTemplateSchema = z.object({
   templateId: z.string(),
@@ -21,6 +22,24 @@ const updateTournamentTemplateSchema = z.object({
 });
 
 export const updateTournamentTemplate = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.tournament: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+  }
+
   try {
     const { templateId, selectedTournamentIds, ...updateData } = 
       updateTournamentTemplateSchema.parse(request.data);

--- a/functions/src/callables/validateEndTournament.ts
+++ b/functions/src/callables/validateEndTournament.ts
@@ -1,8 +1,27 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const validateEndTournament = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.tournament: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'tournament');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'トーナメント運営の権限がありません');
+    }
+
     const { tournamentId } = request.data;
     
     if (!tournamentId) {

--- a/functions/src/itemOrder/createMenuItem.ts
+++ b/functions/src/itemOrder/createMenuItem.ts
@@ -1,17 +1,33 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 export const createMenuItem = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.kitchen: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'kitchen');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'キッチン画面操作の権限がありません');
+  }
+
   try {
     const { name, price, category, description, imageBase64, isArchive, isSoldOut } = request.data;
 
     // バリデーション
     if (!name || !price || !category) {
-      return {
-        success: false,
-        error: '必須項目が不足しています'
-      };
+      throw new HttpsError('invalid-argument', '必須項目が不足しています');
     }
 
     const db = getFirestore();
@@ -44,10 +60,7 @@ export const createMenuItem = onCall(async (request) => {
         await file.makePublic();
       } catch (error) {
         console.error('画像アップロードエラー:', error);
-        return {
-          success: false,
-          error: '画像のアップロードに失敗しました'
-        };
+        throw new HttpsError('internal', '画像のアップロードに失敗しました');
       }
     }
 
@@ -77,9 +90,11 @@ export const createMenuItem = onCall(async (request) => {
 
   } catch (error) {
     console.error('メニュー作成エラー:', error);
-    return {
-      success: false,
-      error: 'メニューの作成に失敗しました'
-    };
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'メニューの作成に失敗しました');
   }
 });

--- a/functions/src/itemOrder/placeOrder.ts
+++ b/functions/src/itemOrder/placeOrder.ts
@@ -1,6 +1,7 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { addLogEntry } from "../utils/logUtils";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 /**
  * Chip名から数値部分を抽出する
@@ -36,7 +37,25 @@ function extractChipAmount(chipName: string): number {
 export const placeOrder = onCall(async (request) => {
   const db = getFirestore();
 
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.order: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'order');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', '注文操作の権限がありません');
+    }
+
     const { userId, item } = request.data as {
       userId: string;
       item: {

--- a/functions/src/itemOrder/toggleSoldOutForMenuItem.ts
+++ b/functions/src/itemOrder/toggleSoldOutForMenuItem.ts
@@ -1,16 +1,32 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 export const toggleSoldOutForMenuItem = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.kitchen: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'kitchen');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'キッチン画面操作の権限がありません');
+  }
+
   try {
     const { menuItemId, isSoldOut } = request.data;
 
     // バリデーション
     if (!menuItemId) {
-      return {
-        success: false,
-        error: 'メニューIDが指定されていません'
-      };
+      throw new HttpsError('invalid-argument', 'メニューIDが指定されていません');
     }
 
     const db = getFirestore();
@@ -33,9 +49,11 @@ export const toggleSoldOutForMenuItem = onCall(async (request) => {
 
   } catch (error) {
     console.error('売り切れ状態切り替えエラー:', error);
-    return {
-      success: false,
-      error: '売り切れ状態の切り替えに失敗しました'
-    };
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', '売り切れ状態の切り替えに失敗しました');
   }
 });

--- a/functions/src/itemOrder/updateMenuItem.ts
+++ b/functions/src/itemOrder/updateMenuItem.ts
@@ -1,8 +1,27 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 export const updateMenuItem = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.kitchen: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'kitchen');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'キッチン画面操作の権限がありません');
+  }
+
   try {
     const { 
       originalId, 
@@ -17,10 +36,7 @@ export const updateMenuItem = onCall(async (request) => {
 
     // バリデーション
     if (!originalId || !name || !price || !category) {
-      return {
-        success: false,
-        error: '必須項目が不足しています'
-      };
+      throw new HttpsError('invalid-argument', '必須項目が不足しています');
     }
 
     const db = getFirestore();
@@ -60,10 +76,7 @@ export const updateMenuItem = onCall(async (request) => {
         await file.makePublic();
       } catch (error) {
         console.error('画像アップロードエラー:', error);
-        return {
-          success: false,
-          error: '画像のアップロードに失敗しました'
-        };
+        throw new HttpsError('internal', '画像のアップロードに失敗しました');
       }
     }
 
@@ -93,9 +106,11 @@ export const updateMenuItem = onCall(async (request) => {
 
   } catch (error) {
     console.error('メニュー更新エラー:', error);
-    return {
-      success: false,
-      error: 'メニューの更新に失敗しました'
-    };
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    
+    throw new HttpsError('internal', 'メニューの更新に失敗しました');
   }
 });

--- a/functions/src/lib/devicePermissions.ts
+++ b/functions/src/lib/devicePermissions.ts
@@ -1,0 +1,34 @@
+import { getFirestore } from "firebase-admin/firestore";
+
+const db = getFirestore();
+
+export type DeviceDoc = {
+  id: string;
+  role: string;
+  options?: Record<string, boolean>;
+  status?: string;
+};
+
+export async function getCallerDeviceByUid(uid: string): Promise<DeviceDoc | null> {
+  const snap = await db.collection("devices").where("uid", "==", uid).limit(1).get();
+  if (snap.empty) return null;
+  const doc = snap.docs[0];
+  const data = doc.data() as any;
+  return {
+    id: doc.id,
+    role: data?.role ?? "terminal",
+    options: data?.options ?? {},
+    status: data?.status ?? "active",
+  };
+}
+
+export function hasRequiredOption(options: Record<string, boolean> | undefined, requiredKey: string): boolean {
+  if (!options) return false;
+  return options[requiredKey] === true;
+}
+
+export function isActive(status?: string): boolean {
+  return (status ?? "active") === "active";
+}
+
+

--- a/functions/src/sideGame/depositTip.ts
+++ b/functions/src/sideGame/depositTip.ts
@@ -1,12 +1,30 @@
-import { onCall } from 'firebase-functions/v2/https';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
 import { addLogEntry } from '../utils/logUtils';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const depositTip = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   const db = getFirestore();
   const { userId, amount } = request.data;
 
   try {
+    // デバイス権限の確認（role: admin または options.side_game: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'side_game');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'サイドゲーム操作の権限がありません');
+    }
     console.log(`=== depositTip開始 ===`);
     console.log(`userId: ${userId}`);
     console.log(`amount: ${amount}`);

--- a/functions/src/sideGame/leaveSeat.ts
+++ b/functions/src/sideGame/leaveSeat.ts
@@ -1,11 +1,29 @@
-import { onCall } from 'firebase-functions/v2/https';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const leaveSeat = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   const db = getFirestore();
   const { tableId, seatNumber, userId } = request.data;
 
   try {
+    // デバイス権限の確認（role: admin または options.side_game: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'side_game');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'サイドゲーム操作の権限がありません');
+    }
     console.log(`=== leaveSeat開始 ===`);
     console.log(`tableId: ${tableId}`);
     console.log(`seatNumber: ${seatNumber}`);

--- a/functions/src/sideGame/registerForSideGame.ts
+++ b/functions/src/sideGame/registerForSideGame.ts
@@ -1,11 +1,29 @@
-import { onCall } from 'firebase-functions/v2/https';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const registerForSideGame = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   const db = getFirestore();
   const { tableId, seatNumber, userId } = request.data;
 
   try {
+    // デバイス権限の確認（role: admin または options.side_game: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'side_game');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'サイドゲーム操作の権限がありません');
+    }
     console.log(`=== registerParticipant開始 ===`);
     console.log(`tableId: ${tableId}`);
     console.log(`seatNumber: ${seatNumber}`);

--- a/functions/src/sideGame/withdrawTip.ts
+++ b/functions/src/sideGame/withdrawTip.ts
@@ -1,12 +1,30 @@
-import { onCall } from 'firebase-functions/v2/https';
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
 import { addLogEntry } from '../utils/logUtils';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
 
 export const withdrawTip = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   const db = getFirestore();
   const { userId, amount } = request.data;
 
   try {
+    // デバイス権限の確認（role: admin または options.side_game: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'side_game');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'サイドゲーム操作の権限がありません');
+    }
     console.log(`=== withdrawTip開始 ===`);
     console.log(`userId: ${userId}`);
     console.log(`amount: ${amount}`);

--- a/functions/src/userLogin/manualCheckIn.ts
+++ b/functions/src/userLogin/manualCheckIn.ts
@@ -1,6 +1,7 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { getFirestore } from "firebase-admin/firestore";
 import * as bcrypt from "bcryptjs";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 /**
  * 手動チェックイン（店舗端末でのログインID + PIN 認証）
@@ -11,7 +12,25 @@ import * as bcrypt from "bcryptjs";
  * How: Firestore 検索 → PIN 検証 → users 更新 → todaysBills 作成
  */
 export const manualCheckIn = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
   try {
+    // デバイス権限の確認（role: admin または options.user_entry_exit: true）
+    const device = await getCallerDeviceByUid(callerUid);
+    if (!device || !isActive(device.status)) {
+      throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+    }
+
+    const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'user_entry_exit');
+    if (!hasPermission) {
+      throw new HttpsError('permission-denied', 'お客様入退店操作の権限がありません');
+    }
+
     const { loginId, pin, entranceFee, entranceFeeDescription } = request.data;
 
     // バリデーション

--- a/functions/src/userLogin/processVisitByQR.ts
+++ b/functions/src/userLogin/processVisitByQR.ts
@@ -1,6 +1,7 @@
-import { onCall } from "firebase-functions/v2/https";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import * as admin from "firebase-admin";
 import { parseQRData, verifyQRData } from "../utils/qrCodeUtils";
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from "../lib/devicePermissions";
 
 /**
  * 入店処理（QRスキャン起点）
@@ -13,7 +14,23 @@ import { parseQRData, verifyQRData } from "../utils/qrCodeUtils";
  * How: verifyQRData → parseQRData → Firestore トランザクションで現在状態を参照し更新（入店のみ）
  */
 export const processVisitByQR = onCall(async (request) => {
-  // 認証チェックを削除（注文処理と同様に認証なしで動作）
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', '認証が必要です');
+  }
+
+  const callerUid = request.auth.uid;
+
+  // デバイス権限の確認（role: admin または options.user_entry_exit: true）
+  const device = await getCallerDeviceByUid(callerUid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'デバイスが見つからないか、アクティブではありません');
+  }
+
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'user_entry_exit');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'お客様入退店操作の権限がありません');
+  }
 
   // 入力取り出し
   const { qrData, entranceFee = 1000, entranceFeeDescription = "入店料" } = request.data ?? {};

--- a/lib/Accounting/accountingPage.dart
+++ b/lib/Accounting/accountingPage.dart
@@ -181,8 +181,6 @@ class _AccountingPageState extends State<AccountingPage> {
     final List<dynamic> items = bill['items'] as List<dynamic>? ?? [];
     final List<dynamic> sideGameChip =
         bill['sideGameChip'] as List<dynamic>? ?? [];
-    final Map<String, dynamic> tournaments =
-        bill['tournaments'] as Map<String, dynamic>? ?? {};
 
     int extraCostAmount = 0;
     for (var cost in extraCost) {
@@ -207,9 +205,13 @@ class _AccountingPageState extends State<AccountingPage> {
     }
 
     int tournamentsAmount = 0;
-    for (var tournament in tournaments.values) {
-      if (tournament is Map<String, dynamic>) {
-        tournamentsAmount += (tournament['entryFee'] as num?)?.toInt() ?? 0;
+    // tournamentsは初期状態では空配列、登録後はMapになる可能性がある
+    final tournamentsData = bill['tournaments'];
+    if (tournamentsData is Map<String, dynamic>) {
+      for (var tournament in tournamentsData.values) {
+        if (tournament is Map<String, dynamic>) {
+          tournamentsAmount += (tournament['entryFee'] as num?)?.toInt() ?? 0;
+        }
       }
     }
 
@@ -450,8 +452,6 @@ class _AccountingPageState extends State<AccountingPage> {
     final List<dynamic> items = bill['items'] as List<dynamic>? ?? [];
     final List<dynamic> sideGameChip =
         bill['sideGameChip'] as List<dynamic>? ?? [];
-    final Map<String, dynamic> tournaments =
-        bill['tournaments'] as Map<String, dynamic>? ?? {};
 
     int extraCostAmount = 0;
     for (var cost in extraCost) {
@@ -479,10 +479,14 @@ class _AccountingPageState extends State<AccountingPage> {
     }
 
     int tournamentsAmount = 0;
-    for (var tournament in tournaments.values) {
-      if (tournament is Map<String, dynamic>) {
-        final price = (tournament['entryFee'] as num?)?.toInt() ?? 0;
-        tournamentsAmount += price;
+    // tournamentsは初期状態では空配列、登録後はMapになる可能性がある
+    final tournamentsData = bill['tournaments'];
+    if (tournamentsData is Map<String, dynamic>) {
+      for (var tournament in tournamentsData.values) {
+        if (tournament is Map<String, dynamic>) {
+          final price = (tournament['entryFee'] as num?)?.toInt() ?? 0;
+          tournamentsAmount += price;
+        }
       }
     }
 
@@ -563,16 +567,20 @@ class _AccountingPageState extends State<AccountingPage> {
       }
     }
 
-    final Map<String, dynamic> tournaments =
-        bill['tournaments'] as Map<String, dynamic>? ?? {};
-    for (final tournament in tournaments.values) {
-      if (tournament is Map<String, dynamic>) {
-        final amount = (tournament['entryFee'] as num?)?.toInt() ?? 0;
-        displayValues['tournaments'] =
-            (displayValues['tournaments'] ?? 0) + amount;
-        monetaryValues['tournaments'] =
-            (monetaryValues['tournaments'] ?? 0) + amount;
+    // tournamentsは初期状態では空配列、登録後はMapになる可能性がある
+    final tournamentsData = bill['tournaments'];
+    if (tournamentsData is Map<String, dynamic>) {
+      for (final tournament in tournamentsData.values) {
+        if (tournament is Map<String, dynamic>) {
+          final amount = (tournament['entryFee'] as num?)?.toInt() ?? 0;
+          displayValues['tournaments'] =
+              (displayValues['tournaments'] ?? 0) + amount;
+          monetaryValues['tournaments'] =
+              (monetaryValues['tournaments'] ?? 0) + amount;
+        }
       }
+    } else if (tournamentsData is List) {
+      // 初期状態の空配列の場合は何もしない
     }
 
     final List<dynamic> items = bill['items'] as List<dynamic>? ?? [];
@@ -1494,41 +1502,44 @@ class _AccountingPageState extends State<AccountingPage> {
               // 内訳
               _buildBillBreakdown(bill),
               const SizedBox(height: 12),
-              Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      onPressed: () async {
-                        final ok = await _revertAccountingStart(bill['id']);
-                        if (ok) {
-                          // 戻したら再編集フローへ
-                          await _startAccounting(bill['id']);
-                        }
-                      },
-                      icon: const Icon(Icons.edit),
-                      label: const Text('支払い方法変更'),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: Colors.blue,
-                        side: const BorderSide(color: Colors.blue),
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      onPressed: () => _revertAccountingStart(bill['id']),
-                      icon: const Icon(Icons.undo),
-                      label: const Text('会計開始前に戻る'),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: Colors.red,
-                        side: const BorderSide(color: Colors.red),
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+              // TODO: revertAccountingStart CFが未実装のため一時的に無効化
+              // 再実装後にコメントを解除すること
+              // Row(
+              //   children: [
+              //     Expanded(
+              //       child: OutlinedButton.icon(
+              //         onPressed: () async {
+              //           final ok = await _revertAccountingStart(bill['id']);
+              //           if (ok) {
+              //             // 戻したら再編集フローへ
+              //             await _startAccounting(bill['id']);
+              //           }
+              //         },
+              //         icon: const Icon(Icons.edit),
+              //         label: const Text('支払い方法変更'),
+              //         style: OutlinedButton.styleFrom(
+              //           foregroundColor: Colors.blue,
+              //           side: const BorderSide(color: Colors.blue),
+              //           padding: const EdgeInsets.symmetric(vertical: 12),
+              //         ),
+              //       ),
+              //     ),
+              //     const SizedBox(width: 8),
+              //     Expanded(
+              //       child: OutlinedButton.icon(
+              //         onPressed: () => _revertAccountingStart(bill['id']),
+              //         icon: const Icon(Icons.undo),
+              //         label: const Text('会計開始前に戻る'),
+              //         style: OutlinedButton.styleFrom(
+              //           foregroundColor: Colors.red,
+              //           side: const BorderSide(color: Colors.red),
+              //           padding: const EdgeInsets.symmetric(vertical: 12),
+              //         ),
+              //       ),
+              //     ),
+              //   ],
+              // ),
+              const SizedBox.shrink(), // 一時的なプレースホルダー
             ] else
               Row(
                 children: [
@@ -1566,28 +1577,30 @@ class _AccountingPageState extends State<AccountingPage> {
     );
   }
 
+  // TODO: revertAccountingStart CFが未実装のため一時的に無効化
+  // 再実装後にコメントを解除すること
   // 会計開始前に戻す（Cloud Function 呼び出し）
-  Future<bool> _revertAccountingStart(String billId) async {
-    try {
-      final result = await _functions
-          .httpsCallable('revertAccountingStart')
-          .call({'billId': billId});
-      if (mounted) {
-        _loadActiveBills();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(result.data['message'] ?? '会計開始を取り消しました')),
-        );
-      }
-      return true;
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('取り消しに失敗しました: $e')));
-      }
-      return false;
-    }
-  }
+  // Future<bool> _revertAccountingStart(String billId) async {
+  //   try {
+  //     final result = await _functions
+  //         .httpsCallable('revertAccountingStart')
+  //         .call({'billId': billId});
+  //     if (mounted) {
+  //       _loadActiveBills();
+  //       ScaffoldMessenger.of(context).showSnackBar(
+  //         SnackBar(content: Text(result.data['message'] ?? '会計開始を取り消しました')),
+  //       );
+  //     }
+  //     return true;
+  //   } catch (e) {
+  //     if (mounted) {
+  //       ScaffoldMessenger.of(
+  //         context,
+  //       ).showSnackBar(SnackBar(content: Text('取り消しに失敗しました: $e')));
+  //     }
+  //     return false;
+  //   }
+  // }
 
   Widget _buildSettledBillCard(Map<String, dynamic> bill) {
     final billId = bill['id'] ?? 'unknown';

--- a/lib/Home/terminalHomePage.dart
+++ b/lib/Home/terminalHomePage.dart
@@ -13,7 +13,13 @@ import 'package:amuse_app_template/sideGame/pages/side_game_table_list.dart';
 import 'package:amuse_app_template/OrderView/OrderManagement/order_management_page.dart';
 import 'package:amuse_app_template/dashboard/home/dashboard_home_page.dart';
 import 'package:amuse_app_template/Utils/firestore_size_page.dart';
+import 'package:amuse_app_template/tournament/pages/tournament_select_page.dart';
+import 'package:amuse_app_template/tournament/pages/table_select_page.dart';
+import 'package:amuse_app_template/tournament/active/pages/table_detail_page.dart';
+import 'package:amuse_app_template/tournament/active/pages/blind_timer_page.dart';
 import 'package:flutter/material.dart';
+import 'package:amuse_app_template/services/device_service.dart';
+import 'package:amuse_app_template/services/device_options.dart';
 
 class terminalHomePage extends StatefulWidget {
   const terminalHomePage({super.key});
@@ -23,27 +29,134 @@ class terminalHomePage extends StatefulWidget {
 }
 
 class _terminalHomePageState extends State<terminalHomePage> {
+  final DeviceService _deviceService = DeviceService();
+  bool _loadingDevice = true;
+  bool _isAdminDevice = false;
+  Map<String, bool> _deviceOptions = const {};
+
+  @override
+  void initState() {
+    super.initState();
+    _initDevice();
+  }
+
+  Future<void> _initDevice() async {
+    final device = await _deviceService.getCurrentDevice();
+    if (!mounted) return;
+    setState(() {
+      _loadingDevice = false;
+      _isAdminDevice = (device?.role == 'admin');
+      _deviceOptions = device?.options ?? const {};
+    });
+  }
+
+  /// 卓ページへの遷移（トーナメント選択→卓選択→卓詳細ページ）
+  Future<void> _navigateToTablePage(BuildContext context) async {
+    // デバイスに卓番が指定されているか確認
+    final device = await _deviceService.getCurrentDevice();
+    final myTableId = device?.getTableIdForOption(DeviceOptionKeys.tournamentTable);
+    final hasTableAssignment = myTableId != null;
+
+    if (!context.mounted) return;
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TournamentSelectPage(
+          title: '卓ページ - トーナメント選択',
+          filterByDeviceTable: hasTableAssignment, // 卓番指定がある場合のみフィルタ
+          onSelected: (tournamentId, tournamentName) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => TableSelectPage(
+                  tournamentId: tournamentId,
+                  tournamentName: tournamentName,
+                  onSelected: (tableId, tableName) {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => TableDetailPage(
+                          tournamentId: tournamentId,
+                          tableId: tableId,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  /// ブラインドタイマーへの遷移（トーナメント選択→タイマーページ）
+  void _navigateToBlindTimer(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TournamentSelectPage(
+          title: 'ブラインドタイマー - トーナメント選択',
+          onSelected: (tournamentId, tournamentName) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => BlindTimerPage(
+                  tournamentId: tournamentId,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final screenHeight = MediaQuery.of(context).size.height;
     final buttonHeight = (screenHeight - kToolbarHeight - 80) / 2.3;
 
-    final List<({String label, Widget destination})> buttons = [
-      (label: 'ユーザー作成', destination: const CreateUserAccount()),
-      (label: 'ユーザーログイン', destination: const UserCheckInPage()),
-      (label: 'メニュー追加', destination: const MenuEditorListPage()),
-      (label: '注文画面', destination: const CategorySelectPage()),
-      (label: '入店中user一覧', destination: const StayingUsersListPage()),
-      (label: 'Tournament 作成', destination: const TournamentCreationMenuPage()),
-      (label: 'Tournament Home', destination: const ScheduledTournamentListPage()),
-      (label: 'sideGame', destination: const SideGameTableListPage()),
-      (label: '注文管理', destination: const OrderManagementPage()),
-      (label: 'スタッフ打刻', destination: const StaffAttendancePage()),
-      (label: '会計管理', destination: const AccountingPage()),
-      (label: '売上ダッシュボード', destination: const DashboardHomePage()),
-      (label: '支払い分割テスト', destination: const PaymentSplitTestPage()),
-      (label: 'Firestoreサイズ計算', destination: const FirestoreSizePage()),
+    // 通常のボタン（直接遷移）
+    final List<({String label, Widget destination, String? optionKey})> buttons = [
+      (label: 'ユーザー作成', destination: const CreateUserAccount(), optionKey: null),
+      (label: 'ユーザーログイン', destination: const UserCheckInPage(), optionKey: DeviceOptionKeys.userEntryExit),
+      (label: 'メニュー追加', destination: const MenuEditorListPage(), optionKey: null),
+      (label: '注文画面', destination: const CategorySelectPage(), optionKey: DeviceOptionKeys.order),
+      (label: '入店中user一覧', destination: const StayingUsersListPage(), optionKey: null),
+      (label: 'Tournament 作成', destination: const TournamentCreationMenuPage(), optionKey: DeviceOptionKeys.tournament),
+      (label: 'Tournament Home', destination: const ScheduledTournamentListPage(), optionKey: DeviceOptionKeys.tournament),
+      (label: 'sideGame', destination: const SideGameTableListPage(), optionKey: DeviceOptionKeys.sideGame),
+      (label: '注文管理', destination: const OrderManagementPage(), optionKey: DeviceOptionKeys.kitchen),
+      (label: 'スタッフ打刻', destination: const StaffAttendancePage(), optionKey: DeviceOptionKeys.staffEntryExit),
+      (label: '会計管理', destination: const AccountingPage(), optionKey: DeviceOptionKeys.accounting),
+      (label: '売上ダッシュボード', destination: const DashboardHomePage(), optionKey: null),
+      (label: '支払い分割テスト', destination: const PaymentSplitTestPage(), optionKey: null),
+      (label: 'Firestoreサイズ計算', destination: const FirestoreSizePage(), optionKey: null),
     ];
+
+    final visibleButtons = buttons.where((btn) {
+      // 管理者端末は全表示
+      if (_isAdminDevice) return true;
+      // オプションがまだ付与されていない（空）場合は従来通り全表示
+      if (_deviceOptions.isEmpty) return true;
+      // オプションキーが無いボタンは常に表示（一般系）
+      if (btn.optionKey == null) return true;
+      // 付与済みオプションのみ表示
+      return _deviceOptions[btn.optionKey!] == true;
+    }).toList();
+
+    // 特殊ボタン（ダイアログ経由で遷移）
+    final showTablePageButton = _isAdminDevice ||
+        _deviceOptions.isEmpty ||
+        _deviceOptions[DeviceOptionKeys.tournament] == true ||
+        _deviceOptions[DeviceOptionKeys.tournamentTable] == true;
+
+    final showBlindTimerButton = _isAdminDevice ||
+        _deviceOptions.isEmpty ||
+        _deviceOptions[DeviceOptionKeys.tournament] == true;
 
     return Scaffold(
       appBar: AppBar(
@@ -64,7 +177,9 @@ class _terminalHomePageState extends State<terminalHomePage> {
           ),
         ],
       ),
-      body: GridView.custom(
+      body: _loadingDevice
+          ? const Center(child: CircularProgressIndicator())
+          : GridView.custom(
         padding: const EdgeInsets.all(16),
         physics: const AlwaysScrollableScrollPhysics(), // スクロール可能に変更
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
@@ -73,19 +188,57 @@ class _terminalHomePageState extends State<terminalHomePage> {
           mainAxisSpacing: 12,
           mainAxisExtent: buttonHeight,
         ),
-        childrenDelegate: SliverChildListDelegate.fixed(
-          buttons.map((btn) {
+        childrenDelegate: SliverChildListDelegate.fixed([
+          // 通常ボタン
+          ...visibleButtons.map((btn) {
             return ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => btn.destination),
-                );
+              onPressed: () async {
+                // オプションチェック（optionKeyが指定されている場合のみ）
+                if (btn.optionKey != null) {
+                  final ok = await _deviceService.hasOption(btn.optionKey!);
+                  if (!ok) {
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('権限がありません: ${DeviceOptionKeys.label(btn.optionKey!)}'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                    }
+                    return;
+                  }
+                }
+                if (context.mounted) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => btn.destination),
+                  );
+                }
               },
               child: Text(btn.label, textAlign: TextAlign.center),
             );
-          }).toList(),
-        ),
+          }),
+          // 卓ページボタン
+          if (showTablePageButton)
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.teal,
+                foregroundColor: Colors.white,
+              ),
+              onPressed: () => _navigateToTablePage(context),
+              child: const Text('卓ページ', textAlign: TextAlign.center),
+            ),
+          // ブラインドタイマーボタン
+          if (showBlindTimerButton)
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.deepPurple,
+                foregroundColor: Colors.white,
+              ),
+              onPressed: () => _navigateToBlindTimer(context),
+              child: const Text('ブラインドタイマー', textAlign: TextAlign.center),
+            ),
+        ]),
       ),
     );
   }

--- a/lib/models/device.dart
+++ b/lib/models/device.dart
@@ -11,6 +11,8 @@ class Device {
   final DateTime createdAt;
   final DateTime updatedAt;
   final String status;
+  final Map<String, bool> options;
+  final Map<String, Map<String, dynamic>> optionParams;
 
   const Device({
     required this.id,
@@ -22,11 +24,38 @@ class Device {
     required this.createdAt,
     required this.updatedAt,
     required this.status,
+    this.options = const {},
+    this.optionParams = const {},
   });
 
   /// Firestore ドキュメントから Device オブジェクトを作成
   factory Device.fromFirestore(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
+    final rawOptions = (data['options'] as Map<String, dynamic>?) ?? {};
+    final mappedOptions = <String, bool>{};
+    rawOptions.forEach((key, value) {
+      if (value is bool) {
+        mappedOptions[key] = value;
+      } else if (value is num) {
+        // 0/1 などを受けた場合に防御的にboolへ
+        mappedOptions[key] = value != 0;
+      } else if (value is String) {
+        // "true"/"false" を防御的にboolへ
+        mappedOptions[key] = (value.toLowerCase() == 'true');
+      }
+    });
+
+    // optionParams の読み込み
+    final rawOptionParams = (data['optionParams'] as Map<String, dynamic>?) ?? {};
+    final mappedOptionParams = <String, Map<String, dynamic>>{};
+    rawOptionParams.forEach((key, value) {
+      if (value is Map<String, dynamic>) {
+        mappedOptionParams[key] = value;
+      } else if (value is Map) {
+        mappedOptionParams[key] = Map<String, dynamic>.from(value);
+      }
+    });
+
     return Device(
       id: doc.id,
       name: data['name'] ?? '',
@@ -37,6 +66,8 @@ class Device {
       createdAt: (data['createdAt'] as Timestamp).toDate(),
       updatedAt: (data['updatedAt'] as Timestamp).toDate(),
       status: data['status'] ?? 'active',
+      options: mappedOptions,
+      optionParams: mappedOptionParams,
     );
   }
 
@@ -51,7 +82,14 @@ class Device {
       'createdAt': Timestamp.fromDate(createdAt),
       'updatedAt': Timestamp.fromDate(updatedAt),
       'status': status,
+      'options': options,
+      'optionParams': optionParams,
     };
+  }
+
+  /// 指定オプションに紐づく卓IDを取得（なければnull）
+  String? getTableIdForOption(String optionKey) {
+    return optionParams[optionKey]?['tableId'] as String?;
   }
 
   /// デバッグ用の文字列表現
@@ -71,6 +109,8 @@ class Device {
     DateTime? createdAt,
     DateTime? updatedAt,
     String? status,
+    Map<String, bool>? options,
+    Map<String, Map<String, dynamic>>? optionParams,
   }) {
     return Device(
       id: id ?? this.id,
@@ -82,6 +122,8 @@ class Device {
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       status: status ?? this.status,
+      options: options ?? this.options,
+      optionParams: optionParams ?? this.optionParams,
     );
   }
 
@@ -98,7 +140,9 @@ class Device {
         other.platform == platform &&
         other.createdAt == createdAt &&
         other.updatedAt == updatedAt &&
-        other.status == status;
+        other.status == status &&
+        _mapEquals(other.options, options) &&
+        _mapEquals(other.optionParams, optionParams);
   }
 
   /// ハッシュコード
@@ -114,7 +158,18 @@ class Device {
       createdAt,
       updatedAt,
       status,
+      options.hashCode,
+      optionParams.hashCode,
     );
+  }
+
+  /// Map の簡易比較（浅い比較）
+  static bool _mapEquals(Map a, Map b) {
+    if (a.length != b.length) return false;
+    for (final key in a.keys) {
+      if (!b.containsKey(key) || a[key] != b[key]) return false;
+    }
+    return true;
   }
 }
 

--- a/lib/pages/device_management_page.dart
+++ b/lib/pages/device_management_page.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../services/device_service.dart';
 import '../models/device.dart';
+import '../services/device_options.dart';
+
+/// 卓情報の簡易モデル
+class _TableItem {
+  final String id;
+  final String name;
+  const _TableItem({required this.id, required this.name});
+}
 
 /// デバイス管理画面（管理者用）
 class DeviceManagementPage extends StatefulWidget {
@@ -12,6 +21,7 @@ class DeviceManagementPage extends StatefulWidget {
 
 class _DeviceManagementPageState extends State<DeviceManagementPage> {
   final DeviceService _deviceService = DeviceService();
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   List<Device> _devices = [];
   bool _isLoading = true;
   String? _error;
@@ -96,6 +106,255 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text('デバイス「${device.name}」を削除しました'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('エラー: $e'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  /// 卓一覧を取得（逆用途に指定された卓を除外）
+  Future<List<_TableItem>> _getAvailableTablesForOption(
+    String optionKey,
+    String currentDeviceId,
+  ) async {
+    try {
+      // 1. tables コレクションから有効な卓を取得
+      final tablesSnap = await _firestore
+          .collection('tables')
+          .where('isEnabled', isEqualTo: true)
+          .get();
+
+      // 2. 全デバイスの optionParams を取得
+      final devicesSnap = await _firestore.collection('devices').get();
+
+      // 3. 逆用途に指定されている卓IDを収集
+      final excludedTableIds = <String>{};
+      final oppositeKey = optionKey == DeviceOptionKeys.tournamentTable
+          ? DeviceOptionKeys.sideGame
+          : DeviceOptionKeys.tournamentTable;
+
+      for (final doc in devicesSnap.docs) {
+        // 自分自身は除外対象外
+        if (doc.id == currentDeviceId) continue;
+        final params = doc.data()['optionParams'] as Map<String, dynamic>?;
+        final tableId = params?[oppositeKey]?['tableId'] as String?;
+        if (tableId != null) {
+          excludedTableIds.add(tableId);
+        }
+      }
+
+      // 4. 除外してリスト返却
+      return tablesSnap.docs
+          .where((doc) => !excludedTableIds.contains(doc.id))
+          .map((doc) {
+            final data = doc.data();
+            return _TableItem(
+              id: doc.id,
+              name: data['name'] as String? ?? doc.id,
+            );
+          })
+          .toList();
+    } catch (e) {
+      print('卓一覧取得エラー: $e');
+      return [];
+    }
+  }
+
+  Future<void> _editOptions(Device device) async {
+    final presetKeys = DeviceOptionKeys.all;
+    // 現在のオプションを編集用にコピー
+    final Map<String, bool> working = {...device.options};
+    // optionParams も編集用にコピー
+    final Map<String, Map<String, dynamic>> workingParams = {
+      for (final entry in device.optionParams.entries)
+        entry.key: Map<String, dynamic>.from(entry.value),
+    };
+
+    // 卓紐づけ可能なオプション用の選択状態
+    final Map<String, String?> selectedTableIds = {};
+    for (final key in DeviceOptionKeys.tableBindableOptions) {
+      selectedTableIds[key] = workingParams[key]?['tableId'] as String?;
+    }
+
+    // 卓一覧のキャッシュ
+    final Map<String, List<_TableItem>> tableCache = {};
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) {
+          // 排他制御: 選択時に排他グループの他のオプションをOFFにする
+          void handleOptionChange(String key, bool? value) {
+            setState(() {
+              working[key] = value == true;
+              if (value == true) {
+                // 排他グループの他のオプションをOFF
+                for (final exclusiveKey in DeviceOptionKeys.getExclusiveKeys(key)) {
+                  working[exclusiveKey] = false;
+                  // 排他されたオプションの卓紐づけもクリア
+                  if (DeviceOptionKeys.isTableBindable(exclusiveKey)) {
+                    selectedTableIds[exclusiveKey] = null;
+                    workingParams.remove(exclusiveKey);
+                  }
+                }
+              }
+              // OFFにした場合は卓紐づけもクリア
+              if (value != true && DeviceOptionKeys.isTableBindable(key)) {
+                selectedTableIds[key] = null;
+                workingParams.remove(key);
+              }
+            });
+          }
+
+          return AlertDialog(
+            title: Text('オプション編集: ${device.name}'),
+            content: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'プリセット',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  ...presetKeys.map((key) {
+                    final value = working[key] == true;
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        CheckboxListTile(
+                          value: value,
+                          onChanged: (v) => handleOptionChange(key, v),
+                          title: Text(DeviceOptionKeys.label(key)),
+                          secondary: IconButton(
+                            icon: const Icon(Icons.info_outline, color: Colors.blueAccent),
+                            tooltip: '説明を表示',
+                            onPressed: () {
+                              showDialog<void>(
+                                context: context,
+                                builder: (ctx) => AlertDialog(
+                                  title: Text(DeviceOptionKeys.label(key)),
+                                  content: Text(DeviceOptionKeys.description(key)),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.of(ctx).pop(),
+                                      child: const Text('OK'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                          dense: true,
+                          contentPadding: EdgeInsets.zero,
+                          controlAffinity: ListTileControlAffinity.leading,
+                        ),
+                        // 卓紐づけUI（有効かつ卓紐づけ可能な場合のみ表示）
+                        if (value && DeviceOptionKeys.isTableBindable(key))
+                          Padding(
+                            padding: const EdgeInsets.only(left: 48, bottom: 8),
+                            child: FutureBuilder<List<_TableItem>>(
+                              future: tableCache.containsKey(key)
+                                  ? Future.value(tableCache[key])
+                                  : _getAvailableTablesForOption(key, device.id).then((tables) {
+                                      tableCache[key] = tables;
+                                      return tables;
+                                    }),
+                              builder: (context, snapshot) {
+                                if (snapshot.connectionState == ConnectionState.waiting) {
+                                  return const SizedBox(
+                                    height: 48,
+                                    child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+                                  );
+                                }
+                                final tables = snapshot.data ?? [];
+                                return DropdownButtonFormField<String?>(
+                                  value: selectedTableIds[key],
+                                  decoration: const InputDecoration(
+                                    labelText: '卓を指定（任意）',
+                                    border: OutlineInputBorder(),
+                                    contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                  ),
+                                  items: [
+                                    const DropdownMenuItem<String?>(
+                                      value: null,
+                                      child: Text('指定なし（全卓操作可）'),
+                                    ),
+                                    ...tables.map((t) => DropdownMenuItem<String?>(
+                                      value: t.id,
+                                      child: Text(t.name),
+                                    )),
+                                  ],
+                                  onChanged: (tableId) {
+                                    setState(() {
+                                      selectedTableIds[key] = tableId;
+                                      if (tableId != null) {
+                                        workingParams[key] = {'tableId': tableId};
+                                      } else {
+                                        workingParams.remove(key);
+                                      }
+                                    });
+                                  },
+                                );
+                              },
+                            ),
+                          ),
+                      ],
+                    );
+                  }),
+                  const SizedBox(height: 12),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('キャンセル'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('保存'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+
+    if (result == true) {
+      try {
+        // プリセットのみを送信（全置換）
+        final Map<String, bool> presetOnly = {
+          for (final key in presetKeys) key: (working[key] == true)
+        };
+        // optionParams を構築
+        final Map<String, Map<String, dynamic>> finalParams = {};
+        for (final key in DeviceOptionKeys.tableBindableOptions) {
+          if (presetOnly[key] == true && selectedTableIds[key] != null) {
+            finalParams[key] = {'tableId': selectedTableIds[key]};
+          }
+        }
+        await _deviceService.updateDeviceOptions(
+          targetDeviceId: device.id,
+          options: presetOnly,
+          optionParams: finalParams,
+        );
+        await _loadDevices();
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('オプションを更新しました'),
               backgroundColor: Colors.green,
             ),
           );
@@ -365,6 +624,12 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
                       child: const Text('退役'),
                     ),
                     const Spacer(),
+                    OutlinedButton.icon(
+                      onPressed: () => _editOptions(device),
+                      icon: const Icon(Icons.tune),
+                      label: const Text('オプション編集'),
+                    ),
+                    const SizedBox(width: 8),
                     IconButton(
                       onPressed: () => _deleteDevice(device),
                       icon: const Icon(Icons.delete),
@@ -373,6 +638,29 @@ class _DeviceManagementPageState extends State<DeviceManagementPage> {
                     ),
                   ],
                 ),
+                const SizedBox(height: 8),
+                if (device.options.isNotEmpty) ...[
+                  const Text(
+                    '付与済みオプション',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 4),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: device.options.entries
+                        .where((e) => e.value == true && DeviceOptionKeys.all.contains(e.key))
+                        .map((e) {
+                          // 卓紐づけがある場合は表示
+                          final tableId = device.getTableIdForOption(e.key);
+                          final label = tableId != null
+                              ? '${DeviceOptionKeys.label(e.key)} ($tableId)'
+                              : DeviceOptionKeys.label(e.key);
+                          return Chip(label: Text(label));
+                        })
+                        .toList(),
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/services/device_options.dart
+++ b/lib/services/device_options.dart
@@ -1,0 +1,79 @@
+class DeviceOptionKeys {
+  static const String order = 'order';
+  static const String userEntryExit = 'user_entry_exit';
+  static const String staffEntryExit = 'staff_entry_exit';
+  static const String accounting = 'accounting';
+  static const String tournament = 'tournament';
+  static const String tournamentTable = 'tournament_table';
+  static const String kitchen = 'kitchen';
+  static const String sideGame = 'side_game';
+
+  static const List<String> all = <String>[
+    order,
+    userEntryExit,
+    staffEntryExit,
+    accounting,
+    tournament,
+    tournamentTable,
+    kitchen,
+    sideGame,
+  ];
+
+  /// 排他グループ: 同時に1つしか選択できないオプションのグループ
+  static const List<List<String>> exclusiveGroups = [
+    [tournament, tournamentTable],
+  ];
+
+  /// 卓紐づけが可能なオプション
+  static const List<String> tableBindableOptions = [
+    tournamentTable,
+    sideGame,
+  ];
+
+  static const Map<String, String> labels = <String, String>{
+    order: '注文操作',
+    userEntryExit: 'お客様入退店操作',
+    staffEntryExit: 'スタッフ出退勤操作',
+    accounting: '会計操作',
+    tournament: 'トーナメント運営',
+    tournamentTable: 'トーナメント卓専用',
+    kitchen: 'キッチン画面操作',
+    sideGame: 'サイドゲーム操作',
+  };
+
+  static String label(String key) {
+    return labels[key] ?? key;
+  }
+
+  static const Map<String, String> descriptions = <String, String>{
+    order: '注文の作成・カート操作・注文確定・注文履歴の閲覧など、売上に関わる一連の注文操作を行えます。',
+    userEntryExit: '来店・退店の受付（ユーザー側）に関する操作が可能になります。QRの受付や入店管理等を含みます。',
+    staffEntryExit: 'スタッフの出勤・退勤打刻や、その受付に関する操作が可能になります。',
+    accounting: '会計画面の表示、金額入力、割引・割勘・支払方法の確定など会計処理全般を行えます。',
+    tournament: 'トーナメントの作成・開始/一時停止/再開、全卓の管理、ブラインドタイマー操作など運営全般が可能です。',
+    tournamentTable: '指定された卓の詳細ページのみ表示・操作できます。卓番を指定するとその卓専用になります。',
+    kitchen: 'キッチン向けの調理・提供状況管理画面にアクセスし、注文ステータスの更新（調理中/提供済み等）ができます。',
+    sideGame: 'サイドゲームの参加/離席、チップの入出金、ステータス更新などの操作が可能になります。卓番を指定するとその卓専用になります。',
+  };
+
+  static String description(String key) {
+    return descriptions[key] ?? 'この操作に関する詳細な説明は現在準備中です。';
+  }
+
+  /// 指定キーと排他関係にあるキーを取得
+  static List<String> getExclusiveKeys(String key) {
+    for (final group in exclusiveGroups) {
+      if (group.contains(key)) {
+        return group.where((k) => k != key).toList();
+      }
+    }
+    return [];
+  }
+
+  /// 卓紐づけが可能かどうか
+  static bool isTableBindable(String key) {
+    return tableBindableOptions.contains(key);
+  }
+}
+
+

--- a/lib/services/device_service.dart
+++ b/lib/services/device_service.dart
@@ -16,6 +16,9 @@ class DeviceService {
   final FirebaseFunctions _functions = FirebaseFunctions.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
+  /// 直近取得したデバイスの簡易キャッシュ（任意）
+  Device? _cachedDevice;
+
 
   /// デバイスが登録済みかチェック
   Future<bool> isDeviceRegistered() async {
@@ -51,7 +54,9 @@ class DeviceService {
         return null;
       }
 
-      return Device.fromFirestore(doc);
+      final device = Device.fromFirestore(doc);
+      _cachedDevice = device;
+      return device;
     } catch (e) {
       print('デバイス情報取得エラー: $e');
       return null;
@@ -99,7 +104,9 @@ class DeviceService {
 
       // デバイス情報を取得して返す
       final doc = await _firestore.collection('devices').doc(deviceId).get();
-      return Device.fromFirestore(doc);
+      final device = Device.fromFirestore(doc);
+      _cachedDevice = device;
+      return device;
     } catch (e) {
       print('デバイス登録エラー: $e');
       
@@ -140,6 +147,11 @@ class DeviceService {
       }
 
       await _firestore.collection('devices').doc(deviceId).update(updateData);
+      // 更新後の最新を反映
+      final refreshed = await _firestore.collection('devices').doc(deviceId).get();
+      if (refreshed.exists) {
+        _cachedDevice = Device.fromFirestore(refreshed);
+      }
     } catch (e) {
       print('デバイス更新エラー: $e');
       rethrow;
@@ -168,6 +180,11 @@ class DeviceService {
         'status': status,
         'updatedAt': FieldValue.serverTimestamp(),
       });
+      // キャッシュ更新
+      final refreshed = await _firestore.collection('devices').doc(deviceId).get();
+      if (refreshed.exists) {
+        _cachedDevice = Device.fromFirestore(refreshed);
+      }
     } catch (e) {
       print('デバイスステータス更新エラー: $e');
       rethrow;
@@ -178,6 +195,7 @@ class DeviceService {
   Future<void> deleteDevice(String deviceId) async {
     try {
       await _firestore.collection('devices').doc(deviceId).delete();
+      _cachedDevice = null;
     } catch (e) {
       print('デバイス削除エラー: $e');
       rethrow;
@@ -220,6 +238,94 @@ class DeviceService {
     final random = Random();
     const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     return List.generate(22, (index) => chars[random.nextInt(chars.length)]).join();
+  }
+
+  /// 最新デバイス情報を再取得してキャッシュに反映
+  Future<Device?> refreshDevice() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final deviceId = prefs.getString(_deviceIdKey);
+      if (deviceId == null) {
+        return null;
+      }
+      final doc = await _firestore.collection('devices').doc(deviceId).get();
+      if (!doc.exists) {
+        _cachedDevice = null;
+        return null;
+      }
+      final device = Device.fromFirestore(doc);
+      _cachedDevice = device;
+      return device;
+    } catch (e) {
+      print('デバイス再取得エラー: $e');
+      return null;
+    }
+  }
+
+  /// デバイスが指定オプションを保持しているかチェック（adminは常に許可する運用）
+  Future<bool> hasOption(String optionKey, {bool adminBypass = true}) async {
+    try {
+      final device = _cachedDevice ?? await getCurrentDevice();
+      if (device == null) return false;
+      if (adminBypass && device.role == 'admin') return true;
+      return device.options[optionKey] == true;
+    } catch (e) {
+      print('オプションチェックエラー: $e');
+      return false;
+    }
+  }
+
+  /// 管理者用：端末のオプションを更新（CF経由）
+  Future<Map<String, bool>> updateDeviceOptions({
+    required String targetDeviceId,
+    required Map<String, bool> options,
+    Map<String, Map<String, dynamic>>? optionParams,
+  }) async {
+    try {
+      final callable = _functions.httpsCallable('updateDeviceOptions');
+      final callData = <String, dynamic>{
+        'deviceId': targetDeviceId,
+        'options': options,
+      };
+      if (optionParams != null) {
+        callData['optionParams'] = optionParams;
+      }
+      final result = await callable.call(callData);
+      final data = (result.data as Map).cast<String, dynamic>();
+      final updated = (data['options'] as Map).cast<String, bool>();
+      // 自分自身を更新した場合はキャッシュも更新
+      final prefs = await SharedPreferences.getInstance();
+      final myId = prefs.getString(_deviceIdKey);
+      if (myId != null && myId == targetDeviceId) {
+        _cachedDevice = await getCurrentDevice();
+      }
+      return updated;
+    } catch (e) {
+      print('オプション更新エラー: $e');
+      rethrow;
+    }
+  }
+
+  /// 指定オプションに紐づく卓IDを取得（キャッシュから）
+  String? getTableIdForOption(String optionKey) {
+    return _cachedDevice?.getTableIdForOption(optionKey);
+  }
+
+  /// 全デバイスのoptionParamsを取得（卓除外用）
+  Future<List<Map<String, dynamic>>> getAllDeviceOptionParams() async {
+    try {
+      final snapshot = await _firestore.collection('devices').get();
+      return snapshot.docs.map((doc) {
+        final data = doc.data();
+        return {
+          'deviceId': doc.id,
+          'optionParams': data['optionParams'] ?? {},
+        };
+      }).toList();
+    } catch (e) {
+      print('全デバイスoptionParams取得エラー: $e');
+      return [];
+    }
   }
 
   /// デバイスが管理者かチェック

--- a/lib/sideGame/pages/side_game_table_list.dart
+++ b/lib/sideGame/pages/side_game_table_list.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:amuse_app_template/globalConstant.dart';
 import 'package:amuse_app_template/sideGame/pages/side_game_table_home.dart';
+import 'package:amuse_app_template/services/device_service.dart';
+import 'package:amuse_app_template/services/device_options.dart';
 
 class SideGameTableListPage extends StatefulWidget {
   const SideGameTableListPage({super.key});
@@ -12,6 +14,51 @@ class SideGameTableListPage extends StatefulWidget {
 
 class _SideGameTableListPageState extends State<SideGameTableListPage> {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final DeviceService _deviceService = DeviceService();
+
+  String? _myTableId;
+  Set<String> _excludedTableIds = {};
+  bool _isLoadingPermissions = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPermissions();
+  }
+
+  Future<void> _loadPermissions() async {
+    try {
+      // 1. 現在のデバイス情報を取得
+      final device = await _deviceService.getCurrentDevice();
+      _myTableId = device?.getTableIdForOption(DeviceOptionKeys.sideGame);
+
+      // 2. 他デバイスでtournament_table用に指定された卓を除外リストに追加
+      final devicesSnap = await _firestore.collection('devices').get();
+      final excluded = <String>{};
+      for (final doc in devicesSnap.docs) {
+        if (doc.id == device?.id) continue; // 自分自身は除外対象外
+        final params = doc.data()['optionParams'] as Map<String, dynamic>?;
+        final tableId = params?[DeviceOptionKeys.tournamentTable]?['tableId'] as String?;
+        if (tableId != null) {
+          excluded.add(tableId);
+        }
+      }
+
+      if (mounted) {
+        setState(() {
+          _excludedTableIds = excluded;
+          _isLoadingPermissions = false;
+        });
+      }
+    } catch (e) {
+      print('権限読み込みエラー: $e');
+      if (mounted) {
+        setState(() {
+          _isLoadingPermissions = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -20,29 +67,50 @@ class _SideGameTableListPageState extends State<SideGameTableListPage> {
         title: const Text('サイドゲーム テーブル選択'),
         centerTitle: true,
       ),
-      body: StreamBuilder<QuerySnapshot>(
-        stream: _firestore.collection('tables').snapshots(),
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            return Center(
-              child: Text('エラーが発生しました: ${snapshot.error}'),
-            );
-          }
+      body: _isLoadingPermissions
+          ? const Center(child: CircularProgressIndicator())
+          : StreamBuilder<QuerySnapshot>(
+              stream: _firestore.collection('tables').snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  return Center(
+                    child: Text('エラーが発生しました: ${snapshot.error}'),
+                  );
+                }
 
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
 
-          final tables = snapshot.data!.docs
-              .where((doc) {
-                final data = doc.data() as Map<String, dynamic>;
-                return data['isEnabled'] == true;
-              })
-              .toList();
+                final tables = snapshot.data!.docs
+                    .where((doc) {
+                      final data = doc.data() as Map<String, dynamic>;
+                      if (data['isEnabled'] != true) return false;
 
-          return _buildTableGrid(tables);
-        },
-      ),
+                      // 自分に卓番付与がある場合はその卓のみ
+                      if (_myTableId != null && doc.id != _myTableId) return false;
+
+                      // 他デバイスでtournament_table用に指定された卓は除外
+                      if (_excludedTableIds.contains(doc.id)) return false;
+
+                      return true;
+                    })
+                    .toList();
+
+                if (tables.isEmpty) {
+                  return Center(
+                    child: Text(
+                      _myTableId != null
+                          ? '指定された卓が見つかりません'
+                          : '利用可能な卓がありません',
+                      style: const TextStyle(color: Colors.grey),
+                    ),
+                  );
+                }
+
+                return _buildTableGrid(tables);
+              },
+            ),
     );
   }
 

--- a/lib/tournament/dialogs/table_select_dialog.dart
+++ b/lib/tournament/dialogs/table_select_dialog.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:amuse_app_template/services/device_service.dart';
+import 'package:amuse_app_template/services/device_options.dart';
+
+/// 卓選択ダイアログ
+/// デバイスに卓番付与がある場合はその卓のみ表示
+/// 他デバイスで逆用途に指定された卓は除外
+class TableSelectDialog extends StatefulWidget {
+  final String tournamentId;
+  final String tournamentName;
+
+  const TableSelectDialog({
+    super.key,
+    required this.tournamentId,
+    required this.tournamentName,
+  });
+
+  /// ダイアログを表示し、選択された卓を返す
+  static Future<Map<String, dynamic>?> show(
+    BuildContext context, {
+    required String tournamentId,
+    required String tournamentName,
+  }) {
+    return showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (context) => TableSelectDialog(
+        tournamentId: tournamentId,
+        tournamentName: tournamentName,
+      ),
+    );
+  }
+
+  @override
+  State<TableSelectDialog> createState() => _TableSelectDialogState();
+}
+
+class _TableSelectDialogState extends State<TableSelectDialog> {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final DeviceService _deviceService = DeviceService();
+
+  bool _isLoading = true;
+  List<Map<String, dynamic>> _tables = [];
+  String? _myTableId;
+  Set<String> _excludedTableIds = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTables();
+  }
+
+  Future<void> _loadTables() async {
+    try {
+      // 1. 現在のデバイス情報を取得
+      final device = await _deviceService.getCurrentDevice();
+      _myTableId = device?.getTableIdForOption(DeviceOptionKeys.tournamentTable);
+
+      // 2. 他デバイスでside_game用に指定された卓を除外リストに追加
+      final devicesSnap = await _firestore.collection('devices').get();
+      final excluded = <String>{};
+      for (final doc in devicesSnap.docs) {
+        if (doc.id == device?.id) continue; // 自分自身は除外対象外
+        final params = doc.data()['optionParams'] as Map<String, dynamic>?;
+        final tableId = params?[DeviceOptionKeys.sideGame]?['tableId'] as String?;
+        if (tableId != null) {
+          excluded.add(tableId);
+        }
+      }
+      _excludedTableIds = excluded;
+
+      // 3. トーナメントの卓一覧を取得（tablesSeatサブコレクション）
+      final tablesSnap = await _firestore
+          .collection('scheduledTournaments')
+          .doc(widget.tournamentId)
+          .collection('tablesSeat')
+          .get();
+
+      final tables = <Map<String, dynamic>>[];
+      for (final doc in tablesSnap.docs) {
+        // waiting, busted は卓ではないのでスキップ
+        if (doc.id == 'waiting' || doc.id == 'busted') continue;
+
+        final data = doc.data();
+        final tableId = doc.id;
+
+        // 自分に卓番付与がある場合はその卓のみ
+        if (_myTableId != null && tableId != _myTableId) continue;
+
+        // 他デバイスでside_game用に指定された卓は除外
+        if (_excludedTableIds.contains(tableId)) continue;
+
+        tables.add({
+          'id': tableId,
+          'name': data['name'] as String? ?? tableId,
+          ...data,
+        });
+      }
+
+      // 卓名でソート
+      tables.sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
+
+      setState(() {
+        _tables = tables;
+        _isLoading = false;
+      });
+    } catch (e) {
+      print('卓一覧取得エラー: $e');
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('卓を選択\n${widget.tournamentName}', style: const TextStyle(fontSize: 16)),
+      content: SizedBox(
+        width: 300,
+        height: 300,
+        child: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : _tables.isEmpty
+                ? Center(
+                    child: Text(
+                      _myTableId != null
+                          ? '指定された卓がこのトーナメントに存在しません'
+                          : '卓がありません',
+                      style: const TextStyle(color: Colors.grey),
+                      textAlign: TextAlign.center,
+                    ),
+                  )
+                : ListView.builder(
+                    itemCount: _tables.length,
+                    itemBuilder: (context, index) {
+                      final table = _tables[index];
+                      final name = table['name'] as String;
+                      final seats = table['seats'] as Map<String, dynamic>? ?? {};
+                      final occupiedCount = seats.values.where((s) => s != null && s['userId'] != null).length;
+                      final maxSeats = table['maxSeats'] as int? ?? seats.length;
+
+                      return ListTile(
+                        leading: const Icon(Icons.table_restaurant),
+                        title: Text(name),
+                        subtitle: Text('$occupiedCount / $maxSeats 席'),
+                        onTap: () {
+                          Navigator.of(context).pop(table);
+                        },
+                      );
+                    },
+                  ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+      ],
+    );
+  }
+}
+

--- a/lib/tournament/dialogs/tournament_select_dialog.dart
+++ b/lib/tournament/dialogs/tournament_select_dialog.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// トーナメント選択ダイアログ
+/// 開催中と今後開催で分けて表示
+class TournamentSelectDialog extends StatefulWidget {
+  const TournamentSelectDialog({super.key});
+
+  /// ダイアログを表示し、選択されたトーナメントを返す
+  static Future<Map<String, dynamic>?> show(BuildContext context) {
+    return showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (context) => const TournamentSelectDialog(),
+    );
+  }
+
+  @override
+  State<TournamentSelectDialog> createState() => _TournamentSelectDialogState();
+}
+
+class _TournamentSelectDialogState extends State<TournamentSelectDialog>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  // 開催中: running, registered, paused
+  // 今後開催: scheduled
+  static const _activeStatuses = ['running', 'registered', 'paused'];
+  static const _upcomingStatuses = ['scheduled'];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('トーナメントを選択'),
+      contentPadding: const EdgeInsets.only(top: 16),
+      content: SizedBox(
+        width: 400,
+        height: 400,
+        child: Column(
+          children: [
+            TabBar(
+              controller: _tabController,
+              labelColor: Theme.of(context).primaryColor,
+              unselectedLabelColor: Colors.grey,
+              tabs: const [
+                Tab(text: '開催中'),
+                Tab(text: '今後開催'),
+              ],
+            ),
+            Expanded(
+              child: TabBarView(
+                controller: _tabController,
+                children: [
+                  _buildTournamentList(_activeStatuses),
+                  _buildTournamentList(_upcomingStatuses),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('キャンセル'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTournamentList(List<String> statuses) {
+    return StreamBuilder<QuerySnapshot>(
+      stream: _firestore
+          .collection('scheduledTournaments')
+          .orderBy('startAt', descending: false)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('エラー: ${snapshot.error}'));
+        }
+
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        // クライアント側でstatusをフィルタリング
+        final allDocs = snapshot.data?.docs ?? [];
+        debugPrint('全トーナメント数: ${allDocs.length}');
+        for (final d in allDocs) {
+          final dd = d.data() as Map<String, dynamic>;
+          debugPrint('ID: ${d.id}, status: ${dd['status']}');
+        }
+        final docs = allDocs.where((doc) {
+          final data = doc.data() as Map<String, dynamic>;
+          final status = data['status'] as String? ?? '';
+          debugPrint('フィルタ対象statuses: $statuses, 現在のstatus: $status, 含まれる: ${statuses.contains(status)}');
+          return statuses.contains(status);
+        }).toList();
+        debugPrint('フィルタ後: ${docs.length}件');
+
+        if (docs.isEmpty) {
+          return const Center(
+            child: Text(
+              '該当するトーナメントがありません',
+              style: TextStyle(color: Colors.grey),
+            ),
+          );
+        }
+
+        return ListView.builder(
+          itemCount: docs.length,
+          itemBuilder: (context, index) {
+            final doc = docs[index];
+            final data = doc.data() as Map<String, dynamic>;
+            final snapshotData = data['snapshot'] as Map<String, dynamic>? ?? {};
+            final name = snapshotData['name'] as String? ?? '無名のトーナメント';
+            final status = data['status'] as String? ?? '';
+            final startAt = data['startAt'] as Timestamp?;
+
+            return ListTile(
+              title: Text(name),
+              subtitle: Text('${doc.id}\n${_formatStartAt(startAt)}'),
+              isThreeLine: true,
+              trailing: _buildStatusChip(status),
+              onTap: () {
+                Navigator.of(context).pop({
+                  'id': doc.id,
+                  'name': name,
+                  'status': status,
+                  ...data,
+                });
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _formatStartAt(Timestamp? timestamp) {
+    if (timestamp == null) return '開始時刻未設定';
+    final dt = timestamp.toDate();
+    return '${dt.month}/${dt.day} ${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+  }
+
+  Widget _buildStatusChip(String status) {
+    final (label, color) = switch (status) {
+      'running' => ('実施中', Colors.orange),
+      'registered' => ('レジスト済', Colors.green),
+      'paused' => ('一時停止', Colors.amber),
+      'scheduled' => ('予定', Colors.blue),
+      _ => (status, Colors.grey),
+    };
+
+    return Chip(
+      label: Text(label, style: const TextStyle(fontSize: 12)),
+      backgroundColor: color.withValues(alpha: 0.2),
+      side: BorderSide(color: color),
+      padding: EdgeInsets.zero,
+      labelPadding: const EdgeInsets.symmetric(horizontal: 8),
+    );
+  }
+}
+

--- a/lib/tournament/pages/table_select_page.dart
+++ b/lib/tournament/pages/table_select_page.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:amuse_app_template/services/device_service.dart';
+import 'package:amuse_app_template/services/device_options.dart';
+
+/// 卓選択ページ
+/// デバイスに卓番付与がある場合はその卓のみ表示
+/// 他デバイスで逆用途に指定された卓は除外
+class TableSelectPage extends StatefulWidget {
+  final String tournamentId;
+  final String tournamentName;
+  final Function(String tableId, String tableName) onSelected;
+
+  const TableSelectPage({
+    super.key,
+    required this.tournamentId,
+    required this.tournamentName,
+    required this.onSelected,
+  });
+
+  @override
+  State<TableSelectPage> createState() => _TableSelectPageState();
+}
+
+class _TableSelectPageState extends State<TableSelectPage> {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final DeviceService _deviceService = DeviceService();
+
+  bool _isLoading = true;
+  List<Map<String, dynamic>> _tables = [];
+  String? _myTableId;
+  Set<String> _excludedTableIds = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTables();
+  }
+
+  Future<void> _loadTables() async {
+    try {
+      // 1. 現在のデバイス情報を取得
+      final device = await _deviceService.getCurrentDevice();
+      _myTableId = device?.getTableIdForOption(DeviceOptionKeys.tournamentTable);
+
+      // 2. 他デバイスでside_game用に指定された卓を除外リストに追加
+      final devicesSnap = await _firestore.collection('devices').get();
+      final excluded = <String>{};
+      for (final doc in devicesSnap.docs) {
+        if (doc.id == device?.id) continue; // 自分自身は除外対象外
+        final params = doc.data()['optionParams'] as Map<String, dynamic>?;
+        final tableId = params?[DeviceOptionKeys.sideGame]?['tableId'] as String?;
+        if (tableId != null) {
+          excluded.add(tableId);
+        }
+      }
+      _excludedTableIds = excluded;
+
+      // 3. トーナメントの卓一覧を取得（tablesSeatサブコレクション）
+      final tablesSnap = await _firestore
+          .collection('scheduledTournaments')
+          .doc(widget.tournamentId)
+          .collection('tablesSeat')
+          .get();
+
+      final tables = <Map<String, dynamic>>[];
+      for (final doc in tablesSnap.docs) {
+        // waiting, busted は卓ではないのでスキップ
+        if (doc.id == 'waiting' || doc.id == 'busted') continue;
+
+        final data = doc.data();
+        final tableId = doc.id;
+
+        // 自分に卓番付与がある場合はその卓のみ
+        if (_myTableId != null && tableId != _myTableId) continue;
+
+        // 他デバイスでside_game用に指定された卓は除外
+        if (_excludedTableIds.contains(tableId)) continue;
+
+        tables.add({
+          'id': tableId,
+          'name': data['name'] as String? ?? tableId,
+          ...data,
+        });
+      }
+
+      // 卓名でソート
+      tables.sort((a, b) => (a['name'] as String).compareTo(b['name'] as String));
+
+      setState(() {
+        _tables = tables;
+        _isLoading = false;
+      });
+    } catch (e) {
+      debugPrint('卓一覧取得エラー: $e');
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('卓を選択\n${widget.tournamentName}', style: const TextStyle(fontSize: 16)),
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _tables.isEmpty
+              ? Center(
+                  child: Text(
+                    _myTableId != null
+                        ? '指定された卓がこのトーナメントに存在しません'
+                        : '卓がありません',
+                    style: const TextStyle(color: Colors.grey),
+                    textAlign: TextAlign.center,
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: _tables.length,
+                  itemBuilder: (context, index) {
+                    final table = _tables[index];
+                    final name = table['name'] as String;
+                    final seats = table['seats'] as Map<String, dynamic>? ?? {};
+                    // seatXXUserIdで終わるキーの値がnullでないものを数える
+                    final occupiedCount = seats.entries
+                        .where((entry) => entry.key.endsWith('UserId') && entry.value != null && (entry.value as String).isNotEmpty)
+                        .length;
+                    final maxSeats = table['maxSeats'] as int? ?? seats.length;
+
+                    return ListTile(
+                      leading: const Icon(Icons.table_restaurant),
+                      title: Text(name),
+                      subtitle: Text('$occupiedCount / $maxSeats 席'),
+                      onTap: () {
+                        widget.onSelected(table['id'] as String, name);
+                      },
+                    );
+                  },
+                ),
+    );
+  }
+}
+

--- a/lib/tournament/pages/tournament_select_page.dart
+++ b/lib/tournament/pages/tournament_select_page.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:amuse_app_template/services/device_service.dart';
+import 'package:amuse_app_template/services/device_options.dart';
+
+/// トーナメント選択ページ
+/// 開催中と今後開催で分けて表示
+/// filterByTableId が指定されている場合、その卓が登録されているトーナメントのみ表示
+class TournamentSelectPage extends StatefulWidget {
+  final String title;
+  final Function(String tournamentId, String tournamentName) onSelected;
+  /// trueの場合、デバイスに指定された卓番を持つトーナメントのみ表示
+  final bool filterByDeviceTable;
+
+  const TournamentSelectPage({
+    super.key,
+    this.title = 'トーナメントを選択',
+    required this.onSelected,
+    this.filterByDeviceTable = false,
+  });
+
+  @override
+  State<TournamentSelectPage> createState() => _TournamentSelectPageState();
+}
+
+class _TournamentSelectPageState extends State<TournamentSelectPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final DeviceService _deviceService = DeviceService();
+
+  // 開催中: running, registered, paused
+  // 今後開催: scheduled
+  static const _activeStatuses = ['running', 'registered', 'paused'];
+  static const _upcomingStatuses = ['scheduled'];
+
+  String? _myTableId;
+  bool _isLoadingDevice = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    _loadDeviceInfo();
+  }
+
+  Future<void> _loadDeviceInfo() async {
+    if (widget.filterByDeviceTable) {
+      final device = await _deviceService.getCurrentDevice();
+      _myTableId = device?.getTableIdForOption(DeviceOptionKeys.tournamentTable);
+    }
+    if (mounted) {
+      setState(() {
+        _isLoadingDevice = false;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: '開催中'),
+            Tab(text: '今後開催'),
+          ],
+        ),
+      ),
+      body: _isLoadingDevice
+          ? const Center(child: CircularProgressIndicator())
+          : TabBarView(
+              controller: _tabController,
+              children: [
+                _buildTournamentList(_activeStatuses),
+                _buildTournamentList(_upcomingStatuses),
+              ],
+            ),
+    );
+  }
+
+  Widget _buildTournamentList(List<String> statuses) {
+    return StreamBuilder<QuerySnapshot>(
+      stream: _firestore
+          .collection('scheduledTournaments')
+          .orderBy('startAt', descending: false)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(child: Text('エラー: ${snapshot.error}'));
+        }
+
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        // クライアント側でstatusをフィルタリング
+        final statusFilteredDocs = (snapshot.data?.docs ?? []).where((doc) {
+          final data = doc.data() as Map<String, dynamic>;
+          final status = data['status'] as String? ?? '';
+          return statuses.contains(status);
+        }).toList();
+
+        // 卓番フィルタリングが有効で、卓番が指定されている場合
+        if (widget.filterByDeviceTable && _myTableId != null) {
+          return _buildFilteredByTableList(statusFilteredDocs, statuses);
+        }
+
+        // 通常表示
+        return _buildListView(statusFilteredDocs);
+      },
+    );
+  }
+
+  /// 卓番でフィルタリングしたトーナメントリストを構築
+  Widget _buildFilteredByTableList(List<QueryDocumentSnapshot> docs, List<String> statuses) {
+    return FutureBuilder<List<QueryDocumentSnapshot>>(
+      future: _filterTournamentsByTable(docs),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(child: Text('エラー: ${snapshot.error}'));
+        }
+
+        final filteredDocs = snapshot.data ?? [];
+        return _buildListView(filteredDocs);
+      },
+    );
+  }
+
+  /// 指定された卓が登録されているトーナメントのみをフィルタリング
+  Future<List<QueryDocumentSnapshot>> _filterTournamentsByTable(List<QueryDocumentSnapshot> docs) async {
+    if (_myTableId == null) return docs;
+
+    final result = <QueryDocumentSnapshot>[];
+    for (final doc in docs) {
+      // 各トーナメントのtablesSeatサブコレクションに指定卓が存在するかチェック
+      final tableDoc = await _firestore
+          .collection('scheduledTournaments')
+          .doc(doc.id)
+          .collection('tablesSeat')
+          .doc(_myTableId)
+          .get();
+
+      if (tableDoc.exists) {
+        result.add(doc);
+      }
+    }
+    return result;
+  }
+
+  Widget _buildListView(List<QueryDocumentSnapshot> docs) {
+    if (docs.isEmpty) {
+      return Center(
+        child: Text(
+          widget.filterByDeviceTable && _myTableId != null
+              ? '指定された卓が登録されているトーナメントがありません'
+              : '該当するトーナメントがありません',
+          style: const TextStyle(color: Colors.grey),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: docs.length,
+      itemBuilder: (context, index) {
+        final doc = docs[index];
+        final data = doc.data() as Map<String, dynamic>;
+        final snapshotData = data['snapshot'] as Map<String, dynamic>? ?? {};
+        final name = snapshotData['name'] as String? ?? '無名のトーナメント';
+        final status = data['status'] as String? ?? '';
+        final startAt = data['startAt'] as Timestamp?;
+
+        return ListTile(
+          title: Text(name),
+          subtitle: Text(_formatStartAt(startAt)),
+          trailing: _buildStatusChip(status),
+          onTap: () {
+            widget.onSelected(doc.id, name);
+          },
+        );
+      },
+    );
+  }
+
+  String _formatStartAt(Timestamp? timestamp) {
+    if (timestamp == null) return '開始時刻未設定';
+    final dt = timestamp.toDate();
+    return '${dt.month}/${dt.day} ${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+  }
+
+  Widget _buildStatusChip(String status) {
+    final (label, color) = switch (status) {
+      'running' => ('実施中', Colors.orange),
+      'registered' => ('レジスト済', Colors.green),
+      'paused' => ('一時停止', Colors.amber),
+      'scheduled' => ('予定', Colors.blue),
+      _ => (status, Colors.grey),
+    };
+
+    return Chip(
+      label: Text(label, style: const TextStyle(fontSize: 12)),
+      backgroundColor: color.withValues(alpha: 0.2),
+      side: BorderSide(color: color),
+      padding: EdgeInsets.zero,
+      labelPadding: const EdgeInsets.symmetric(horizontal: 8),
+    );
+  }
+}


### PR DESCRIPTION
…_select_pageのseats処理修正

- すべてのCloud Functionsにオプションベースのサーバサイドガードを実装
  - キッチン関連: toggleSoldOutForMenuItem, updateMenuItem, createMenuItem
  - トーナメント関連: deleteTournamentRecurrence, validateEndTournament
  - 会計関連: updateActiveBill, cancelAccounting, processRefund, getRefundHistory
  - その他: 既存の関数にも適切な権限チェックを追加
- accountingPage.dartでtournamentsフィールドが初期状態ではList、登録後はMapになる問題を修正
- table_select_page.dartでseatsの構造を正しく処理するように修正（seatXXUserIdで終わるキーの値をチェック）