### PR TITLE
feat: ユーザーアクションメニューの機能追加と改善

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,6 +9,12 @@ service cloud.firestore {
     match /users/{userId} {
       allow read: if true; // 開発用：全許可
       allow write: if false; // 書き込みはCloud Functions経由のみ
+      
+      // ログサブコレクション（pointALogs, pointBLogs, sideGameChipLogs）
+      match /{logCollection=**} {
+        allow read: if true; // 開発用：全許可
+        allow write: if false; // 書き込みはCloud Functions経由のみ
+      }
     }
 
     match /staffs/{staffId} {

--- a/functions/src/callables/appendExtra.ts
+++ b/functions/src/callables/appendExtra.ts
@@ -1,0 +1,62 @@
+/**
+ * appendExtra Cloud Function
+ * 
+ * bills/{billId}/extras サブコレクションに追加料金を追加する
+ */
+
+import { onCall } from 'firebase-functions/v2/https';
+import { HttpsError } from 'firebase-functions/v2/https';
+import { getCallerDeviceByUid, hasRequiredOption, isActive } from '../lib/devicePermissions';
+import { appendExtra, AppendExtraRequest } from '../helpers/billsApi/appendExtra';
+import { logger } from 'firebase-functions';
+
+export const appendExtraCallable = onCall(async (request) => {
+  // 認証チェック
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'User must be authenticated');
+  }
+
+  const uid = request.auth.uid;
+
+  // デバイス権限チェック
+  const device = await getCallerDeviceByUid(uid);
+  if (!device || !isActive(device.status)) {
+    throw new HttpsError('permission-denied', 'Device not registered or not active');
+  }
+
+  // 権限チェック: admin または canEditBills オプションが必要
+  const hasPermission = device.role === 'admin' || hasRequiredOption(device.options, 'canEditBills');
+  if (!hasPermission) {
+    throw new HttpsError('permission-denied', 'Device does not have canEditBills permission');
+  }
+
+  // リクエストデータの取得
+  const data = request.data as AppendExtraRequest;
+
+  // バリデーション
+  if (!data.billId || !data.name || data.amountIncl === undefined) {
+    throw new HttpsError('invalid-argument', 'billId, name, amountIncl are required');
+  }
+
+  if (data.amountIncl < 0) {
+    throw new HttpsError('invalid-argument', 'amountIncl must be 0 or greater');
+  }
+
+  try {
+    const result = await appendExtra(data);
+    return result;
+  } catch (error) {
+    logger.error('appendExtra callable error', {
+      uid,
+      billId: data.billId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    throw new HttpsError('internal', 'Failed to append extra');
+  }
+});
+

--- a/functions/src/callables/index.ts
+++ b/functions/src/callables/index.ts
@@ -51,3 +51,4 @@ export { leaveSeat } from '../sideGame/leaveSeat';
 export { withdrawTip } from '../sideGame/withdrawTip';
 export { depositTip } from '../sideGame/depositTip';
 export { updateDeviceOptions } from './updateDeviceOptions';
+export { appendExtraCallable as appendExtra } from './appendExtra';

--- a/functions/src/helpers/billsApi/appendExtra.ts
+++ b/functions/src/helpers/billsApi/appendExtra.ts
@@ -1,0 +1,270 @@
+/**
+ * appendExtra ヘルパAPI
+ * 
+ * bills/{billId}/extras サブコレクションに追加料金を追加する
+ * appendItem のパターンに従い、冪等性を保証
+ */
+
+import { getFirestore } from 'firebase-admin/firestore';
+import * as admin from 'firebase-admin';
+import { HttpsError } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions';
+import * as crypto from 'crypto';
+import { shouldDualWrite } from './dualWrite';
+
+/**
+ * リクエストペイロードの正規化ハッシュを生成
+ */
+function stableHash(input: unknown): string {
+  const json = JSON.stringify(input, Object.keys((input as any) ?? {}).sort());
+  return crypto.createHash('sha256').update(json).digest('hex');
+}
+
+export interface AppendExtraRequest {
+  billId: string;
+  name: string;
+  amountIncl: number;
+  idempotencyKey?: string; // オプション（指定されない場合は自動生成）
+}
+
+export interface AppendExtraResponse {
+  success: boolean;
+  billId: string;
+  extraId: string;
+  createdAt: string; // ISO8601形式
+  diagnostics?: {
+    reason?: string;
+    reused?: boolean;
+  };
+}
+
+/**
+ * appendExtraCore: トランザクション内で extras を作成するコアロジック
+ */
+export interface AppendExtraCoreParams {
+  billId: string;
+  name: string;
+  amountIncl: number;
+  idempotencyKey: string;
+  requestHash: string;
+}
+
+export interface AppendExtraCoreResult {
+  success: boolean;
+  billId: string;
+  extraId: string;
+  createdAt: string; // ISO8601形式（トランザクション内では空文字、後で設定）
+  reused: boolean;
+  diagnostics?: {
+    reason?: string;
+    reused?: boolean;
+  };
+  dualWriteResult?: 'success' | 'failed' | 'skipped';
+  dualWriteError?: any;
+}
+
+export async function appendExtraCore(
+  tx: admin.firestore.Transaction,
+  db: admin.firestore.Firestore,
+  params: AppendExtraCoreParams
+): Promise<AppendExtraCoreResult> {
+  const { billId, name, amountIncl, idempotencyKey, requestHash } = params;
+  
+  const billRef = db.collection('bills').doc(billId);
+  const idempotencyRef = billRef.collection('idempotency').doc(idempotencyKey);
+
+  // 1) 強い冪等チェック
+  const idemSnap = await tx.get(idempotencyRef);
+  if (idemSnap.exists) {
+    const prevHash = idemSnap.data()?.requestHash;
+    if (prevHash && prevHash !== requestHash) {
+      // ハッシュ不一致 → failed-precondition
+      throw new HttpsError(
+        'failed-precondition',
+        `Idempotency key conflict: ${idempotencyKey} (hash mismatch)`
+      );
+    }
+    // ハッシュ一致 → 再利用
+    const extraId = idemSnap.data()?.extraId as string | undefined;
+    if (extraId) {
+      // 既存のextraドキュメントを確認
+      const extraRef = billRef.collection('extras').doc(extraId);
+      const extraSnap = await tx.get(extraRef);
+      if (extraSnap.exists) {
+        return {
+          success: true,
+          billId,
+          extraId,
+          createdAt: '', // 後で設定
+          reused: true,
+          diagnostics: {
+            reason: 'Idempotency key reused',
+            reused: true,
+          },
+        };
+      }
+    }
+  }
+
+  // 2) bills/{billId} を読み込み、status チェック
+  const billSnap = await tx.get(billRef);
+  if (!billSnap.exists) {
+    throw new HttpsError('not-found', `Bill not found: ${billId}`);
+  }
+
+  const billData = billSnap.data()!;
+  const status = billData.status as string;
+  
+  // 許可: open/in_progress、拒否: settling/settled/voided
+  const allowed = status === 'open' || status === 'in_progress';
+  if (!allowed) {
+    throw new HttpsError('failed-precondition', `Cannot append extra to bill with status: ${status}`);
+  }
+
+  // 3) /bills/{billId}/extras/{extraId} を作成（extraId = idempotencyKey）
+  const extraId = idempotencyKey;
+  const extraRef = billRef.collection('extras').doc(extraId);
+  const now = admin.firestore.FieldValue.serverTimestamp();
+
+  // 4) デュアルライト: todaysBills の読み取りを書き込みの前に実行（トランザクションの制約）
+  let legacyRef: admin.firestore.DocumentReference | null = null;
+  let legacySnap: admin.firestore.DocumentSnapshot | null = null;
+  if (shouldDualWrite()) {
+    legacyRef = db.collection('todaysBills').doc(billId);
+    legacySnap = await tx.get(legacyRef);
+  }
+  
+  // 5) 書き込み操作（すべての読み取りの後に実行）
+  tx.set(extraRef, {
+    name,
+    amountIncl,
+    createdAt: now,
+  });
+
+  // 6) 親 /bills/{billId}.updatedAt を更新
+  tx.update(billRef, {
+    updatedAt: now,
+  });
+
+  // 7) /bills/{billId}/idempotency/{idempotencyKey} を作成（extraIdを保存）
+  tx.set(idempotencyRef, {
+    requestHash,
+    extraId,
+    createdAt: now,
+  });
+
+  // 8) DualWrite（必要に応じて）
+  let dualWriteResult: 'success' | 'failed' | 'skipped' = 'skipped';
+  let dualWriteError: any = null;
+  
+  if (shouldDualWrite() && legacyRef && legacySnap) {
+    try {
+      // DualWriteの実装は省略（必要に応じて追加）
+      dualWriteResult = 'skipped';
+    } catch (error) {
+      dualWriteResult = 'failed';
+      dualWriteError = error;
+      logger.warn('DualWrite failed for appendExtra', { billId, extraId, error });
+    }
+  }
+
+  return {
+    success: true,
+    billId,
+    extraId,
+    createdAt: '', // 後で設定
+    reused: false,
+    dualWriteResult,
+    dualWriteError,
+  };
+}
+
+/**
+ * 伝票に追加料金を追加
+ * 
+ * @param request リクエスト
+ * @returns レスポンス
+ */
+export async function appendExtra(request: AppendExtraRequest): Promise<AppendExtraResponse> {
+  const { billId, name, amountIncl, idempotencyKey } = request;
+
+  // バリデーション
+  if (!billId || !name || amountIncl === undefined) {
+    throw new HttpsError('invalid-argument', 'billId, name, amountIncl are required');
+  }
+
+  if (amountIncl < 0) {
+    throw new HttpsError('invalid-argument', 'amountIncl must be 0 or greater');
+  }
+
+  const db = getFirestore();
+  const billRef = db.collection('bills').doc(billId);
+
+  // idempotencyKeyが指定されていない場合は自動生成
+  const finalIdempotencyKey = idempotencyKey || `extra_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+
+  // requestHash を生成（billId, name, amountIncl を正規化）
+  const requestHash = stableHash({
+    billId,
+    name,
+    amountIncl,
+  });
+
+  let reused = false;
+
+  try {
+    const result: AppendExtraCoreResult = await db.runTransaction(async (tx) => {
+      return await appendExtraCore(tx, db, {
+        billId,
+        name,
+        amountIncl,
+        idempotencyKey: finalIdempotencyKey,
+        requestHash,
+      });
+    });
+    
+    reused = result.reused;
+
+    // トランザクション後に extra ドキュメントを読み直して createdAt の実値を取得
+    const extraRef = billRef.collection('extras').doc(result.extraId);
+    const extraSnap = await extraRef.get();
+    if (!extraSnap.exists) {
+      throw new HttpsError('internal', 'Extra document not found after transaction');
+    }
+    const extraData = extraSnap.data()!;
+    const createdAt = extraData.createdAt;
+    const createdAtIso = createdAt && createdAt.toDate ? createdAt.toDate().toISOString() : new Date().toISOString();
+
+    // createdAt を設定
+    result.createdAt = createdAtIso;
+
+    logger.info('appendExtra', {
+      op: 'appendExtra',
+      billId,
+      extraId: result.extraId,
+      idempKey: finalIdempotencyKey,
+      result: reused ? 'reused' : 'ok',
+      requestHash8: requestHash.substring(0, 8),
+    });
+
+    // dualWriteResult と dualWriteError を戻り値から削除（内部情報のみ）
+    const { dualWriteResult: _, dualWriteError: __, ...response } = result;
+    return response as AppendExtraResponse;
+  } catch (error) {
+    logger.error('appendExtra: failed', {
+      op: 'appendExtra',
+      billId,
+      idempKey: finalIdempotencyKey,
+      result: 'fail',
+      code: error instanceof HttpsError ? error.code : 'internal',
+      reason: error instanceof Error ? error.message : String(error),
+      requestHash8: requestHash.substring(0, 8),
+    });
+    
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    throw new HttpsError('internal', 'Failed to append extra');
+  }
+}
+

--- a/lib/Home/stayingUsersListPage.dart
+++ b/lib/Home/stayingUsersListPage.dart
@@ -86,7 +86,6 @@ class _StayingUsersListPageState extends State<StayingUsersListPage> {
           pokerName.isEmpty ? '(名前未設定)' : pokerName,
           style: const TextStyle(fontWeight: FontWeight.bold),
         ),
-        subtitle: Text('Table: ${currentTable ?? '-'}   Seat: ${currentSeat ?? '-'}'), // activeStays には含まれないため常に '-'
         // trailing は削除（アイコン非表示）
         onTap: () {
           showUserActionHome(

--- a/lib/user_actions/add_extra_popup.dart
+++ b/lib/user_actions/add_extra_popup.dart
@@ -1,0 +1,581 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:async';
+
+/// 追加料金を手動で追加するダイアログ
+Future<void> showAddExtraDialog({
+  required BuildContext context,
+  required Map<String, dynamic> user,
+}) async {
+  final outerCtx = context;
+  final String billId = (user['billId'] ?? '').toString();
+  final String pokerName = (user['pokerName'] ?? '(名前未設定)').toString();
+
+  if (billId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('伝票IDが見つかりません')),
+      );
+    }
+    return;
+  }
+
+  final TextEditingController amountController = TextEditingController();
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
+  await showDialog<void>(
+    context: outerCtx,
+    barrierDismissible: true,
+    builder: (dialogCtx) {
+      return Dialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Container(
+          constraints: const BoxConstraints(maxWidth: 600, maxHeight: 700),
+          child: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // ヘッダー
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: Colors.green.shade50,
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(16),
+                      topRight: Radius.circular(16),
+                    ),
+                  ),
+                  child: Row(
+                    children: const [
+                      Icon(Icons.attach_money, color: Colors.green),
+                      SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          '追加料金',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                // コンテンツ
+                Flexible(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // 対象ユーザー
+                        Text(
+                          '対象ユーザー: $pokerName',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        // 注意文（会計データについて）
+                        Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Colors.orange.shade50,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: Colors.orange.shade200),
+                          ),
+                          child: const Text(
+                            '下記の会計データは実際の会計データからズレがある場合があります。正確なデータは会計管理画面から確認してください。',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.orange,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        // 現時点の未会計データ
+                        const Text(
+                          '現時点の未会計データ',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        StreamBuilder<DocumentSnapshot>(
+                          stream: FirebaseFirestore.instance
+                              .collection('bills')
+                              .doc(billId)
+                              .snapshots(),
+                          builder: (context, billSnapshot) {
+                            if (!billSnapshot.hasData || !billSnapshot.data!.exists) {
+                              return const Center(child: CircularProgressIndicator());
+                            }
+
+                            return StreamBuilder<List<Map<String, dynamic>>>(
+                              stream: _getBillSubcollections(billId),
+                              builder: (context, subcollectionsSnapshot) {
+                                if (subcollectionsSnapshot.connectionState == ConnectionState.waiting) {
+                                  return const Center(child: CircularProgressIndicator());
+                                }
+
+                                final categories = subcollectionsSnapshot.data ?? [];
+                                int totalAmount = 0;
+
+                                for (final category in categories) {
+                                  totalAmount += category['amount'] as int? ?? 0;
+                                }
+
+                                return Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    // カテゴリごとの金額
+                                    ...categories.map((category) {
+                                      final categoryName = category['name'] as String;
+                                      final amount = category['amount'] as int;
+                                      if (amount == 0) return const SizedBox.shrink();
+                                      
+                                      return Padding(
+                                        padding: const EdgeInsets.only(bottom: 8),
+                                        child: Row(
+                                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                          children: [
+                                            Text(categoryName),
+                                            Text(
+                                              '¥${amount.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                              style: const TextStyle(fontWeight: FontWeight.bold),
+                                            ),
+                                          ],
+                                        ),
+                                      );
+                                    }),
+                                    const Divider(),
+                                    // 合計金額
+                                    Row(
+                                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                      children: [
+                                        const Text(
+                                          '合計金額',
+                                          style: TextStyle(
+                                            fontSize: 18,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                        Text(
+                                          '¥${totalAmount.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                          style: const TextStyle(
+                                            fontSize: 18,
+                                            fontWeight: FontWeight.bold,
+                                            color: Colors.green,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                );
+                              },
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        // 注意文（追加料金について）
+                        Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Colors.grey.shade100,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: Colors.grey.shade300),
+                          ),
+                          child: const Text(
+                            'ここで追加された料金はその他料金カテゴリに追加料金として保存されます',
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        // 金額入力フィールド
+                        TextFormField(
+                          controller: amountController,
+                          decoration: const InputDecoration(
+                            labelText: '金額',
+                            hintText: '0',
+                            prefixText: '¥',
+                            border: OutlineInputBorder(),
+                          ),
+                          keyboardType: TextInputType.number,
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return '金額を入力してください';
+                            }
+                            final amount = int.tryParse(value);
+                            if (amount == null || amount < 0) {
+                              return '0以上の数値を入力してください';
+                            }
+                            return null;
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                // アクション
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.of(dialogCtx).pop(),
+                        child: const Text('キャンセル'),
+                      ),
+                      const SizedBox(width: 8),
+                      ElevatedButton(
+                        onPressed: () async {
+                          if (!formKey.currentState!.validate()) {
+                            return;
+                          }
+
+                          final amount = int.tryParse(amountController.text);
+                          if (amount == null || amount < 0) {
+                            return;
+                          }
+
+                          // 確認ダイアログを表示
+                          Navigator.of(dialogCtx).pop();
+                          
+                          final confirmed = await showDialog<bool>(
+                            context: outerCtx,
+                            builder: (confirmCtx) => AlertDialog(
+                              title: const Text('追加料金の確認'),
+                              content: Text('¥${amount.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')} を追加しますか？'),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.of(confirmCtx).pop(false),
+                                  child: const Text('キャンセル'),
+                                ),
+                                ElevatedButton(
+                                  onPressed: () => Navigator.of(confirmCtx).pop(true),
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: Colors.green,
+                                    foregroundColor: Colors.white,
+                                  ),
+                                  child: const Text('確定'),
+                                ),
+                              ],
+                            ),
+                          );
+
+                          if (confirmed == true) {
+                            await _executeAddExtra(
+                              context: outerCtx,
+                              billId: billId,
+                              pokerName: pokerName,
+                              amount: amount,
+                            );
+                          }
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green,
+                          foregroundColor: Colors.white,
+                        ),
+                        child: const Text('確定'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+/// billsのサブコレクションからカテゴリごとの金額を取得
+Stream<List<Map<String, dynamic>>> _getBillSubcollections(String billId) async* {
+  final billRef = FirebaseFirestore.instance.collection('bills').doc(billId);
+  
+  // extras
+  final extrasSnapshot = await billRef.collection('extras').get();
+  int extraCostAmount = extrasSnapshot.docs.fold(0, (sum, doc) {
+    return sum + ((doc.data()['amountIncl'] as num?)?.toInt() ?? 0);
+  });
+  
+  // items
+  final itemsSnapshot = await billRef.collection('items').get();
+  int itemsAmount = itemsSnapshot.docs.fold(0, (sum, doc) {
+    return sum + ((doc.data()['totalPriceIncl'] as num?)?.toInt() ?? 0);
+  });
+  
+  // sideGameChips (action='purchase'のみ)
+  final sideGameChipsSnapshot = await billRef.collection('sideGameChips').get();
+  int sideGameChipAmount = sideGameChipsSnapshot.docs
+      .where((doc) => doc.data()['action'] == 'purchase')
+      .fold(0, (sum, doc) {
+        return sum + ((doc.data()['amountIncl'] as num?)?.toInt() ?? 0);
+      });
+  
+  // tournaments
+  final tournamentsSnapshot = await billRef.collection('tournaments').get();
+  int tournamentsAmount = tournamentsSnapshot.docs.fold(0, (sum, doc) {
+    final data = doc.data();
+    final entryFeeIncl = (data['entryFeeIncl'] as num?)?.toInt() ?? 0;
+    final entryCount = (data['entryCount'] as num?)?.toInt() ?? 0;
+    final reentryFeeIncl = (data['reentryFeeIncl'] as num?)?.toInt() ?? 0;
+    final reentryCount = (data['reentryCount'] as num?)?.toInt() ?? 0;
+    final addonFeeIncl = (data['addonFeeIncl'] as num?)?.toInt() ?? 0;
+    final addonCount = (data['addonCount'] as num?)?.toInt() ?? 0;
+    return sum + (entryFeeIncl * entryCount) + (reentryFeeIncl * reentryCount) + (addonFeeIncl * addonCount);
+  });
+  
+  yield [
+    {'name': 'その他料金', 'amount': extraCostAmount},
+    {'name': 'フード・ドリンク', 'amount': itemsAmount},
+    {'name': 'サイドゲームチップ', 'amount': sideGameChipAmount},
+    {'name': 'トーナメント', 'amount': tournamentsAmount},
+  ];
+  
+  // リアルタイム更新のために監視
+  final extrasStream = billRef.collection('extras').snapshots();
+  final itemsStream = billRef.collection('items').snapshots();
+  final sideGameChipsStream = billRef.collection('sideGameChips').snapshots();
+  final tournamentsStream = billRef.collection('tournaments').snapshots();
+  
+  await for (final snapshots in _combineSubcollectionStreams([
+    extrasStream,
+    itemsStream,
+    sideGameChipsStream,
+    tournamentsStream,
+  ])) {
+    final extras = snapshots[0].docs;
+    final items = snapshots[1].docs;
+    final sideGameChips = snapshots[2].docs;
+    final tournaments = snapshots[3].docs;
+    
+    int extraCostAmount = extras.fold(0, (sum, doc) {
+      final data = doc.data() as Map<String, dynamic>? ?? {};
+      return sum + ((data['amountIncl'] as num?)?.toInt() ?? 0);
+    });
+    
+    int itemsAmount = items.fold(0, (sum, doc) {
+      final data = doc.data() as Map<String, dynamic>? ?? {};
+      return sum + ((data['totalPriceIncl'] as num?)?.toInt() ?? 0);
+    });
+    
+    int sideGameChipAmount = sideGameChips
+        .where((doc) {
+          final data = doc.data() as Map<String, dynamic>? ?? {};
+          return data['action'] == 'purchase';
+        })
+        .fold(0, (sum, doc) {
+          final data = doc.data() as Map<String, dynamic>? ?? {};
+          return sum + ((data['amountIncl'] as num?)?.toInt() ?? 0);
+        });
+    
+    int tournamentsAmount = tournaments.fold(0, (sum, doc) {
+      final data = doc.data() as Map<String, dynamic>? ?? {};
+      final entryFeeIncl = (data['entryFeeIncl'] as num?)?.toInt() ?? 0;
+      final entryCount = (data['entryCount'] as num?)?.toInt() ?? 0;
+      final reentryFeeIncl = (data['reentryFeeIncl'] as num?)?.toInt() ?? 0;
+      final reentryCount = (data['reentryCount'] as num?)?.toInt() ?? 0;
+      final addonFeeIncl = (data['addonFeeIncl'] as num?)?.toInt() ?? 0;
+      final addonCount = (data['addonCount'] as num?)?.toInt() ?? 0;
+      return sum + (entryFeeIncl * entryCount) + (reentryFeeIncl * reentryCount) + (addonFeeIncl * addonCount);
+    });
+    
+    yield [
+      {'name': 'その他料金', 'amount': extraCostAmount},
+      {'name': 'フード・ドリンク', 'amount': itemsAmount},
+      {'name': 'サイドゲームチップ', 'amount': sideGameChipAmount},
+      {'name': 'トーナメント', 'amount': tournamentsAmount},
+    ];
+  }
+}
+
+Stream<List<QuerySnapshot>> _combineSubcollectionStreams(List<Stream<QuerySnapshot>> streams) {
+  if (streams.isEmpty) {
+    return Stream.value([]);
+  }
+  
+  final controller = StreamController<List<QuerySnapshot>>();
+  final List<QuerySnapshot?> latest = List.filled(streams.length, null);
+  final List<StreamSubscription> subscriptions = [];
+  
+  void checkAndEmit() {
+    if (latest.every((snapshot) => snapshot != null)) {
+      controller.add(latest.cast<QuerySnapshot>());
+    }
+  }
+  
+  for (int i = 0; i < streams.length; i++) {
+    final index = i;
+    subscriptions.add(
+      streams[i].listen(
+        (snapshot) {
+          latest[index] = snapshot;
+          checkAndEmit();
+        },
+        onError: controller.addError,
+      ),
+    );
+  }
+  
+  controller.onCancel = () {
+    for (final sub in subscriptions) {
+      sub.cancel();
+    }
+  };
+  
+  return controller.stream;
+}
+
+/// 追加料金処理を実行
+Future<void> _executeAddExtra({
+  required BuildContext context,
+  required String billId,
+  required String pokerName,
+  required int amount,
+}) async {
+  if (!context.mounted) return;
+
+  final overlayState = Overlay.maybeOf(context, rootOverlay: true);
+  OverlayEntry? loadingOverlay;
+  bool loadingShown = false;
+
+  void hideLoading() {
+    if (loadingShown) {
+      try {
+        loadingOverlay?.remove();
+      } catch (_) {
+        // noop
+      }
+      loadingOverlay = null;
+      loadingShown = false;
+    }
+  }
+
+  try {
+    // ローディング表示
+    loadingOverlay = OverlayEntry(
+      builder: (_) => Material(
+        color: Colors.black54,
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                SizedBox(width: 16),
+                Text('追加料金処理中...'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    if (overlayState != null) {
+      overlayState.insert(loadingOverlay!);
+      loadingShown = true;
+    }
+
+    // Cloud Function呼び出し
+    final functions = FirebaseFunctions.instance;
+    final callable = functions.httpsCallable('appendExtra');
+
+    final result = await callable.call({
+      'billId': billId,
+      'name': '追加料金',
+      'amountIncl': amount,
+    }).timeout(
+      const Duration(seconds: 30),
+      onTimeout: () => throw TimeoutException('Cloud Functionの呼び出しがタイムアウトしました'),
+    );
+
+    if (!context.mounted) {
+      hideLoading();
+      return;
+    }
+
+    final data = result.data as Map<String, dynamic>? ?? {};
+    final bool ok = data['success'] == true;
+
+    hideLoading();
+
+    if (ok) {
+      await showDialog(
+        context: context,
+        builder: (dCtx) => AlertDialog(
+          title: Row(
+            children: const [
+              Icon(Icons.check_circle, color: Colors.green),
+              SizedBox(width: 8),
+              Text('完了'),
+            ],
+          ),
+          content: Text('$pokerName様に追加料金¥${amount.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}を追加しました'),
+          actions: [
+            ElevatedButton(
+              onPressed: () => Navigator.of(dCtx).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      final err = data['error'] ?? '不明なエラー';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('追加料金の登録に失敗しました: $err'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  } on TimeoutException {
+    hideLoading();
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('処理がタイムアウトしました。しばらく待ってから再試行してください。'),
+          backgroundColor: Colors.red,
+          duration: Duration(seconds: 5),
+        ),
+      );
+    }
+  } catch (e) {
+    hideLoading();
+    if (context.mounted) {
+      final msg = e.toString();
+      String ui = '追加料金の登録に失敗しました';
+      if (msg.contains('network')) {
+        ui = 'ネットワークエラーが発生しました。接続を確認してください。';
+      } else if (msg.contains('permission')) {
+        ui = '権限が不足しています。管理者に連絡してください。';
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(ui),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 5),
+        ),
+      );
+    }
+  } finally {
+    hideLoading();
+  }
+}
+

--- a/lib/user_actions/chip_point_logs_page.dart
+++ b/lib/user_actions/chip_point_logs_page.dart
@@ -1,0 +1,394 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// チップ・ポイント履歴参照ページ
+class ChipPointLogsPage extends StatefulWidget {
+  final String userId;
+  final String pokerName;
+
+  const ChipPointLogsPage({
+    super.key,
+    required this.userId,
+    required this.pokerName,
+  });
+
+  @override
+  State<ChipPointLogsPage> createState() => _ChipPointLogsPageState();
+}
+
+class _ChipPointLogsPageState extends State<ChipPointLogsPage> {
+  String _selectedLogType = 'pointA'; // 'pointA', 'pointB', 'sideGameChip'
+  String? _selectedDate; // 選択された日付（YYYY-MM-DD形式）
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${widget.pokerName} - 履歴'),
+      ),
+      body: Column(
+        children: [
+          // ログタイプ選択
+          Container(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: SegmentedButton<String>(
+                    segments: const [
+                      ButtonSegment(
+                        value: 'pointA',
+                        label: Text('Point A'),
+                        icon: Icon(Icons.account_balance_wallet),
+                      ),
+                      ButtonSegment(
+                        value: 'pointB',
+                        label: Text('Point B'),
+                        icon: Icon(Icons.account_balance_wallet),
+                      ),
+                      ButtonSegment(
+                        value: 'sideGameChip',
+                        label: Text('SideGame Chip'),
+                        icon: Icon(Icons.casino),
+                      ),
+                    ],
+                    selected: {_selectedLogType},
+                    onSelectionChanged: (Set<String> newSelection) {
+                      setState(() {
+                        _selectedLogType = newSelection.first;
+                        _selectedDate = null; // ログタイプ変更時は日付をリセット
+                      });
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // 日付選択
+          StreamBuilder<List<String>>(
+            stream: _getAvailableDates(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const SizedBox(
+                  height: 60,
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+
+              final dates = snapshot.data ?? [];
+              
+              // デフォルトで直近の日付を選択
+              if (_selectedDate == null && dates.isNotEmpty) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  setState(() {
+                    _selectedDate = dates.first;
+                  });
+                });
+              }
+
+              if (dates.isEmpty) {
+                return const SizedBox(
+                  height: 60,
+                  child: Center(child: Text('利用可能な日付がありません')),
+                );
+              }
+
+              return Container(
+                height: 60,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: dates.length,
+                  itemBuilder: (context, index) {
+                    final date = dates[index];
+                    final isSelected = _selectedDate == date;
+                    final dateObj = DateTime.parse(date);
+                    final displayText = '${dateObj.month}/${dateObj.day}';
+
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      child: ChoiceChip(
+                        label: Text(displayText),
+                        selected: isSelected,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setState(() {
+                              _selectedDate = date;
+                            });
+                          }
+                        },
+                        selectedColor: Colors.blue.shade100,
+                        backgroundColor: Colors.grey.shade200,
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+          // ログ一覧
+          Expanded(
+            child: _buildLogsList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogsList() {
+    if (_selectedDate == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    String collectionName;
+    switch (_selectedLogType) {
+      case 'pointA':
+        collectionName = 'pointALogs';
+        break;
+      case 'pointB':
+        collectionName = 'pointBLogs';
+        break;
+      case 'sideGameChip':
+        collectionName = 'sideGameChipLogs';
+        break;
+      default:
+        collectionName = 'pointALogs';
+    }
+
+    return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+      stream: FirebaseFirestore.instance
+          .collection('users')
+          .doc(widget.userId)
+          .collection(collectionName)
+          .doc(_selectedDate!)
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.error, color: Colors.red, size: 48),
+                const SizedBox(height: 16),
+                Text(
+                  'エラーが発生しました',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.red[700],
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  snapshot.error.toString(),
+                  style: const TextStyle(fontSize: 14),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          );
+        }
+
+        if (!snapshot.hasData || !snapshot.data!.exists) {
+          return const Center(
+            child: Text('この日付の履歴がありません'),
+          );
+        }
+
+        final docData = snapshot.data!.data()!;
+        final logs = docData['logs'] as Map<String, dynamic>? ?? {};
+
+        if (logs.isEmpty) {
+          return const Center(
+            child: Text('履歴がありません'),
+          );
+        }
+
+        // logs内のエントリをリストに変換
+        final logEntries = logs.entries.map((entry) {
+          final entryData = entry.value as Map<String, dynamic>;
+          return {
+            'entryId': entry.key,
+            'actor': entryData['actor'] as String? ?? '',
+            'amountDelta': entryData['amountDelta'] as num? ?? 0,
+            'appliedAt': entryData['appliedAt'] as Timestamp?,
+            'category': entryData['category'] as String? ?? '',
+            'reasonType': entryData['reasonType'] as String? ?? '',
+          };
+        }).toList();
+
+        // appliedAtでソート（最新が上）
+        logEntries.sort((a, b) {
+          final aTime = a['appliedAt'] as Timestamp?;
+          final bTime = b['appliedAt'] as Timestamp?;
+          if (aTime == null && bTime == null) return 0;
+          if (aTime == null) return 1;
+          if (bTime == null) return -1;
+          return bTime.compareTo(aTime);
+        });
+
+        return ListView.builder(
+          itemCount: logEntries.length,
+          itemBuilder: (context, index) {
+            final log = logEntries[index];
+            final amountDelta = log['amountDelta'] as num? ?? 0;
+            final appliedAt = log['appliedAt'] as Timestamp?;
+            final category = log['category'] as String? ?? '';
+
+            String formattedDate = '日時不明';
+            if (appliedAt != null) {
+              final date = appliedAt.toDate();
+              formattedDate = '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+            }
+
+            // categoryに応じて色を決定
+            Color amountColor = Colors.black;
+            IconData iconData = Icons.info;
+            if (category == 'income') {
+              amountColor = Colors.green;
+              iconData = Icons.arrow_upward;
+            } else if (category == 'expense') {
+              amountColor = Colors.red;
+              iconData = Icons.arrow_downward;
+            } else if (category == 'purchase') {
+              amountColor = Colors.orange;
+              iconData = Icons.shopping_cart;
+            }
+
+            // categoryの表示名（ログタイプに応じて変更）
+            String categoryDisplayName = category;
+            switch (category) {
+              case 'income':
+                if (_selectedLogType == 'sideGameChip') {
+                  categoryDisplayName = '預け入れ';
+                } else {
+                  // pointA, pointB
+                  categoryDisplayName = '獲得';
+                }
+                break;
+              case 'expense':
+                if (_selectedLogType == 'sideGameChip') {
+                  categoryDisplayName = '引出し';
+                } else {
+                  // pointA, pointB
+                  categoryDisplayName = '使用';
+                }
+                break;
+              case 'purchase':
+                categoryDisplayName = '購入';
+                break;
+            }
+
+            return Card(
+              margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: amountColor.withOpacity(0.1),
+                  child: Icon(
+                    iconData,
+                    color: amountColor,
+                  ),
+                ),
+                title: Text(
+                  categoryDisplayName,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                subtitle: Text(formattedDate),
+                trailing: Text(
+                  '${amountDelta >= 0 ? '+' : ''}${amountDelta.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: amountColor,
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// 利用可能な日付（直近10個）を取得
+  Stream<List<String>> _getAvailableDates() async* {
+    String collectionName;
+    switch (_selectedLogType) {
+      case 'pointA':
+        collectionName = 'pointALogs';
+        break;
+      case 'pointB':
+        collectionName = 'pointBLogs';
+        break;
+      case 'sideGameChip':
+        collectionName = 'sideGameChipLogs';
+        break;
+      default:
+        collectionName = 'pointALogs';
+    }
+
+    // 過去30日分の日付を生成
+    final dates = List.generate(30, (index) {
+      final date = DateTime.now().subtract(Duration(days: index));
+      return date.toIso8601String().split('T')[0];
+    });
+
+    // 各日付のドキュメントの存在を確認
+    final List<String> availableDates = [];
+    for (final date in dates) {
+      try {
+        final doc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(widget.userId)
+            .collection(collectionName)
+            .doc(date)
+            .get();
+        
+        if (doc.exists) {
+          availableDates.add(date);
+          // 最大10個まで
+          if (availableDates.length >= 10) {
+            break;
+          }
+        }
+      } catch (e) {
+        // エラーは無視して続行
+        continue;
+      }
+    }
+
+    yield availableDates;
+
+    // リアルタイム更新：当日のドキュメントを監視
+    final today = DateTime.now().toIso8601String().split('T')[0];
+    if (dates.contains(today)) {
+      await for (final doc in FirebaseFirestore.instance
+          .collection('users')
+          .doc(widget.userId)
+          .collection(collectionName)
+          .doc(today)
+          .snapshots()) {
+        final List<String> updatedDates = List.from(availableDates);
+        
+        if (doc.exists && !updatedDates.contains(today)) {
+          // 当日のドキュメントが存在し、リストに含まれていない場合は追加
+          updatedDates.insert(0, today);
+          // 最大10個まで
+          if (updatedDates.length > 10) {
+            updatedDates.removeLast();
+          }
+        } else if (!doc.exists && updatedDates.contains(today)) {
+          // 当日のドキュメントが削除された場合はリストから削除
+          updatedDates.remove(today);
+        }
+        
+        yield updatedDates;
+      }
+    }
+  }
+}
+

--- a/lib/user_actions/chip_point_view_popup.dart
+++ b/lib/user_actions/chip_point_view_popup.dart
@@ -1,0 +1,327 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'chip_point_logs_page.dart';
+
+/// 所持チップ・所持ポイント参照ポップアップ
+Future<void> showChipPointViewDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+}) async {
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _ChipPointViewDialog(userId: userId, pokerName: pokerName),
+  );
+}
+
+class _ChipPointViewDialog extends StatelessWidget {
+  final String userId;
+  final String pokerName;
+
+  const _ChipPointViewDialog({
+    required this.userId,
+    required this.pokerName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 500, maxHeight: 600),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // ヘッダー
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.orange.shade50,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                ),
+              ),
+              child: Row(
+                children: const [
+                  Icon(Icons.volunteer_activism, color: Colors.orange),
+                  SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        Text(
+                          '所持チップ',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          '所持ポイント',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // コンテンツ
+            Flexible(
+              child: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+                stream: FirebaseFirestore.instance
+                    .collection('users')
+                    .doc(userId)
+                    .snapshots(),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (snapshot.hasError) {
+                    return Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.error, color: Colors.red, size: 48),
+                          const SizedBox(height: 16),
+                          Text(
+                            'エラーが発生しました',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.red[700],
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            snapshot.error.toString(),
+                            style: const TextStyle(fontSize: 14),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  if (!snapshot.hasData || !snapshot.data!.exists) {
+                    return Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.person_off, color: Colors.grey, size: 48),
+                          const SizedBox(height: 16),
+                          Text(
+                            'ユーザー情報が見つかりません',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.grey[700],
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  final userData = snapshot.data!.data() as Map<String, dynamic>? ?? {};
+                  final pointA = userData['pointA'] as num? ?? 0;
+                  final pointB = userData['pointB'] as num? ?? 0;
+                  final sideGameChip = userData['sideGameChip'] as num? ?? 0;
+
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // ユーザー名表示
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 12,
+                            horizontal: 16,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.blue.shade50,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: Colors.blue.shade200),
+                          ),
+                          child: Column(
+                            children: [
+                              const Icon(Icons.person, color: Colors.blue, size: 16),
+                              const SizedBox(height: 4),
+                              Text(
+                                pokerName,
+                                style: const TextStyle(
+                                  fontSize: 9,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.blue,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+
+                        // PointA表示
+                        _buildBalanceCard(
+                          title: 'Point A',
+                          amount: pointA.toInt(),
+                          icon: Icons.account_balance_wallet,
+                          color: Colors.blue,
+                        ),
+                        const SizedBox(height: 6),
+
+                        // PointB表示
+                        _buildBalanceCard(
+                          title: 'Point B',
+                          amount: pointB.toInt(),
+                          icon: Icons.account_balance_wallet,
+                          color: Colors.green,
+                        ),
+                        const SizedBox(height: 6),
+
+                        // SideGameChip表示
+                        _buildBalanceCard(
+                          title: 'SideGame Chip',
+                          amount: sideGameChip.toInt(),
+                          icon: Icons.casino,
+                          color: Colors.orange,
+                        ),
+                        const SizedBox(height: 10),
+
+                        // Logs参照ボタン
+                        ElevatedButton.icon(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (ctx) => ChipPointLogsPage(
+                                  userId: userId,
+                                  pokerName: pokerName,
+                                ),
+                              ),
+                            );
+                          },
+                          icon: const Icon(Icons.history),
+                          label: const Text('履歴を参照'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.orange,
+                            foregroundColor: Colors.white,
+                            minimumSize: const Size(double.infinity, 48),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+            // アクション
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('閉じる'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBalanceCard({
+    required String title,
+    required int amount,
+    required IconData icon,
+    required Color color,
+  }) {
+    // ColorからMaterialColorに変換するか、色を直接指定
+    Color backgroundColor;
+    Color borderColor;
+    Color textColor;
+    
+    // 色に応じて適切なshadeを選択
+    if (color == Colors.blue) {
+      backgroundColor = Colors.blue.shade50;
+      borderColor = Colors.blue.shade200;
+      textColor = Colors.blue.shade700;
+    } else if (color == Colors.green) {
+      backgroundColor = Colors.green.shade50;
+      borderColor = Colors.green.shade200;
+      textColor = Colors.green.shade700;
+    } else if (color == Colors.orange) {
+      backgroundColor = Colors.orange.shade50;
+      borderColor = Colors.orange.shade200;
+      textColor = Colors.orange.shade700;
+    } else {
+      // デフォルト（色を薄く/濃くする）
+      backgroundColor = color.withOpacity(0.1);
+      borderColor = color.withOpacity(0.3);
+      textColor = color;
+    }
+    
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: borderColor, width: 2),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: color, size: 16),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 7,
+                    color: textColor,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  amount.toString().replaceAllMapped(
+                    RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+                    (Match m) => '${m[1]},',
+                  ),
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: color,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/user_actions/current_accounting_popup.dart
+++ b/lib/user_actions/current_accounting_popup.dart
@@ -1,0 +1,675 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// 現在の会計参照ダイアログ
+Future<void> showCurrentAccountingDialog({
+  required BuildContext context,
+  required Map<String, dynamic> user,
+}) async {
+  final outerCtx = context;
+  final String billId = (user['billId'] ?? '').toString();
+  final String pokerName = (user['pokerName'] ?? '(名前未設定)').toString();
+
+  if (billId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('伝票IDが見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _CurrentAccountingDialog(billId: billId, pokerName: pokerName),
+  );
+}
+
+class _CurrentAccountingDialog extends StatelessWidget {
+  final String billId;
+  final String pokerName;
+
+  const _CurrentAccountingDialog({
+    required this.billId,
+    required this.pokerName,
+  });
+
+  // カテゴリ名を取得
+  String _getCategoryName(String category) {
+    switch (category) {
+      case 'extraCost':
+        return 'その他料金';
+      case 'tournaments':
+        return 'トーナメント';
+      case 'items':
+        return 'フード・ドリンク';
+      case 'sideGameChip':
+        return 'サイドゲームチップ';
+      default:
+        return category;
+    }
+  }
+
+  // カテゴリセクションを構築
+  Widget _buildCategorySection({
+    required String categoryName,
+    required int totalAmount,
+    required List<Widget> children,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.shade300),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                categoryName,
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Text(
+                '¥${totalAmount.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          if (children.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            ...children,
+          ],
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 600, maxHeight: 700),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // ヘッダー
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.blue.shade50,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                ),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.calculate, color: Colors.blue),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          '現在の合計金額',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          pokerName,
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey[700],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // コンテンツ
+            Flexible(
+              child: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+                stream: FirebaseFirestore.instance
+                    .collection('bills')
+                    .doc(billId)
+                    .snapshots(),
+                builder: (context, billSnapshot) {
+                  if (billSnapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (billSnapshot.hasError) {
+                    return Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.error, color: Colors.red, size: 48),
+                          const SizedBox(height: 16),
+                          Text(
+                            'エラーが発生しました',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.red[700],
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            billSnapshot.error.toString(),
+                            style: const TextStyle(fontSize: 14),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  if (!billSnapshot.hasData || !billSnapshot.data!.exists) {
+                    return const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Center(
+                        child: Text('伝票情報が見つかりません'),
+                      ),
+                    );
+                  }
+
+                  return StreamBuilder<List<Map<String, dynamic>>>(
+                    stream: _getBillSubcollections(billId),
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+
+                      if (snapshot.hasError) {
+                        return Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Text('エラー: ${snapshot.error}'),
+                        );
+                      }
+
+                      final categories = snapshot.data ?? [];
+                      final extraCostAmount = categories.firstWhere(
+                        (c) => c['name'] == 'その他料金',
+                        orElse: () => {'amount': 0},
+                      )['amount'] as int;
+                      final itemsAmount = categories.firstWhere(
+                        (c) => c['name'] == 'フード・ドリンク',
+                        orElse: () => {'amount': 0},
+                      )['amount'] as int;
+                      final sideGameChipAmount = categories.firstWhere(
+                        (c) => c['name'] == 'サイドゲームチップ',
+                        orElse: () => {'amount': 0},
+                      )['amount'] as int;
+                      final tournamentsAmount = categories.firstWhere(
+                        (c) => c['name'] == 'トーナメント',
+                        orElse: () => {'amount': 0},
+                      )['amount'] as int;
+
+                      final grandTotal = extraCostAmount + itemsAmount + sideGameChipAmount + tournamentsAmount;
+
+                      return SingleChildScrollView(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'カテゴリ別内訳',
+                              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(height: 12),
+                            
+                            // その他料金
+                            if (extraCostAmount > 0) ...[
+                              FutureBuilder<QuerySnapshot>(
+                                future: FirebaseFirestore.instance
+                                    .collection('bills')
+                                    .doc(billId)
+                                    .collection('extras')
+                                    .get(),
+                                builder: (context, extrasSnapshot) {
+                                  if (!extrasSnapshot.hasData) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  final extrasList = extrasSnapshot.data!.docs
+                                      .map((doc) => doc.data() as Map<String, dynamic>)
+                                      .toList();
+                                  final hasExtras = extrasList.isNotEmpty;
+                                  
+                                  if (!hasExtras) return const SizedBox.shrink();
+                                  
+                                  return _buildCategorySection(
+                                    categoryName: _getCategoryName('extraCost'),
+                                    totalAmount: extraCostAmount,
+                                    children: [
+                                      ...extrasList.map((extra) {
+                                        final amount = (extra['amountIncl'] as num?)?.toInt() ?? 0;
+                                        final name = extra['name'] as String? ?? '追加料金';
+                                        return Padding(
+                                          padding: const EdgeInsets.only(left: 16, top: 4, bottom: 4),
+                                          child: Row(
+                                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                            children: [
+                                              Text(
+                                                name,
+                                                style: const TextStyle(fontSize: 13, color: Colors.grey),
+                                              ),
+                                              Text(
+                                                '¥${amount.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                                style: const TextStyle(fontSize: 13, color: Colors.grey),
+                                              ),
+                                            ],
+                                          ),
+                                        );
+                                      }),
+                                    ],
+                                  );
+                                },
+                              ),
+                              const SizedBox(height: 12),
+                            ],
+
+                            // フード・ドリンク
+                            if (itemsAmount > 0) ...[
+                              FutureBuilder<QuerySnapshot>(
+                                future: FirebaseFirestore.instance
+                                    .collection('bills')
+                                    .doc(billId)
+                                    .collection('items')
+                                    .get(),
+                                builder: (context, itemsSnapshot) {
+                                  if (!itemsSnapshot.hasData) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  final itemsList = itemsSnapshot.data!.docs
+                                      .map((doc) => doc.data() as Map<String, dynamic>)
+                                      .toList();
+                                  
+                                  return _buildCategorySection(
+                                    categoryName: _getCategoryName('items'),
+                                    totalAmount: itemsAmount,
+                                    children: [
+                                      ...itemsList.map((item) {
+                                        final name = item['name'] as String? ?? '不明';
+                                        final quantity = (item['quantity'] as num?)?.toInt() ?? 0;
+                                        final totalPriceIncl = (item['totalPriceIncl'] as num?)?.toInt() ?? 0;
+                                        return Padding(
+                                          padding: const EdgeInsets.only(left: 16, top: 4, bottom: 4),
+                                          child: Row(
+                                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                            children: [
+                                              Expanded(
+                                                child: Text(
+                                                  '$name × $quantity',
+                                                  style: const TextStyle(fontSize: 13, color: Colors.grey),
+                                                ),
+                                              ),
+                                              Text(
+                                                '¥${totalPriceIncl.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                                style: const TextStyle(fontSize: 13, color: Colors.grey),
+                                              ),
+                                            ],
+                                          ),
+                                        );
+                                      }),
+                                    ],
+                                  );
+                                },
+                              ),
+                              const SizedBox(height: 12),
+                            ],
+
+                            // サイドゲームチップ
+                            if (sideGameChipAmount > 0) ...[
+                              FutureBuilder<QuerySnapshot>(
+                                future: FirebaseFirestore.instance
+                                    .collection('bills')
+                                    .doc(billId)
+                                    .collection('sideGameChips')
+                                    .where('action', isEqualTo: 'purchase')
+                                    .get(),
+                                builder: (context, chipsSnapshot) {
+                                  if (!chipsSnapshot.hasData) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  final chipsList = chipsSnapshot.data!.docs
+                                      .map((doc) => doc.data() as Map<String, dynamic>)
+                                      .toList();
+                                  
+                                  return _buildCategorySection(
+                                    categoryName: _getCategoryName('sideGameChip'),
+                                    totalAmount: sideGameChipAmount,
+                                    children: [
+                                      ...chipsList.map((chip) {
+                                        final chipQty = (chip['chipQty'] as num?)?.toInt() ?? 0;
+                                        final amountIncl = (chip['amountIncl'] as num?)?.toInt() ?? 0;
+                                        final name = chip['name'] as String? ?? 'チップ購入';
+                                        return Padding(
+                                          padding: const EdgeInsets.only(left: 16, top: 4, bottom: 4),
+                                          child: Row(
+                                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                            children: [
+                                              Expanded(
+                                                child: Text(
+                                                  '$name: ${chipQty}chip',
+                                                  style: const TextStyle(fontSize: 13, color: Colors.grey),
+                                                ),
+                                              ),
+                                              Text(
+                                                '¥${amountIncl.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                                style: const TextStyle(fontSize: 13, color: Colors.grey),
+                                              ),
+                                            ],
+                                          ),
+                                        );
+                                      }),
+                                    ],
+                                  );
+                                },
+                              ),
+                              const SizedBox(height: 12),
+                            ],
+
+                            // トーナメント
+                            if (tournamentsAmount > 0) ...[
+                              FutureBuilder<QuerySnapshot>(
+                                future: FirebaseFirestore.instance
+                                    .collection('bills')
+                                    .doc(billId)
+                                    .collection('tournaments')
+                                    .get(),
+                                builder: (context, tournamentsSnapshot) {
+                                  if (!tournamentsSnapshot.hasData) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  final tournamentsList = tournamentsSnapshot.data!.docs.map((doc) {
+                                    final data = doc.data() as Map<String, dynamic>;
+                                    return {
+                                      'templateName': data['templateName'] ?? '不明',
+                                      'entryCount': (data['entryCount'] as num?)?.toInt() ?? 0,
+                                      'entryFeeIncl': (data['entryFeeIncl'] as num?)?.toInt() ?? 0,
+                                      'reentryCount': (data['reentryCount'] as num?)?.toInt() ?? 0,
+                                      'reentryFeeIncl': (data['reentryFeeIncl'] as num?)?.toInt() ?? 0,
+                                      'addonCount': (data['addonCount'] as num?)?.toInt() ?? 0,
+                                      'addonFeeIncl': (data['addonFeeIncl'] as num?)?.toInt() ?? 0,
+                                    };
+                                  }).toList();
+                                  
+                                  return _buildCategorySection(
+                                    categoryName: _getCategoryName('tournaments'),
+                                    totalAmount: tournamentsAmount,
+                                    children: [
+                                      ...tournamentsList.map((tournament) {
+                                        final templateName = tournament['templateName'] as String;
+                                        final entryCount = tournament['entryCount'] as int;
+                                        final entryFeeIncl = tournament['entryFeeIncl'] as int;
+                                        final reentryCount = tournament['reentryCount'] as int;
+                                        final reentryFeeIncl = tournament['reentryFeeIncl'] as int;
+                                        final addonCount = tournament['addonCount'] as int;
+                                        final addonFeeIncl = tournament['addonFeeIncl'] as int;
+                                        final tournamentTotal = 
+                                            entryCount * entryFeeIncl +
+                                            reentryCount * reentryFeeIncl +
+                                            addonCount * addonFeeIncl;
+                                        
+                                        return Padding(
+                                          padding: const EdgeInsets.only(left: 16, top: 4, bottom: 4),
+                                          child: Column(
+                                            crossAxisAlignment: CrossAxisAlignment.start,
+                                            children: [
+                                              Text(
+                                                templateName,
+                                                style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500, color: Colors.grey),
+                                              ),
+                                              if (entryCount > 0)
+                                                Padding(
+                                                  padding: const EdgeInsets.only(left: 8, top: 2),
+                                                  child: Text(
+                                                    '  エントリー: ${entryCount}回 × ¥${entryFeeIncl.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')} = ¥${(entryCount * entryFeeIncl).toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                                                  ),
+                                                ),
+                                              if (reentryCount > 0)
+                                                Padding(
+                                                  padding: const EdgeInsets.only(left: 8, top: 2),
+                                                  child: Text(
+                                                    '  リエントリー: ${reentryCount}回 × ¥${reentryFeeIncl.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')} = ¥${(reentryCount * reentryFeeIncl).toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                                                  ),
+                                                ),
+                                              if (addonCount > 0)
+                                                Padding(
+                                                  padding: const EdgeInsets.only(left: 8, top: 2),
+                                                  child: Text(
+                                                    '  アドオン: ${addonCount}回 × ¥${addonFeeIncl.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')} = ¥${(addonCount * addonFeeIncl).toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                                    style: const TextStyle(fontSize: 12, color: Colors.grey),
+                                                  ),
+                                                ),
+                                              Padding(
+                                                padding: const EdgeInsets.only(left: 8, top: 2),
+                                                child: Row(
+                                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                                  children: [
+                                                    const Text(
+                                                      '  小計',
+                                                      style: TextStyle(fontSize: 12, fontWeight: FontWeight.w500, color: Colors.grey),
+                                                    ),
+                                                    Text(
+                                                      '¥${tournamentTotal.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                                      style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500, color: Colors.grey),
+                                                    ),
+                                                  ],
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        );
+                                      }),
+                                    ],
+                                  );
+                                },
+                              ),
+                              const SizedBox(height: 12),
+                            ],
+
+                            const Divider(),
+                            const SizedBox(height: 8),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                const Text(
+                                  '合計',
+                                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                                ),
+                                Text(
+                                  '¥${grandTotal.toString().replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                  style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 8),
+                            const Text(
+                              '※この表示は UI補助用途のみです。金額の正は amounts.* および verifyPaymentSplit にあります。',
+                              style: TextStyle(fontSize: 12, color: Colors.grey),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+            // アクション
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('閉じる'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Stream<List<Map<String, dynamic>>> _getBillSubcollections(String billId) async* {
+    final billRef = FirebaseFirestore.instance.collection('bills').doc(billId);
+
+    // Initial fetch
+    final extrasSnapshot = await billRef.collection('extras').get();
+    int extraCostAmount = extrasSnapshot.docs.fold(0, (sum, doc) {
+      final data = doc.data() as Map<String, dynamic>? ?? {};
+      return sum + ((data['amountIncl'] as num?)?.toInt() ?? 0);
+    });
+
+    final itemsSnapshot = await billRef.collection('items').get();
+    int itemsAmount = itemsSnapshot.docs.fold(0, (sum, doc) {
+      final data = doc.data() as Map<String, dynamic>? ?? {};
+      return sum + ((data['totalPriceIncl'] as num?)?.toInt() ?? 0);
+    });
+
+    final sideGameChipsSnapshot = await billRef.collection('sideGameChips').get();
+    int sideGameChipAmount = sideGameChipsSnapshot.docs
+        .where((doc) {
+          final data = doc.data() as Map<String, dynamic>? ?? {};
+          return data['action'] == 'purchase';
+        })
+        .fold(0, (sum, doc) {
+          final data = doc.data() as Map<String, dynamic>? ?? {};
+          return sum + ((data['amountIncl'] as num?)?.toInt() ?? 0);
+        });
+
+    final tournamentsSnapshot = await billRef.collection('tournaments').get();
+    int tournamentsAmount = tournamentsSnapshot.docs.fold(0, (sum, doc) {
+      final data = doc.data() as Map<String, dynamic>? ?? {};
+      final entryFeeIncl = (data['entryFeeIncl'] as num?)?.toInt() ?? 0;
+      final entryCount = (data['entryCount'] as num?)?.toInt() ?? 0;
+      final reentryFeeIncl = (data['reentryFeeIncl'] as num?)?.toInt() ?? 0;
+      final reentryCount = (data['reentryCount'] as num?)?.toInt() ?? 0;
+      final addonFeeIncl = (data['addonFeeIncl'] as num?)?.toInt() ?? 0;
+      final addonCount = (data['addonCount'] as num?)?.toInt() ?? 0;
+      return sum + (entryFeeIncl * entryCount) + (reentryFeeIncl * reentryCount) + (addonFeeIncl * addonCount);
+    });
+
+    yield [
+      {'name': 'その他料金', 'amount': extraCostAmount},
+      {'name': 'フード・ドリンク', 'amount': itemsAmount},
+      {'name': 'サイドゲームチップ', 'amount': sideGameChipAmount},
+      {'name': 'トーナメント', 'amount': tournamentsAmount},
+    ];
+
+    // Real-time updates
+    final extrasStream = billRef.collection('extras').snapshots();
+    final itemsStream = billRef.collection('items').snapshots();
+    final sideGameChipsStream = billRef.collection('sideGameChips').snapshots();
+    final tournamentsStream = billRef.collection('tournaments').snapshots();
+
+    await for (final snapshots in _combineSubcollectionStreams([
+      extrasStream,
+      itemsStream,
+      sideGameChipsStream,
+      tournamentsStream,
+    ])) {
+      final extras = snapshots[0].docs;
+      final items = snapshots[1].docs;
+      final sideGameChips = snapshots[2].docs;
+      final tournaments = snapshots[3].docs;
+
+      int extraCostAmount = extras.fold(0, (sum, doc) {
+        final data = doc.data() as Map<String, dynamic>? ?? {};
+        return sum + ((data['amountIncl'] as num?)?.toInt() ?? 0);
+      });
+
+      int itemsAmount = items.fold(0, (sum, doc) {
+        final data = doc.data() as Map<String, dynamic>? ?? {};
+        return sum + ((data['totalPriceIncl'] as num?)?.toInt() ?? 0);
+      });
+
+      int sideGameChipAmount = sideGameChips
+          .where((doc) {
+            final data = doc.data() as Map<String, dynamic>? ?? {};
+            return data['action'] == 'purchase';
+          })
+          .fold(0, (sum, doc) {
+            final data = doc.data() as Map<String, dynamic>? ?? {};
+            return sum + ((data['amountIncl'] as num?)?.toInt() ?? 0);
+          });
+
+      int tournamentsAmount = tournaments.fold(0, (sum, doc) {
+        final data = doc.data() as Map<String, dynamic>? ?? {};
+        final entryFeeIncl = (data['entryFeeIncl'] as num?)?.toInt() ?? 0;
+        final entryCount = (data['entryCount'] as num?)?.toInt() ?? 0;
+        final reentryFeeIncl = (data['reentryFeeIncl'] as num?)?.toInt() ?? 0;
+        final reentryCount = (data['reentryCount'] as num?)?.toInt() ?? 0;
+        final addonFeeIncl = (data['addonFeeIncl'] as num?)?.toInt() ?? 0;
+        final addonCount = (data['addonCount'] as num?)?.toInt() ?? 0;
+        return sum + (entryFeeIncl * entryCount) + (reentryFeeIncl * reentryCount) + (addonFeeIncl * addonCount);
+      });
+
+      yield [
+        {'name': 'その他料金', 'amount': extraCostAmount},
+        {'name': 'フード・ドリンク', 'amount': itemsAmount},
+        {'name': 'サイドゲームチップ', 'amount': sideGameChipAmount},
+        {'name': 'トーナメント', 'amount': tournamentsAmount},
+      ];
+    }
+  }
+
+  Stream<List<QuerySnapshot>> _combineSubcollectionStreams(List<Stream<QuerySnapshot>> streams) {
+    if (streams.isEmpty) {
+      return Stream.value([]);
+    }
+    
+    final controller = StreamController<List<QuerySnapshot>>();
+    final List<QuerySnapshot?> latest = List.filled(streams.length, null);
+    final List<StreamSubscription> subscriptions = [];
+    
+    void checkAndEmit() {
+      if (latest.every((snapshot) => snapshot != null)) {
+        controller.add(latest.cast<QuerySnapshot>());
+      }
+    }
+    
+    for (int i = 0; i < streams.length; i++) {
+      final index = i;
+      subscriptions.add(
+        streams[i].listen(
+          (snapshot) {
+            latest[index] = snapshot;
+            checkAndEmit();
+          },
+          onError: controller.addError,
+        ),
+      );
+    }
+    
+    controller.onCancel = () {
+      for (final sub in subscriptions) {
+        sub.cancel();
+      }
+    };
+    
+    return controller.stream;
+  }
+
+}
+

--- a/lib/user_actions/current_seat_popup.dart
+++ b/lib/user_actions/current_seat_popup.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// 現在の座席確認ダイアログ
+Future<void> showCurrentSeatDialog({
+  required BuildContext context,
+  required Map<String, dynamic> user,
+}) async {
+  final outerCtx = context;
+  final String billId = (user['billId'] ?? '').toString();
+  final String pokerName = (user['pokerName'] ?? '(名前未設定)').toString();
+
+  if (billId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('伝票IDが見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _CurrentSeatDialog(billId: billId, pokerName: pokerName),
+  );
+}
+
+class _CurrentSeatDialog extends StatelessWidget {
+  final String billId;
+  final String pokerName;
+
+  const _CurrentSeatDialog({
+    required this.billId,
+    required this.pokerName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 600, maxHeight: 700),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // ヘッダー
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.purple.shade50,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                ),
+              ),
+              child: Row(
+                children: const [
+                  Icon(Icons.event_seat, color: Colors.purple),
+                  SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '現在の座席確認',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            // コンテンツ
+            Flexible(
+              child: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+                stream: FirebaseFirestore.instance
+                    .collection('bills')
+                    .doc(billId)
+                    .snapshots(),
+                builder: (context, billSnapshot) {
+                  if (billSnapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (billSnapshot.hasError) {
+                    return Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.error, color: Colors.red, size: 48),
+                          const SizedBox(height: 16),
+                          Text(
+                            'エラーが発生しました',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.red[700],
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            billSnapshot.error.toString(),
+                            style: const TextStyle(fontSize: 14),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  if (!billSnapshot.hasData || !billSnapshot.data!.exists) {
+                    return const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Center(
+                        child: Text('伝票情報が見つかりません'),
+                      ),
+                    );
+                  }
+
+                  final billData = billSnapshot.data!.data()!;
+                  final place = billData['place'] as Map<String, dynamic>? ?? {};
+                  final tableId = place['table'] as String?;
+                  final seat = place['seat'] as num?;
+
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // ユーザー名
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 12,
+                            horizontal: 16,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.blue.shade50,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: Colors.blue.shade200),
+                          ),
+                          child: Column(
+                            children: [
+                              const Icon(Icons.person, color: Colors.blue, size: 32),
+                              const SizedBox(height: 8),
+                              Text(
+                                pokerName,
+                                style: const TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.blue,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                        // 座席情報
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.all(16),
+                          decoration: BoxDecoration(
+                            color: Colors.purple.shade50,
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(color: Colors.purple.shade200, width: 2),
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Text(
+                                '現在の座席',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(height: 12),
+                              Row(
+                                children: [
+                                  const Icon(Icons.table_restaurant, color: Colors.purple),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    'テーブル: ${tableId ?? '未設定'}',
+                                    style: const TextStyle(fontSize: 16),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 8),
+                              Row(
+                                children: [
+                                  const Icon(Icons.event_seat, color: Colors.purple),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    '席: ${seat != null ? seat.toString() : '未設定'}',
+                                    style: const TextStyle(fontSize: 16),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                        // テーブルステータス（tableIdがnullでない場合）
+                        if (tableId != null) ...[
+                          const SizedBox(height: 16),
+                          StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+                            stream: FirebaseFirestore.instance
+                                .collection('tables')
+                                .doc(tableId)
+                                .snapshots(),
+                            builder: (context, tableSnapshot) {
+                              if (tableSnapshot.connectionState == ConnectionState.waiting) {
+                                return const Center(child: CircularProgressIndicator());
+                              }
+
+                              if (!tableSnapshot.hasData || !tableSnapshot.data!.exists) {
+                                return Container(
+                                  width: double.infinity,
+                                  padding: const EdgeInsets.all(16),
+                                  decoration: BoxDecoration(
+                                    color: Colors.grey.shade100,
+                                    borderRadius: BorderRadius.circular(12),
+                                    border: Border.all(color: Colors.grey.shade300),
+                                  ),
+                                  child: const Text(
+                                    'テーブル情報が見つかりません',
+                                    style: TextStyle(fontSize: 14),
+                                  ),
+                                );
+                              }
+
+                              final tableData = tableSnapshot.data!.data()!;
+                              final status = tableData['status'] as String? ?? '不明';
+
+                              return Container(
+                                width: double.infinity,
+                                padding: const EdgeInsets.all(16),
+                                decoration: BoxDecoration(
+                                  color: Colors.orange.shade50,
+                                  borderRadius: BorderRadius.circular(12),
+                                  border: Border.all(color: Colors.orange.shade200, width: 2),
+                                ),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    const Text(
+                                      'テーブルステータス',
+                                      style: TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 12),
+                                    Row(
+                                      children: [
+                                        const Icon(Icons.info, color: Colors.orange),
+                                        const SizedBox(width: 8),
+                                        Text(
+                                          'ステータス: $status',
+                                          style: const TextStyle(fontSize: 16),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                        ],
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+            // アクション
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('閉じる'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/user_actions/order_history_popup.dart
+++ b/lib/user_actions/order_history_popup.dart
@@ -1,0 +1,395 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:async';
+import '../globalConstant.dart';
+
+/// 注文履歴参照ポップアップ
+Future<void> showOrderHistoryDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+}) async {
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _OrderHistoryDialog(userId: userId, pokerName: pokerName),
+  );
+}
+
+class _OrderHistoryDialog extends StatelessWidget {
+  final String userId;
+  final String pokerName;
+
+  const _OrderHistoryDialog({
+    required this.userId,
+    required this.pokerName,
+  });
+
+  String _getBusinessDate() {
+    final now = DateTime.now();
+    final closeHour = GlobalConstants.normalizeStoreCloseHour(GlobalConstants.STORE_CLOSE_HOUR);
+    
+    if (now.hour < closeHour) {
+      final businessDate = now.subtract(const Duration(days: 1));
+      return businessDate.toIso8601String().split('T')[0];
+    } else {
+      return now.toIso8601String().split('T')[0];
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final businessDate = _getBusinessDate();
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 600),
+        child: Column(
+          children: [
+            // ヘッダー
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.indigo.shade50,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                ),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.receipt_long, color: Colors.indigo),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '注文履歴 - $pokerName',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+            // 注文一覧
+            Expanded(
+              child: StreamBuilder<QuerySnapshot>(
+                stream: FirebaseFirestore.instance
+                    .collection('bills')
+                    .where('party.userId', isEqualTo: userId)
+                    .where('businessDate', isEqualTo: businessDate)
+                    .snapshots(),
+                builder: (context, billsSnapshot) {
+                  if (billsSnapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (billsSnapshot.hasError) {
+                    return Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Icon(Icons.error, color: Colors.red, size: 48),
+                          const SizedBox(height: 16),
+                          Text(
+                            'エラーが発生しました',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.red[700],
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            billsSnapshot.error.toString(),
+                            style: const TextStyle(fontSize: 14),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  if (!billsSnapshot.hasData || billsSnapshot.data!.docs.isEmpty) {
+                    return const Center(
+                      child: Text('当日の注文履歴がありません'),
+                    );
+                  }
+
+                  // 全てのbillsからitemsを取得
+                  final List<Map<String, dynamic>> allItems = [];
+                  
+                  for (final billDoc in billsSnapshot.data!.docs) {
+                    final billId = billDoc.id;
+                    // itemsサブコレクションを取得（非同期のため、StreamBuilderを使用）
+                  }
+
+                  // StreamBuilderでitemsを取得
+                  return StreamBuilder<List<Map<String, dynamic>>>(
+                    stream: _getAllItemsStream(billsSnapshot.data!.docs),
+                    builder: (context, itemsSnapshot) {
+                      if (itemsSnapshot.connectionState == ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+
+                      if (itemsSnapshot.hasError) {
+                        return Center(
+                          child: Text('エラー: ${itemsSnapshot.error}'),
+                        );
+                      }
+
+                      final items = itemsSnapshot.data ?? [];
+                      
+                      if (items.isEmpty) {
+                        return const Center(
+                          child: Text('当日の注文履歴がありません'),
+                        );
+                      }
+
+                      // orderedAtでソート（最新が上）
+                      items.sort((a, b) {
+                        final aTime = a['orderedAt'] as Timestamp?;
+                        final bTime = b['orderedAt'] as Timestamp?;
+                        if (aTime == null && bTime == null) return 0;
+                        if (aTime == null) return 1;
+                        if (bTime == null) return -1;
+                        return bTime.compareTo(aTime);
+                      });
+
+                      // businessDateをYYYYMMDD形式に変換
+                      final orderDocId = businessDate.replaceAll('-', '');
+
+                      return ListView.builder(
+                        padding: const EdgeInsets.all(8),
+                        itemCount: items.length,
+                        itemBuilder: (context, index) {
+                          final item = items[index];
+                          final itemId = item['itemId'] as String? ?? '';
+                          final name = item['name'] as String? ?? '';
+                          final quantity = item['quantity'] as num? ?? 0;
+                          final unitPriceIncl = item['unitPriceIncl'] as num? ?? 0;
+                          final totalPriceIncl = item['totalPriceIncl'] as num? ?? 0;
+                          final orderedAt = item['orderedAt'] as Timestamp?;
+                          
+                          String formattedDate = '日時不明';
+                          if (orderedAt != null) {
+                            final date = orderedAt.toDate();
+                            formattedDate = '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+                          }
+
+                          return Card(
+                            margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                            child: StreamBuilder<DocumentSnapshot>(
+                              stream: itemId.isNotEmpty
+                                  ? FirebaseFirestore.instance
+                                      .collection('orders')
+                                      .doc(orderDocId)
+                                      .collection('_TodaysOrders')
+                                      .doc(itemId)
+                                      .snapshots()
+                                  : null,
+                              builder: (context, statusSnapshot) {
+                                String statusText = '';
+                                Color statusColor = Colors.grey;
+                                
+                                if (statusSnapshot.hasData && statusSnapshot.data!.exists) {
+                                  final statusData = statusSnapshot.data!.data() as Map<String, dynamic>?;
+                                  final status = statusData?['status'] as String? ?? '';
+                                  switch (status) {
+                                    case 'served':
+                                      statusText = '提供済み';
+                                      statusColor = Colors.green;
+                                      break;
+                                    case 'preparing':
+                                      statusText = '準備中';
+                                      statusColor = Colors.orange;
+                                      break;
+                                    case 'cancel':
+                                      statusText = 'キャンセル';
+                                      statusColor = Colors.red;
+                                      break;
+                                    default:
+                                      statusText = status;
+                                      break;
+                                  }
+                                }
+
+                                return ListTile(
+                                  leading: const Icon(Icons.restaurant, color: Colors.indigo),
+                                  title: Text(
+                                    name,
+                                    style: const TextStyle(fontWeight: FontWeight.bold),
+                                  ),
+                                  subtitle: Text('数量: $quantity  単価: ¥${unitPriceIncl.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}'),
+                                  trailing: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      if (statusText.isNotEmpty)
+                                        Container(
+                                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                          decoration: BoxDecoration(
+                                            color: statusColor.withOpacity(0.1),
+                                            borderRadius: BorderRadius.circular(4),
+                                            border: Border.all(color: statusColor),
+                                          ),
+                                          child: Text(
+                                            statusText,
+                                            style: TextStyle(
+                                              fontSize: 12,
+                                              color: statusColor,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                        ),
+                                      const SizedBox(width: 8),
+                                      Column(
+                                        mainAxisAlignment: MainAxisAlignment.center,
+                                        crossAxisAlignment: CrossAxisAlignment.end,
+                                        children: [
+                                          Text(
+                                            '¥${totalPriceIncl.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                            style: const TextStyle(
+                                              fontSize: 16,
+                                              fontWeight: FontWeight.bold,
+                                              color: Colors.indigo,
+                                            ),
+                                          ),
+                                          Text(
+                                            formattedDate,
+                                            style: const TextStyle(
+                                              fontSize: 12,
+                                              color: Colors.grey,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  ),
+                                );
+                              },
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Stream<List<Map<String, dynamic>>> _getAllItemsStream(List<QueryDocumentSnapshot> bills) async* {
+    if (bills.isEmpty) {
+      yield [];
+      return;
+    }
+
+    // 全てのbillsのitemsサブコレクションを取得
+    final List<Map<String, dynamic>> allItems = [];
+    
+    for (final billDoc in bills) {
+      final billId = billDoc.id;
+      final itemsSnapshot = await FirebaseFirestore.instance
+          .collection('bills')
+          .doc(billId)
+          .collection('items')
+          .get();
+      
+      for (final itemDoc in itemsSnapshot.docs) {
+        final data = itemDoc.data() as Map<String, dynamic>;
+        allItems.add({
+          ...data,
+          'billId': billId,
+          'itemId': itemDoc.id, // ドキュメントIDを追加
+        });
+      }
+    }
+
+    yield allItems;
+    
+    // リアルタイム更新のために各billのitemsを監視
+    final controllers = bills.map((billDoc) {
+      final billId = billDoc.id;
+      return FirebaseFirestore.instance
+          .collection('bills')
+          .doc(billId)
+          .collection('items')
+          .snapshots();
+    }).toList();
+
+    await for (final snapshots in _combineStreams(controllers)) {
+      final List<Map<String, dynamic>> updatedItems = [];
+      for (int i = 0; i < snapshots.length; i++) {
+        final billId = bills[i].id;
+        for (final doc in snapshots[i].docs) {
+          final data = doc.data() as Map<String, dynamic>;
+          updatedItems.add({
+            ...data,
+            'billId': billId,
+            'itemId': doc.id, // ドキュメントIDを追加
+          });
+        }
+      }
+      yield updatedItems;
+    }
+  }
+
+  Stream<List<QuerySnapshot>> _combineStreams(List<Stream<QuerySnapshot>> streams) {
+    if (streams.isEmpty) {
+      return Stream.value([]);
+    }
+    
+    final controller = StreamController<List<QuerySnapshot>>();
+    final List<QuerySnapshot?> latest = List.filled(streams.length, null);
+    final List<StreamSubscription> subscriptions = [];
+    
+    void checkAndEmit() {
+      if (latest.every((snapshot) => snapshot != null)) {
+        controller.add(latest.cast<QuerySnapshot>());
+      }
+    }
+    
+    for (int i = 0; i < streams.length; i++) {
+      final index = i;
+      subscriptions.add(
+        streams[i].listen(
+          (snapshot) {
+            latest[index] = snapshot;
+            checkAndEmit();
+          },
+          onError: controller.addError,
+        ),
+      );
+    }
+    
+    controller.onCancel = () {
+      for (final sub in subscriptions) {
+        sub.cancel();
+      }
+    };
+    
+    return controller.stream;
+  }
+}
+

--- a/lib/user_actions/profile_popup.dart
+++ b/lib/user_actions/profile_popup.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// プロフィール参照ポップアップ
+Future<void> showProfileDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+}) async {
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _ProfileDialog(userId: userId, pokerName: pokerName),
+  );
+}
+
+class _ProfileDialog extends StatelessWidget {
+  final String userId;
+  final String pokerName;
+
+  const _ProfileDialog({
+    required this.userId,
+    required this.pokerName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 600, maxHeight: 700),
+        child: Column(
+          children: [
+            // ヘッダー
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.brown.shade50,
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                ),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.account_circle, color: Colors.brown),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'プロフィール - $pokerName',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+            // プロフィール情報
+            Expanded(
+              child: StreamBuilder<DocumentSnapshot>(
+                stream: FirebaseFirestore.instance
+                    .collection('users')
+                    .doc(userId)
+                    .snapshots(),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (snapshot.hasError) {
+                    return Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Icon(Icons.error, color: Colors.red, size: 48),
+                          const SizedBox(height: 16),
+                          Text(
+                            'エラーが発生しました',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.red[700],
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            snapshot.error.toString(),
+                            style: const TextStyle(fontSize: 14),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  if (!snapshot.hasData || !snapshot.data!.exists) {
+                    return const Center(
+                      child: Text('ユーザー情報が見つかりません'),
+                    );
+                  }
+
+                  final userData = snapshot.data!.data() as Map<String, dynamic>;
+                  final pointA = userData['pointA'] as num? ?? 0;
+                  final pointB = userData['pointB'] as num? ?? 0;
+                  final sideGameChip = userData['sideGameChip'] as num? ?? 0;
+                  final birthMonthDay = userData['birthMonthDay'] as String? ?? '';
+                  final email = userData['email'] as String? ?? '';
+                  final createdAt = userData['createdAt'] as Timestamp?;
+                  final lastLogin = userData['lastLogin'] as Timestamp?;
+
+                  String formatDate(Timestamp? timestamp) {
+                    if (timestamp == null) return '未設定';
+                    final date = timestamp.toDate();
+                    return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+                  }
+
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildInfoRow('Poker Name', pokerName),
+                        const SizedBox(height: 12),
+                        _buildInfoRow('Point A', pointA.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')),
+                        const SizedBox(height: 12),
+                        _buildInfoRow('Point B', pointB.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')),
+                        const SizedBox(height: 12),
+                        _buildInfoRow('SideGame Chip', sideGameChip.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')),
+                        const SizedBox(height: 12),
+                        _buildInfoRow('生年月日', birthMonthDay.isEmpty ? '未設定' : birthMonthDay),
+                        const SizedBox(height: 12),
+                        _buildInfoRow('Email', email.isEmpty ? '未設定' : email),
+                        const SizedBox(height: 12),
+                        _buildInfoRow('アカウント作成日', formatDate(createdAt)),
+                        const SizedBox(height: 12),
+                        _buildInfoRow('最終ログイン', formatDate(lastLogin)),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade50,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.grey.shade700,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/user_actions/tournament_history_popup.dart
+++ b/lib/user_actions/tournament_history_popup.dart
@@ -1,0 +1,342 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:async';
+import '../globalConstant.dart';
+
+/// トーナメント履歴参照ポップアップ
+Future<void> showTournamentHistoryDialog({
+  required BuildContext context,
+  required String userId,
+  required String pokerName,
+}) async {
+  final outerCtx = context;
+
+  if (userId.isEmpty) {
+    if (outerCtx.mounted) {
+      ScaffoldMessenger.of(outerCtx).showSnackBar(
+        const SnackBar(content: Text('ユーザー識別子が見つかりません')),
+      );
+    }
+    return;
+  }
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (ctx) => _TournamentHistoryDialog(userId: userId, pokerName: pokerName),
+  );
+}
+
+class _TournamentHistoryDialog extends StatelessWidget {
+  final String userId;
+  final String pokerName;
+
+  const _TournamentHistoryDialog({
+    required this.userId,
+    required this.pokerName,
+  });
+
+  String _getBusinessDate() {
+    final now = DateTime.now();
+    final closeHour = GlobalConstants.normalizeStoreCloseHour(GlobalConstants.STORE_CLOSE_HOUR);
+    
+    if (now.hour < closeHour) {
+      final businessDate = now.subtract(const Duration(days: 1));
+      return businessDate.toIso8601String().split('T')[0];
+    } else {
+      return now.toIso8601String().split('T')[0];
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final businessDate = _getBusinessDate();
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 800, maxHeight: 600),
+        child: Column(
+          children: [
+            // ヘッダー
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.redAccent.withOpacity(0.1),
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                ),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.emoji_events, color: Colors.redAccent),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'トーナメント履歴 - $pokerName',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+            // トーナメント一覧
+            Expanded(
+              child: StreamBuilder<QuerySnapshot>(
+                stream: FirebaseFirestore.instance
+                    .collection('bills')
+                    .where('party.userId', isEqualTo: userId)
+                    .where('businessDate', isEqualTo: businessDate)
+                    .snapshots(),
+                builder: (context, billsSnapshot) {
+                  if (billsSnapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (billsSnapshot.hasError) {
+                    return Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Icon(Icons.error, color: Colors.red, size: 48),
+                          const SizedBox(height: 16),
+                          Text(
+                            'エラーが発生しました',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.red[700],
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            billsSnapshot.error.toString(),
+                            style: const TextStyle(fontSize: 14),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  if (!billsSnapshot.hasData || billsSnapshot.data!.docs.isEmpty) {
+                    return const Center(
+                      child: Text('当日のトーナメント履歴がありません'),
+                    );
+                  }
+
+                  // StreamBuilderでtournamentsを取得
+                  return StreamBuilder<List<Map<String, dynamic>>>(
+                    stream: _getAllTournamentsStream(billsSnapshot.data!.docs),
+                    builder: (context, tournamentsSnapshot) {
+                      if (tournamentsSnapshot.connectionState == ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+
+                      if (tournamentsSnapshot.hasError) {
+                        return Center(
+                          child: Text('エラー: ${tournamentsSnapshot.error}'),
+                        );
+                      }
+
+                      final tournaments = tournamentsSnapshot.data ?? [];
+                      
+                      if (tournaments.isEmpty) {
+                        return const Center(
+                          child: Text('当日のトーナメント履歴がありません'),
+                        );
+                      }
+
+                      return ListView.builder(
+                        padding: const EdgeInsets.all(8),
+                        itemCount: tournaments.length,
+                        itemBuilder: (context, index) {
+                          final tournament = tournaments[index];
+                          final templateName = tournament['templateName'] as String? ?? '';
+                          final entryFeeIncl = tournament['entryFeeIncl'] as num? ?? 0;
+                          final entryCount = tournament['entryCount'] as num? ?? 0;
+                          final reentryFeeIncl = tournament['reentryFeeIncl'] as num? ?? 0;
+                          final reentryCount = tournament['reentryCount'] as num? ?? 0;
+                          final addonFeeIncl = tournament['addonFeeIncl'] as num? ?? 0;
+                          final addonCount = tournament['addonCount'] as num? ?? 0;
+
+                          final totalAmount = (entryFeeIncl * entryCount) +
+                              (reentryFeeIncl * reentryCount) +
+                              (addonFeeIncl * addonCount);
+
+                          return Card(
+                            margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                            child: Padding(
+                              padding: const EdgeInsets.all(16),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      const Icon(Icons.emoji_events, color: Colors.redAccent),
+                                      const SizedBox(width: 8),
+                                      Expanded(
+                                        child: Text(
+                                          templateName,
+                                          style: const TextStyle(
+                                            fontSize: 18,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 12),
+                                  if (entryCount > 0)
+                                    Padding(
+                                      padding: const EdgeInsets.only(bottom: 4),
+                                      child: Text(
+                                        'エントリー: ¥${(entryFeeIncl * entryCount).toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                        style: const TextStyle(fontSize: 14),
+                                      ),
+                                    ),
+                                  if (reentryCount > 0)
+                                    Padding(
+                                      padding: const EdgeInsets.only(bottom: 4),
+                                      child: Text(
+                                        'リエントリー: ¥${(reentryFeeIncl * reentryCount).toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')} (${reentryCount.toInt()}回)',
+                                        style: const TextStyle(fontSize: 14),
+                                      ),
+                                    ),
+                                  if (addonCount > 0)
+                                    Padding(
+                                      padding: const EdgeInsets.only(bottom: 4),
+                                      child: Text(
+                                        'addon: ¥${(addonFeeIncl * addonCount).toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')} (${addonCount.toInt()}回)',
+                                        style: const TextStyle(fontSize: 14),
+                                      ),
+                                    ),
+                                  const Divider(),
+                                  Padding(
+                                    padding: const EdgeInsets.only(top: 4),
+                                    child: Text(
+                                      '合計金額: ¥${totalAmount.toString().replaceAllMapped(RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},')}',
+                                      style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                        color: Colors.redAccent,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Stream<List<Map<String, dynamic>>> _getAllTournamentsStream(List<QueryDocumentSnapshot> bills) async* {
+    if (bills.isEmpty) {
+      yield [];
+      return;
+    }
+
+    // 全てのbillsのtournamentsサブコレクションを取得
+    final List<Map<String, dynamic>> allTournaments = [];
+    
+    for (final billDoc in bills) {
+      final billId = billDoc.id;
+      final tournamentsSnapshot = await FirebaseFirestore.instance
+          .collection('bills')
+          .doc(billId)
+          .collection('tournaments')
+          .get();
+      
+      for (final tournamentDoc in tournamentsSnapshot.docs) {
+        final data = tournamentDoc.data() as Map<String, dynamic>;
+        allTournaments.add({
+          ...data,
+          'billId': billId,
+        });
+      }
+    }
+
+    yield allTournaments;
+    
+    // リアルタイム更新のために各billのtournamentsを監視
+    final controllers = bills.map((billDoc) {
+      final billId = billDoc.id;
+      return FirebaseFirestore.instance
+          .collection('bills')
+          .doc(billId)
+          .collection('tournaments')
+          .snapshots();
+    }).toList();
+
+    await for (final snapshots in _combineStreams(controllers)) {
+      final List<Map<String, dynamic>> updatedTournaments = [];
+      for (int i = 0; i < snapshots.length; i++) {
+        final billId = bills[i].id;
+        for (final doc in snapshots[i].docs) {
+          final data = doc.data() as Map<String, dynamic>;
+          updatedTournaments.add({
+            ...data,
+            'billId': billId,
+          });
+        }
+      }
+      yield updatedTournaments;
+    }
+  }
+
+  Stream<List<QuerySnapshot>> _combineStreams(List<Stream<QuerySnapshot>> streams) {
+    if (streams.isEmpty) {
+      return Stream.value([]);
+    }
+    
+    final controller = StreamController<List<QuerySnapshot>>();
+    final List<QuerySnapshot?> latest = List.filled(streams.length, null);
+    final List<StreamSubscription> subscriptions = [];
+    
+    void checkAndEmit() {
+      if (latest.every((snapshot) => snapshot != null)) {
+        controller.add(latest.cast<QuerySnapshot>());
+      }
+    }
+    
+    for (int i = 0; i < streams.length; i++) {
+      final index = i;
+      subscriptions.add(
+        streams[i].listen(
+          (snapshot) {
+            latest[index] = snapshot;
+            checkAndEmit();
+          },
+          onError: controller.addError,
+        ),
+      );
+    }
+    
+    controller.onCancel = () {
+      for (final sub in subscriptions) {
+        sub.cancel();
+      }
+    };
+    
+    return controller.stream;
+  }
+}
+

--- a/lib/user_actions/user_action_home.dart
+++ b/lib/user_actions/user_action_home.dart
@@ -7,6 +7,13 @@ import 'side_game_tip_view_popup.dart';
 import 'side_game_tip_withdraw_popup.dart';
 import 'side_game_tip_deposit_popup.dart';
 import 'side_game_chip_purchase_popup.dart';
+import 'add_extra_popup.dart';
+import 'chip_point_view_popup.dart';
+import 'order_history_popup.dart';
+import 'tournament_history_popup.dart';
+import 'profile_popup.dart';
+import 'current_seat_popup.dart';
+import 'current_accounting_popup.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 
 /// When: ユーザー行をタップしてアクションを選択したいとき
@@ -181,32 +188,46 @@ _UserActionItem _buildBlockB(Map<String, dynamic> user) => _UserActionItem(
       icon: Icons.attach_money,
       color: Colors.green,
       onSelected: (ctx, u) {
-        ScaffoldMessenger.of(ctx).showSnackBar(
-          const SnackBar(content: Text('追加料金（仮）')),
+        showAddExtraDialog(
+          context: ctx,
+          user: u,
         );
       },
     );
 
-// 塊C: チップ
+// 塊C: チップ（所持チップ・所持ポイント）
 _UserActionItem _buildBlockC(Map<String, dynamic> user) => _UserActionItem(
-      label: 'チップ',
+      label: '所持チップ・ポイント',
       icon: Icons.volunteer_activism,
       color: Colors.orange,
       onSelected: (ctx, u) {
-        ScaffoldMessenger.of(ctx).showSnackBar(
-          const SnackBar(content: Text('チップ（仮）')),
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String? ?? '(名前未設定)';
+        
+        if (userId == null || userId.isEmpty) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('ユーザー情報が不足しています')),
+          );
+          return;
+        }
+        
+        showChipPointViewDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
         );
       },
     );
 
-// 塊D: 席移動
+// 塊D: 席移動（現在の座席確認）
 _UserActionItem _buildBlockD(Map<String, dynamic> user) => _UserActionItem(
-      label: '席移動',
+      label: '現在の座席確認',
       icon: Icons.event_seat,
       color: Colors.purple,
       onSelected: (ctx, u) {
-        ScaffoldMessenger.of(ctx).showSnackBar(
-          const SnackBar(content: Text('席移動（仮）')),
+        showCurrentSeatDialog(
+          context: ctx,
+          user: u,
         );
       },
     );
@@ -217,32 +238,57 @@ _UserActionItem _buildBlockE(Map<String, dynamic> user) => _UserActionItem(
       icon: Icons.receipt_long,
       color: Colors.indigo,
       onSelected: (ctx, u) {
-        ScaffoldMessenger.of(ctx).showSnackBar(
-          const SnackBar(content: Text('注文履歴（仮）')),
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String? ?? '(名前未設定)';
+        
+        if (userId == null || userId.isEmpty) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('ユーザー情報が不足しています')),
+          );
+          return;
+        }
+        
+        showOrderHistoryDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
         );
       },
     );
 
-// 塊F: 会計
+// 塊F: 現在の会計参照
 _UserActionItem _buildBlockF(Map<String, dynamic> user) => _UserActionItem(
-      label: '会計',
+      label: '現在の会計参照',
       icon: Icons.point_of_sale,
       color: Colors.teal,
       onSelected: (ctx, u) {
-        ScaffoldMessenger.of(ctx).showSnackBar(
-          const SnackBar(content: Text('会計（仮）')),
+        showCurrentAccountingDialog(
+          context: ctx,
+          user: u,
         );
       },
     );
 
-// 塊G: トーナメント
+// 塊G: トーナメント（トーナメント履歴）
 _UserActionItem _buildBlockG(Map<String, dynamic> user) => _UserActionItem(
-      label: 'トーナメント',
+      label: 'トーナメント履歴',
       icon: Icons.emoji_events,
       color: Colors.redAccent,
       onSelected: (ctx, u) {
-        ScaffoldMessenger.of(ctx).showSnackBar(
-          const SnackBar(content: Text('トーナメント（仮）')),
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String? ?? '(名前未設定)';
+        
+        if (userId == null || userId.isEmpty) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('ユーザー情報が不足しています')),
+          );
+          return;
+        }
+        
+        showTournamentHistoryDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
         );
       },
     );
@@ -253,8 +299,20 @@ _UserActionItem _buildBlockH(Map<String, dynamic> user) => _UserActionItem(
       icon: Icons.account_circle,
       color: Colors.brown,
       onSelected: (ctx, u) {
-        ScaffoldMessenger.of(ctx).showSnackBar(
-          const SnackBar(content: Text('プロフィール（仮）')),
+        final userId = u['userId'] as String?;
+        final pokerName = u['pokerName'] as String? ?? '(名前未設定)';
+        
+        if (userId == null || userId.isEmpty) {
+          ScaffoldMessenger.of(ctx).showSnackBar(
+            const SnackBar(content: Text('ユーザー情報が不足しています')),
+          );
+          return;
+        }
+        
+        showProfileDialog(
+          context: ctx,
+          userId: userId,
+          pokerName: pokerName,
         );
       },
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Adds extra-charge backend and expands user-facing utilities**
> 
> - New callable `appendExtra` with helper (`helpers/billsApi/appendExtra.ts`): validates device/auth/permissions, enforces idempotency via `bills/{billId}/idempotency/{key}`, writes to `bills/{billId}/extras`, updates `updatedAt`, and logs; exported in `functions/src/callables/index.ts`
> - Firestore rules: allow reads for `users/*` log subcollections (`pointALogs`, `pointBLogs`, `sideGameChipLogs`)
> 
> **UI: User action menu gains rich dialogs**
> - New dialogs/pages: `add_extra_popup` (calls `appendExtra`), `chip_point_view_popup` + `chip_point_logs_page`, `current_accounting_popup`, `current_seat_popup`, `order_history_popup`, `tournament_history_popup`, `profile_popup`
> - `user_action_home.dart`: replaces placeholder SnackBars to launch the above dialogs; adds imports
> - `StayingUsersListPage`: minor list item tweak (remove subtitle)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fd494ae885481bc281b918399df9bd2c25cda5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->