### PR TITLE
fix: 注文管理UIとシステム設定画面の改善、firebase_app_check削除

### DIFF
--- a/lib/Home/systemSettingsPage.dart
+++ b/lib/Home/systemSettingsPage.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../globalConstant.dart';
+import 'createTemporaryTablePage.dart';
 
 class SystemSettingsPage extends StatefulWidget {
   const SystemSettingsPage({super.key});
@@ -23,11 +24,12 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
         backgroundColor: Colors.blue[700],
         foregroundColor: Colors.white,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
             const Text(
               'データ管理',
               style: TextStyle(
@@ -44,11 +46,10 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
                 subtitle: const Text('トーナメント用の一時テーブルを作成します'),
                 trailing: const Icon(Icons.arrow_forward_ios),
                 onTap: () {
-                  // TODO: 一時テーブル作成機能の実装
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('一時テーブル作成機能は準備中です'),
-                      backgroundColor: Colors.blue,
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const CreateTemporaryTablePage(),
                     ),
                   );
                 },
@@ -148,6 +149,7 @@ class _SystemSettingsPageState extends State<SystemSettingsPage> {
             ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/lib/OrderView/OrderManagement/order_card.dart
+++ b/lib/OrderView/OrderManagement/order_card.dart
@@ -25,52 +25,12 @@ class OrderCard extends StatelessWidget {
     final createdAt = order['createdAt'] as Timestamp?;
     final updatedAt = order['updatedAt'] as Timestamp?;
     
-    return Dismissible(
-      key: Key(order['id'] ?? ''),
-      direction: DismissDirection.endToStart,
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: 20),
-        color: Colors.green,
-        child: const Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.check_circle, color: Colors.white, size: 32),
-            Text(
-              '提供済み',
-              style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-            ),
-          ],
-        ),
-      ),
-      confirmDismiss: (direction) async {
-        return await showDialog<bool>(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('提供済みにしますか？'),
-            content: const Text('この注文を提供済みとしてマークします。'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(false),
-                child: const Text('キャンセル'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(true),
-                child: const Text('確定'),
-              ),
-            ],
-          ),
-        );
-      },
-      onDismissed: (direction) async {
-        await _markAsServed(context);
-      },
-      child: Card(
+    return Card(
         margin: const EdgeInsets.only(bottom: 8),
         child: InkWell(
           onTap: () => _handleCardTap(context),
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -119,13 +79,16 @@ class OrderCard extends StatelessWidget {
                   ],
                 ),
                 
-                const SizedBox(height: 12),
+                const SizedBox(height: 8),
                 
                 // 注文アイテム一覧
-                ...items.map<Widget>((item) {
+                ...items.asMap().entries.map<Widget>((entry) {
+                  final index = entry.key;
+                  final item = entry.value;
                   final name = item['name'] ?? '';
                   final quantity = item['quantity'] ?? 1;
                   final category = item['category'] ?? '';
+                  final isLastItem = index == items.length - 1;
                   
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 4),
@@ -147,12 +110,11 @@ class OrderCard extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            name,
-                            style: const TextStyle(fontSize: 14),
-                          ),
+                        Text(
+                          name,
+                          style: const TextStyle(fontSize: 14),
                         ),
+                        const SizedBox(width: 8),
                         Text(
                           '×$quantity',
                           style: TextStyle(
@@ -161,12 +123,27 @@ class OrderCard extends StatelessWidget {
                             color: Colors.blue[700],
                           ),
                         ),
+                        // 最後のアイテムに提供ボタンを表示
+                        if (isLastItem && (status == 'preparing' || status == 'in_progress')) ...[
+                          const Spacer(),
+                          ElevatedButton.icon(
+                            onPressed: () => _showServedConfirmation(context),
+                            icon: const Icon(Icons.check_circle, size: 27),
+                            label: const Text('提供'),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.green,
+                              foregroundColor: Colors.white,
+                              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 15),
+                              textStyle: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   );
                 }).toList(),
                 
-                const SizedBox(height: 8),
+                const SizedBox(height: 6),
                 
                 // 時間表示
                 Row(
@@ -186,7 +163,6 @@ class OrderCard extends StatelessWidget {
             ),
           ),
         ),
-      ),
     );
   }
 
@@ -292,6 +268,41 @@ class OrderCard extends StatelessWidget {
           backgroundColor: Colors.blue,
         ),
       );
+    }
+  }
+
+  /// 提供済み確認ダイアログを表示
+  Future<void> _showServedConfirmation(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Row(
+          children: [
+            Icon(Icons.check_circle, color: Colors.green),
+            SizedBox(width: 8),
+            Text('提供済みにしますか？'),
+          ],
+        ),
+        content: const Text('この注文を提供済みとしてマークします。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('提供済みにする'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      await _markAsServed(context);
     }
   }
 

--- a/lib/user_actions/order_from_user_action_popup.dart
+++ b/lib/user_actions/order_from_user_action_popup.dart
@@ -261,6 +261,14 @@ Future<void> _showQuantityAndConfirm({
                     }
                   } catch (e) {
                     if (pageContext.mounted) {
+                      // エラーの詳細をログ出力
+                      debugPrint('[OrderPop] ERROR: ${e.toString()}');
+                      debugPrint('[OrderPop] ERROR Type: ${e.runtimeType}');
+                      if (e is FirebaseFunctionsException) {
+                        debugPrint('[OrderPop] Functions Error Code: ${e.code}');
+                        debugPrint('[OrderPop] Functions Error Message: ${e.message}');
+                        debugPrint('[OrderPop] Functions Error Details: ${e.details}');
+                      }
                       ScaffoldMessenger.of(pageContext).showSnackBar(
                         SnackBar(content: Text('注文に失敗しました: $e')),
                       );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,6 @@ import cloud_firestore
 import cloud_functions
 import file_selector_macos
 import firebase_analytics
-import firebase_app_check
 import firebase_auth
 import firebase_core
 import firebase_storage
@@ -22,7 +21,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FirebaseFunctionsPlugin.register(with: registry.registrar(forPlugin: "FirebaseFunctionsPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
-  FLTFirebaseAppCheckPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAppCheckPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,30 +209,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.10+16"
-  firebase_app_check:
-    dependency: "direct main"
-    description:
-      name: firebase_app_check
-      sha256: c4124632094a4062d7a1ff0a9f9c657ff54bece5d8393af4626cb191351a2aac
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.2+10"
-  firebase_app_check_platform_interface:
-    dependency: transitive
-    description:
-      name: firebase_app_check_platform_interface
-      sha256: "4ca80bcc6c5c55289514d85e7c8ba8bc354342d23ab807b01c3f82e2fc7158e4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.1+10"
-  firebase_app_check_web:
-    dependency: transitive
-    description:
-      name: firebase_app_check_web
-      sha256: b3150a78fe18c27525af05b149724ee33bd8592a5959e484fdfa5c98e25edb5f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0+14"
   firebase_auth:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   qr_flutter: ^4.1.0
   shared_preferences: ^2.5.3
   image_picker: ^1.1.2
-  firebase_app_check: ^0.3.2+10
 
   mobile_scanner: ^6.0.2
   


### PR DESCRIPTION
- 注文管理: スワイプ機能を削除し、明示的な「提供」ボタンを追加
  - ボタンは最後のアイテムの右端に配置
  - カードをコンパクト化（上下パディング調整）
  - 個数表示を商品名のすぐ右に配置
- システム設定: SingleChildScrollViewでスクロール可能に
- firebase_app_checkを依存関係から削除（開発時不要）
- 注文処理のデバッグログ追加