### PR TITLE
feat(functions): GCP未実行検知向け logOpsInfo(start) と要件・ルール整備

### DIFF
--- a/.cursor/rules/scheduler-task-reachability-logging.mdc
+++ b/.cursor/rules/scheduler-task-reachability-logging.mdc
@@ -1,0 +1,148 @@
+---
+description: Scheduler / Cloud Tasks / Task Queue / HTTP Task 追加時の開始ログ（logOpsInfo start）と予定時刻・突合キーのルール
+globs: functions/src/**/*.ts
+alwaysApply: false
+---
+
+# Cloud Functions — Scheduler / Task 系の開始ログ・予定時刻ルール
+
+このルールは、`functions/src/**/*.ts` に **Scheduler / Cloud Tasks / Task Queue / HTTP Task** など GCP 側の仕組みで後続 handler を実行する経路を**新規追加または拡張する際**に従う。**未実行・未配送・未到達疑い**を、管理用アプリがなくても Logs Explorer / Firestore / Cloud Tasks / Cloud Scheduler から確認できるようにすることを目的とする。
+
+**実装の正**: `functions/src/shared/logging/logOpsError.ts` の `logOpsInfo`（`eventType: "start"`）。**`logOpsSuccess` / `logOpsError` のルール**は `.cursor/rules/cloud-functions-error-logging.mdc` を優先する。
+
+要件の整理は `docs/エラーログ運用/GCP未実行検知/GCP側未実行検知_要件定義.md` を参照。
+
+---
+
+## 1. 基本方針（必須）
+
+新たに Scheduler / Cloud Tasks / Task Queue / HTTP Task などにより後続処理を実行する機能を追加する場合は、次の **3 点を必須**とする。
+
+1. **実行される handler 側**で、処理入口に **開始ログ**を出す（`logOpsInfo`，原則 `eventType: "start"`。実装は共通ヘルパに寄せる）。
+2. **前段の処理**で、後続がいつ実行される**予定**であるか、または未実行判定の**判定起点時刻**を確認できるようにする。
+3. **予定時刻（または起点時刻）と開始ログを突合できるキー**を、payload / Firestore / ログ context のいずれかで残す。
+
+**目的**: 管理用アプリ作成前でも、未実行・未配送・未到達疑いを突き合わせ可能にする。
+
+---
+
+## 2. handler 側の開始ログ
+
+Scheduler / Task によって呼び出される **handler の処理入口**（主要な Firestore read・外部 API・本処理より前、相関 ID が取れる最小の位置）で **`logOpsInfo`** を呼び、原則 **`eventType: "start"`**（共通実装で付与される）を出力する。
+
+- **意味**: このログは **正常完了を意味しない**。**handler に到達した証跡**のみ。
+- **完了・失敗**: 既存どおり `logOpsSuccess` / `logOpsError` を使う（開始ログの意味は変更しない）。
+
+### 2-1. 必須となる観点（共通ヘルパ利用時）
+
+`logOpsInfo` 経由なら、実装上は少なくとも次が構造化 payload に載る。
+
+- `functionEntry`（export 名と原則一致。例外は `serviceByFunctionEntry.ts` に従う）
+- `operation`（開始なら原則 `"start"`）
+- `eventType: "start"`（共通ヘルパが付与）
+- `service`（`functionEntry` から解決）
+- `projectId`
+- 突合に必要な **`context`**（対象に応じた最小キー）
+
+### 2-2. `context` に含めるべき情報
+
+対象に応じて、次のような **突合キー**を載せる。**すべてを毎回含める必要はない**が、**前段で作った task / 予定時刻 / 業務対象とログを突合できる情報**は必ず含める。
+
+例:
+
+- `jobKey`, `idempotencyKey`, `supervisorRunId`, `plannedRunAt`
+- `scheduledAt`（ISO 文字列など、body と対応するもの）
+- `runId`, `staffId`, `paymentPeriodKey`
+- `tournamentId`, `taskType`, `planVersion`, `planHash`
+- `intendedBusinessDateKey`
+- `targetDate`, `todayStr`（処理対象日として）
+- レンジ系: `rangeStartAt`, `rangeEndAt`, `evaluationDate`, `windowEndDate`
+
+### 2-3. `context` に載せないもの
+
+- **リクエスト body 全文**・**巨大な配列**・**不要な個人情報**
+- **秘密・トークン**
+
+詳細は `cloud-functions-error-logging.mdc` の **`context` 最小限**の考え方に合わせる。
+
+---
+
+## 3. 前段処理側の「予定時刻／判定起点」の記録
+
+Scheduler / Task を作成する **前段**では、後続 handler がいつ動く**予定**か（または未実行判定で見る**起点時刻**が何か）を、後から追えるようにする。
+
+次の **種別に応じて**、いずれかを記録するか、参照可能にする。
+
+| 種別 | 記録・参照する時刻の例 |
+|---|---|
+| Scheduler 直起動（`onSchedule`） | cron / schedule 定義に基づく予定実行時刻 |
+| scheduled job（Task Queue + payload） | payload の `plannedRunAt`（enqueue の `scheduleTime` と意図を揃える） |
+| Cloud Tasks / HTTP Task（遅延実行） | Cloud Tasks の **`scheduleTime`** または HTTP body の **`scheduledAt`** |
+| 即時 Task Queue（`scheduleTime` 未指定） | **`enqueuedAt`** または **`expectedStartBy`**（現状未実装なら別 ChangeSpec で検討） |
+| 業務状態依存で enqueue | 実行可能になった**業務時刻**、または **`expectedStartBy` / `deadlineAt`**（別 ChangeSpec可） |
+
+---
+
+## 4. 予定時刻の保存・確認場所
+
+予定時刻（または判定起点）は、運用で **後から確認できる場所**に残す。
+
+候補:
+
+- task **payload**
+- Firestore の **execution log**（例: `schedulerDispatchLogs`, `schedulerExecutionLogsByCloudTask`）
+- Firestore の **taskIndex** 等
+- Firestore の **業務状態ドキュメント**（例: `payrollRuns`）
+- Cloud Tasks メタデータの **`scheduleTime`**
+- **`logOpsInfo(start)` の `context`**（突合キー用。時刻そのものが payload に無い場合は他ソースと組み合わせる）
+- 前段の **`logOpsSuccess` / `logOpsInfo` の `context`**（dispatch 証跡との相関）
+
+Cloud Tasks / Task Queue を使う場合は、次の **いずれか以上**が、Firestore・payload・GCP コンソール・ログのどこかで追えるようにする。
+
+```text
+scheduleTime
+scheduledAt
+plannedRunAt
+enqueuedAt
+expectedStartBy
+deadlineAt
+```
+
+（即時 enqueue で時刻が無い場合は、その旨を設計判断としてドキュメントまたはコードコメントで明示し、SLA 起点を要件定義に合わせる。）
+
+---
+
+## 5. その他の実装メモ
+
+- 新しい **`functionEntry`** を増やす場合は **`serviceByFunctionEntry.ts`** にマッピングを追加する（`cloud-functions-error-logging.mdc` の **1-4** と同じ）。
+- **replan・delay enqueue** など、`plannedRunAt` と実ディスパッチがずれる経路は、通常経路と **別判定**にできるようキーやドキュメントを分ける。
+- 既存 handler に **開始ログが無い**経路を触る場合は、本ルールに沿って追加を検討する（別 ChangeSpec で明示されている場合はそれに従う）。
+
+---
+
+## 6. 実装時チェックリスト
+
+新規実装・改修の完了前に確認する。実装 AI がこのチェックリストを確認し結果を出力するときは次を守る。
+
+- **機械的な項目**は、コード・検索・差分など**根拠を示して**よい。
+- **文脈・判断が必要な項目**は、仕様や運用意図が読み取れない部分は**断定しない**。**曖昧・未確定・要人間レビュー**である旨を明示し、チェック済みと**言い切らない**。
+
+### 機械的に確認できる項目（検索・差分で判定しやすい）
+
+- [ ] **Task / Scheduler により呼ばれる handler** の入口に **`logOpsInfo`**（開始用、`operation` は原則 `"start"`）がある。
+- [ ] 開始ログが **`logOpsSuccess` と同一視されていない**（start は到達のみ、完了は別ログ）。
+- [ ] 新規 **`functionEntry`** を増やした場合、`functions/src/shared/logging/serviceByFunctionEntry.ts` に **`functionEntry` → `service`** が登録されている。
+- [ ] **`context`** に、前段の task / payload / Firestore と **突合できるキー**が含まれている（該当経路で使う idempotency・runId・plannedRunAt 等）。
+- [ ] **`context`** に **リクエスト全文・巨大配列・トークン・不要な個人情報**を載せていない。
+- [ ] **scheduled job** 経路では、payload の **`plannedRunAt`** と enqueue の **`scheduleTime`**（または同等の遅延指定）の意図がコード上ずれていない（通常経路）。
+- [ ] **HTTP Cloud Task** 経路では、body の **`scheduledAt`** と（あれば）Cloud Tasks の **`scheduleTime`** が追える。
+- [ ] **即時 enqueue** で `scheduleTime` を付けていない場合、`docs/エラーログ運用/GCP未実行検知/GCP側未実行検知_要件定義.md` で想定している **SLA 起点**（run 開始・全 staff 完了等）と整合する記録・コメントまたはドキュメント更新がある。
+
+### 文脈・判断が必要な項目（仕様・運用意図に照らして確認）
+
+- [ ] **判定起点時刻**が、要件定義の分類（cron / `plannedRunAt` / `scheduleTime` / SLA 型）のどれに当たるか、運用で説明できる。
+- [ ] **親子関係**がある（例: `executeScheduledJobTask` → 内部処理）場合、**親の `plannedRunAt`** と **子 handler の start** の突合方針が一貫している。
+- [ ] **replan・`scheduleDelaySeconds` 等**で通常経路と異なる場合、**別判定・別キー**で混同しない設計か。
+- [ ] Firestore **execution log / dispatch log / taskIndex** を書く経路では、未実行確認に必要な **`plannedRunAt` 相当・jobKey・idempotencyKey** が欠けていないか（書かない方針なら理由が明確か）。
+- [ ] **複数経路**から同一 HTTP handler が呼ばれる場合、経路ごとに **task id / scheduledAt / context** で追えるか、または運用上の限界がドキュメント化されている。
+

--- a/docs/エラーログ運用/GCP未実行検知/GCP側未実行検知_要件定義.md
+++ b/docs/エラーログ運用/GCP未実行検知/GCP側未実行検知_要件定義.md
@@ -1,0 +1,994 @@
+# GCP側未実行検知 要件定義
+
+## 1. 文書の目的
+
+本書は、Cloud Functions 内の `logOpsError` では検知できない可能性がある、以下のような異常を確認するための要件を定義する。
+
+- 関数がそもそも起動していない
+- Scheduler が予定どおり処理を呼び出していない
+- Task Queue / Cloud Tasks がタスクを配送していない
+- HTTP Task が関数の入口まで到達していない
+- Firestore trigger が期待どおり発火していない
+- 本来出るべき到達ログ・実行ログ・成功ログが出ていない
+
+本書の主眼は、エラーとしてログに出たものを検知することではなく、**本来発生するはずの実行証跡が存在しない状態を確認できるようにすること**である。
+
+現時点では、Cloud Monitoring アラートや管理用アプリの具体仕様は確定しない。
+
+本書では、将来の管理用アプリや運用確認で参照できるように、以下を整理する。
+
+- どの処理を未実行検知の対象として考えるか
+- 何を handler 到達証跡とするか
+- どの時刻を判定起点にするか
+- どのキーで予定時刻・到達ログ・完了ログ・失敗ログを突合するか
+- どの情報が現状不足しているか
+- 管理用アプリ作成前に、ログ・既存記録だけでどこまで確認できるか
+
+---
+
+## 2. 前提
+
+現在、関数コード内で発生した業務エラー・外部APIエラー・想定外エラーについては、原則として `logOpsError` によって検知できる状態を目指している。
+
+そのため、本書では以下を主対象としない。
+
+- 関数内で throw / catch されたエラー
+- Firestore update / set / transaction の失敗
+- 外部API呼び出し失敗
+- Cloud Tasks の createTask 失敗
+- 業務ロジック上の例外
+- `logOpsError` として出力されるエラー
+
+これらは、既存の `logOpsError` 監視の対象とする。
+
+本書で扱うのは、**関数コードに到達していない、または到達した証跡がない状態**である。
+
+---
+
+## 3. 用語定義
+
+### 3.1 未実行
+
+本来起動されるべき処理について、判定起点時刻または期待タイミングを過ぎても、handler 到達証跡が確認できない状態。
+
+例:
+
+- `schedulerSupervisor` が予定時刻を過ぎても起動していない
+- scheduled job の start ログがない
+- task handler の到達ログがない
+
+### 3.2 未配送
+
+作成された task が、一定時間以内に handler へ配送されていない状態。
+
+例:
+
+- Cloud Tasks / Task Queue に古い task が残っている
+- task 作成記録はあるが、handler 側の start ログがない
+- retry が続いているが handler 到達証跡が確認できない
+
+### 3.3 未到達
+
+GCP側の呼び出しは行われたが、対象の関数コード入口まで到達していない、または到達証跡が確認できない状態。
+
+例:
+
+- HTTP Task が 401 / 403 / 404 / timeout で関数に届かない
+- Cloud Tasks は呼び出しているが、handler側ログがない
+
+### 3.4 到達証跡
+
+handler に到達したことを判断するための記録。
+
+本書では、原則として以下を第一証跡とする。
+
+- `logOpsInfo(eventType: "start")`
+
+### 3.5 完了証跡
+
+handler 到達後、処理が正常完了したことを判断するための記録。
+
+例:
+
+- `logOpsSuccess`
+- 既存の成功ログ
+- Firestore の完了状態
+
+### 3.6 失敗証跡
+
+handler 到達後、処理中に失敗したことを判断するための記録。
+
+例:
+
+- `logOpsError`
+- Cloud Functions / Cloud Run の error log
+- Cloud Tasks の retry / failure 状態
+
+### 3.7 判定起点時刻
+
+未実行・未配送・未到達を判定するための起点時刻。
+
+対象によって、以下のいずれかを採用する。
+
+- Cloud Scheduler / onSchedule の予定実行時刻
+- `plannedRunAt`
+- Cloud Tasks の `scheduleTime`
+- HTTP body の `scheduledAt`
+- task 投入時刻
+- 業務状態が特定状態に到達した時刻
+- run 開始時刻
+- 全 staff 完了時刻
+
+### 3.8 猶予時間
+
+判定起点時刻から、未実行・未配送・未到達疑いと判定するまでに許容する時間。
+
+Cloud Tasks の配送遅延、Cloud Functions の起動遅延、処理開始までの揺れを考慮して対象ごとに定義する。
+
+### 3.9 管理用アプリでの確認対象
+
+未実行・未配送・未到達疑いが発生していないかを、将来実装する管理用アプリ上で確認可能にする対象。
+
+ただし、本書では管理用アプリの具体仕様は決めない。
+
+---
+
+## 4. 基本方針
+
+### 4.1 `logOpsError` と未実行検知を分ける
+
+`logOpsError` は、関数が起動した後の失敗を検知するための仕組みである。
+
+一方、未実行検知は、関数が起動していない、task が配送されていない、handler に到達していないなど、**関数内の失敗ログが出ない可能性がある異常**を確認するための考え方である。
+
+### 4.2 本書では検知材料を整理する
+
+本書の目的は、現時点で Cloud Monitoring アラートや管理用アプリの仕様を確定することではない。
+
+本書では、将来の管理用アプリや監視設計で参照できるように、以下を整理する。
+
+- どの処理を未実行検知の対象として考えるか
+- 何を handler 到達証跡とするか
+- どの時刻を判定起点にするか
+- どのキーで予定時刻・到達ログ・完了ログ・失敗ログを突合するか
+- どの情報が現状不足しているか
+
+### 4.3 通知分類・表示仕様は本書では確定しない
+
+本段階では、以下は確定しない。
+
+- 即時通知対象
+- 軽め通知対象
+- 高優先度 / 中優先度 / 低優先度
+- 管理用アプリの画面構成
+- 管理用アプリの表示項目
+- 通知文面
+- Cloud Monitoring アラート条件
+
+理由は、管理用アプリの仕様が未定であり、現時点で画面や通知の詳細を決めても後で作り直しになる可能性が高いためである。
+
+初期方針としては、未実行・未配送・未到達疑いは原則すべて確認対象とし、実データや運用負荷を見ながら、後続で表示優先度や通知条件を検討する。
+
+### 4.4 判定は「確定」ではなく「疑い」として扱う
+
+`logOpsInfo(eventType: "start")` が存在しない場合でも、原因は複数考えられる。
+
+- Scheduler が起動していない
+- task が作成されていない
+- task が配送されていない
+- HTTP request が handler に到達していない
+- handler 入口より前で失敗している
+- ログ出力自体が欠落している
+
+そのため、原則として **未実行・未配送・未到達疑い** として扱い、原因切り分けは補助確認情報を用いて行う。
+
+---
+
+## 5. 未実行検知対象一覧（整理版）
+
+本書では、未実行・未配送・未到達の第一証跡として、原則 **`logOpsInfo(eventType: "start")`** を使用する。
+
+`logOpsSuccess` は正常完了の証跡、`logOpsError` は handler 到達後の失敗証跡として扱い、未実行判定の第一証跡にはしない。
+
+| No | 対象経路 | 起動元 | 判定起点時刻 | 未実行・未配送・未到達疑いの考え方 | 到達証跡 | 補助確認 |
+|---:|---|---|---|---|---|---|
+| 1 | `schedulerSupervisor` | Cloud Scheduler / onSchedule | Firebase Scheduler の cron 実行時刻。現状は `03:00 JST` | `03:00 JST + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | Cloud Scheduler 履歴 / Logs Explorer / request log |
+| 2 | `executeScheduledJobTask` | Task Queue Function | payload / execution log の `plannedRunAt` | `plannedRunAt + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | Cloud Tasks / `schedulerDispatchLogs` / `schedulerExecutionLogsByCloudTask` |
+| 3 | Cloud Tasks / Firebase Task Queue 全般 | Cloud Tasks / Task Queue | queue / task ごとの `scheduleTime` または投入時刻 | task が古いまま残る、配送されない、retry が続く | handler の `logOpsInfo(eventType: "start")` または request log | Cloud Tasks metrics / Queue 画面 |
+| 4 | `openAssessmentTask` | HTTP Cloud Task | HTTP Cloud Task の `scheduleTime` または body の `scheduledAt` | `scheduleTime + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | Cloud Tasks / request log / task body |
+| 5 | `closeAssessmentTask` | HTTP Cloud Task | HTTP Cloud Task の `scheduleTime` または body の `scheduledAt` | `scheduleTime + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | Cloud Tasks / request log / task body |
+| 6 | `controlHookHttp` | HTTP Cloud Task | tournament task の Cloud Tasks `scheduleTime`。実装上は `enqueueDueAt` | `scheduleTime + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | Cloud Tasks / request log / `taskIndex` |
+| 7 | `processStaffPayroll` | Payroll staff task | 現状、task に予定時刻は保存されていない。暫定的に payroll run 起点の SLA 型で扱う | `payroll run 開始時刻 + 猶予時間` を過ぎても対象 staff の start がない | `logOpsInfo(eventType: "start")` | `payrollRuns` / `staffResults` / Task Queue |
+| 8 | `finalizePayrollRun` | Payroll finalize task | 現状、task に予定時刻は保存されていない。暫定的に全 staff 完了後の SLA 型で扱う | `全 staff 処理完了時刻 + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | `payrollRuns` / `staffResults` / Task Queue |
+| 9 | `payrollNotificationScheduler` | `executeScheduledJobTask` 配下 | 親 `executeScheduledJobTask` の `plannedRunAt` | 親 `plannedRunAt + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | `schedulerExecutionLogsByCloudTask` / 親 job log |
+| 10 | `processPayrollNotifications` | Notification Task Queue | notification task の Cloud Tasks `scheduleTime`。実装上は `scheduleUtc` | `scheduleTime + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | Cloud Tasks / 親 `payrollNotificationScheduler` log |
+| 11 | `enqueueTournamentTasksByScheduler` | `executeScheduledJobTask` 配下 | 親 `executeScheduledJobTask` の `plannedRunAt` | 親 `plannedRunAt + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | `schedulerExecutionLogsByCloudTask` / 親 job log |
+| 12 | `generateRecurringTournamentsByScheduler` | `executeScheduledJobTask` 配下 | 親 `executeScheduledJobTask` の `plannedRunAt` | 親 `plannedRunAt + 猶予時間` を過ぎても start がない | `logOpsInfo(eventType: "start")` | `schedulerExecutionLogsByCloudTask` / 親 job log |
+| 13 | `scheduledCleanup` | scheduled job | 既存 scheduled job の予定時刻 | 予定時刻後に実行証跡がない | 既存実行ログ / 成功ログ | Logs Explorer / schedulerExecutionLogs |
+| 14 | `scheduleGenerateNextYearBusinessHours` | scheduled job | 既存 scheduled job の予定時刻 | 期限までに成功証跡がない | 既存実行ログ / 成功ログ | Logs Explorer / Firestore確認 |
+| 15 | Firestore trigger 系 | Firestore trigger | 元 doc の更新時刻または期待される後続状態 | 元 doc の変更後、期待する trigger 到達証跡または後続状態がない | trigger 実行ログ / 後続状態 | Logs Explorer / Firestore状態 |
+
+---
+
+## 6. 判定の基本形
+
+### 6.1 基本判定
+
+本書における基本判定は以下とする。
+
+```text
+判定起点時刻 + 猶予時間 を過ぎても
+対象 handler の logOpsInfo(eventType: "start") が存在しない
+=
+未実行・未配送・未到達疑い
+
+これは「未実行確定」ではなく、一次判定としての 未実行・未配送・未到達疑い である。
+```
+
+### 6.2 start 後の扱い
+
+`logOpsInfo(eventType: "start")` が存在する場合、その処理は少なくとも handler 入口まで到達している。
+
+その後の結果は以下で確認する。
+
+| 状態 | 見る証跡 |
+|---|---|
+| 正常完了 | `logOpsSuccess` |
+| handler 到達後の失敗 | `logOpsError` |
+| 実行中・早期 return・追加確認 | start はあるが success / error が確認できない状態 |
+
+### 6.3 原因切り分け
+
+start が存在しない場合でも、原因は複数考えられる。
+
+- Scheduler が起動していない
+- task が作成されていない
+- task が配送されていない
+- HTTP request が handler に到達していない
+- handler 入口より前で失敗している
+- ログ出力自体が欠落している
+
+原因切り分けは、以下の補助情報を使って行う。
+
+- Cloud Scheduler 履歴
+- Cloud Tasks 状態
+- request log
+- Firestore 実行記録
+- taskIndex
+- 業務状態ドキュメント
+
+---
+
+## 7. 対象別の判定材料
+
+| 対象 | 判定起点時刻 | 到達証跡 | 完了証跡 | 失敗証跡 | 主な突合キー | 補助確認 |
+|---|---|---|---|---|---|---|
+| `schedulerSupervisor` | Firebase Scheduler の cron 実行時刻。現状 03:00 JST | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `planningDate` | Cloud Scheduler 履歴 / request log |
+| `executeScheduledJobTask` | payload / execution log の `plannedRunAt` | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `jobKey`, `idempotencyKey`, `supervisorRunId`, `plannedRunAt` | Cloud Tasks / `schedulerDispatchLogs` / `schedulerExecutionLogsByCloudTask` |
+| `openAssessmentTask` | HTTP Cloud Task の `scheduleTime` または body の `scheduledAt` | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `action`, `intendedBusinessDateKey`, `idempotencyKey`, `scheduledAt` | Cloud Tasks / request log / task body |
+| `closeAssessmentTask` | HTTP Cloud Task の `scheduleTime` または body の `scheduledAt` | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `intendedBusinessDateKey`, `idempotencyKey`, `scheduledAt` | Cloud Tasks / request log / task body |
+| `controlHookHttp` | tournament task の Cloud Tasks `scheduleTime`。実装上は `enqueueDueAt` | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | 新: `tournamentId`, `taskType`, `planVersion`, `planHash` / 旧: `action`, `tournamentId`, `rev` | Cloud Tasks / request log / taskIndex |
+| `processStaffPayroll` | 現状 task 単位の予定時刻なし。暫定的に payroll run 開始時刻 | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `runId`, `staffId`, `paymentPeriodKey` | payrollRuns, staffResults, Task Queue |
+| `finalizePayrollRun` | 現状 task 単位の予定時刻なし。暫定的に全 staff 完了時刻 / finalize 可能状態到達時刻 | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `runId`, `paymentPeriodKey` | payrollRuns, staffResults, Task Queue |
+| `payrollNotificationScheduler` | 親 `executeScheduledJobTask` の `plannedRunAt` | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `targetDate`, 親 jobKey, 親 idempotencyKey | `schedulerExecutionLogsByCloudTask` / 親 job log |
+| `processPayrollNotifications` | notification task の Cloud Tasks `scheduleTime`。実装上は `scheduleUtc` | `logOpsInfo(eventType: "start")` | 既存 logger.info / 後続で logOpsSuccess 化検討 | `logOpsError` | `todayStr`, `targetDate`, notification task id | Cloud Tasks / 親 payrollNotificationScheduler log |
+| `enqueueTournamentTasksByScheduler` | 親 `executeScheduledJobTask` の `plannedRunAt` | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `rangeStartAt`, `rangeEndAt`, 親 jobKey, 親 idempotencyKey | `schedulerExecutionLogsByCloudTask` / 親 job log |
+| `generateRecurringTournamentsByScheduler` | 親 `executeScheduledJobTask` の `plannedRunAt` | `logOpsInfo(eventType: "start")` | `logOpsSuccess` | `logOpsError` | `evaluationDate`, `windowEndDate`, 親 jobKey, 親 idempotencyKey | `schedulerExecutionLogsByCloudTask` / 親 job log |
+
+---
+
+## 8. 後続検討対象
+
+### 8.1 Firestore trigger 未発火
+
+Firestore trigger は、コードに到達すれば `logOpsError` で検知できるが、trigger 自体が発火していない場合は関数内ログが出ない。
+
+ただし、Firestore trigger 未発火の検知は、GCP側ログだけでなく、元docと期待される後続状態の差分確認が必要になる。
+
+そのため、本書では後続検討対象とする。
+
+対象例:
+
+- billsOnSettle
+- billsEventsOnCreate
+- attendanceOnWrite
+- enqueueTournamentTasksReplanOnWrite
+
+### 8.2 Firestore状態監視
+
+以下は未実行検知というより、業務状態の stuck 検知として扱う。
+
+- payrollRuns が running / dispatching / finalizing のまま
+- staffResults が pending / processing のまま
+- scheduledTournaments/{id}/taskIndex.enqueueState == failed のまま
+- closeRuns が running / failed のまま
+- 必要な analytics marker が作られていない
+
+これらは別文書で、Firestore状態監視として定義する。
+
+---
+
+## 9. 確認方法の使い分け
+
+| 確認方法 | 用途 | 備考 |
+|---|---|---|
+| Logs Explorer | 個別ログの調査 | start / success / error の確認に使う |
+| Cloud Tasks / Task Queue 画面 | queue 滞留、retry、古い task の確認 | task 単位の配送状況確認に使う |
+| Cloud Scheduler 履歴 | Scheduler 自体が起動したかの確認 | schedulerSupervisor などに使う |
+| Firestore execution logs | scheduled job の実行確認 | schedulerDispatchLogs, schedulerExecutionLogsByCloudTask など |
+| Firestore 業務状態 | stuck 状態・後続状態の確認 | payrollRuns, staffResults, taskIndex など |
+| 将来の管理用アプリ | 未実行・未配送・未到達疑いの一覧確認 | 本書では仕様を確定しない |
+| Cloud Monitoring / Log-based alert | 将来的な通知候補 | 本書では具体設定しない |
+
+---
+
+## 10. 将来の管理用アプリに向けた軽い方針
+
+### 10.1 本書で決めること
+
+本書では、将来の管理用アプリで未実行・未配送・未到達疑いを扱えるようにするため、以下を整理する。
+
+- 対象処理
+- 判定起点時刻
+- 到達証跡
+- 完了証跡
+- 失敗証跡
+- 主な突合キー
+- 補助確認情報
+
+### 10.2 本書で決めないこと
+
+以下は、管理用アプリの設計時に改めて決める。
+
+- 管理用アプリの画面構成
+- 一覧に出す項目
+- 詳細画面の表示内容
+- 表示優先度
+- 絞り込み条件
+- 通知条件
+- 通知文面
+- どの情報を中央監視プロジェクト側に集約するか
+
+### 10.3 初期方針
+
+初期方針としては、エラーおよび未実行疑いは原則すべて確認対象とする。
+
+実際の運用データを見た上で、後続で表示優先度・通知条件・管理用アプリ上の見せ方を決める。
+
+---
+
+## 11. 管理用アプリ作成前のログ確認方針
+
+### 11.1 目的
+
+将来の管理用アプリを作成する前でも、運用者が Logs Explorer / Firestore 記録 / Cloud Tasks / Cloud Scheduler から、未実行・未配送・未到達疑いを確認できる状態にする。
+
+そのため、本段階では少なくとも以下の2つを突き合わせられることを目指す。
+
+| 種別 | 内容 |
+|---|---|
+| 判定起点時刻 | 本来その処理が開始される予定だった時刻、または監視上の起点時刻 |
+| 実際の開始時刻 | `logOpsInfo(eventType: "start")` が出力された時刻 |
+
+### 11.2 実際の開始時刻
+
+実際の開始時刻は、対象 handler に追加した `logOpsInfo(eventType: "start")` のログ時刻を使用する。
+
+このログは、handler に到達したことを示す到達証跡であり、正常完了を意味しない。
+
+### 11.3 判定起点時刻の確認場所
+
+対象ごとに、判定起点時刻は以下のいずれかから確認する。
+
+| 対象 | 判定起点時刻 | 確認場所 |
+|---|---|---|
+| `schedulerSupervisor` | cron 実行時刻。現状 03:00 JST | Cloud Scheduler 履歴 / schedule定義 |
+| `executeScheduledJobTask` | `plannedRunAt` | payload / `schedulerDispatchLogs` / `schedulerExecutionLogsByCloudTask` |
+| `payrollNotificationScheduler` | 親 `executeScheduledJobTask` の `plannedRunAt` | 親 job の payload / scheduler execution log |
+| `enqueueTournamentTasksByScheduler` | 親 `executeScheduledJobTask` の `plannedRunAt` | 親 job の payload / scheduler execution log |
+| `generateRecurringTournamentsByScheduler` | 親 `executeScheduledJobTask` の `plannedRunAt` | 親 job の payload / scheduler execution log |
+| `openAssessmentTask` | Cloud Tasks `scheduleTime` または body `scheduledAt` | Cloud Tasks / HTTP body / task作成記録 |
+| `closeAssessmentTask` | Cloud Tasks `scheduleTime` または body `scheduledAt` | Cloud Tasks / HTTP body / task作成記録 |
+| `controlHookHttp` | Cloud Tasks `scheduleTime`。実装上は `enqueueDueAt` | Cloud Tasks / taskIndex.enqueueDueAt / HTTP body scheduledAt |
+| `processPayrollNotifications` | Cloud Tasks `scheduleTime`。実装上は `scheduleUtc` | Cloud Tasks / notification task 作成記録 |
+| `processStaffPayroll` | 現状、task単位の予定時刻は保存されていない | payrollRuns.startedAt 等を暫定起点にする |
+| `finalizePayrollRun` | 現状、task単位の予定時刻は保存されていない | 全 staff 完了時刻 / finalize可能状態を暫定起点にする |
+
+### 11.4 現状不足している対象
+
+以下の対象は、現状のログ・payload・enqueueオプションに task 単位の予定時刻が明示保存されていない。
+
+- `processStaffPayroll`
+- `finalizePayrollRun`
+
+この2件は、管理用アプリ作成前にログ・記録だけで精度高く未実行判定するには材料が不足している。
+
+ただし、今回はこのまま運用する。
+
+そのため、当面は以下の暫定起点で確認する。
+
+| 対象 | 暫定起点 |
+|---|---|
+| `processStaffPayroll` | payrollRuns.startedAt または run 開始を示す時刻 |
+| `finalizePayrollRun` | 全 staff 完了時刻、または finalize 可能状態になった時刻 |
+
+後続で精度を上げる場合は、task 投入時に以下のような監視用時刻を payload または Firestore に保存することを検討する。
+
+- enqueuedAt
+- expectedStartBy
+- deadlineAt
+
+ただし、この追加実装は現時点では行わない。
+
+### 11.5 管理用アプリ作成前の確認方法
+
+管理用アプリ作成前は、以下を手動で突き合わせる。
+
+```text
+判定起点時刻 + 猶予時間
+  を過ぎている
+
+かつ
+
+対象 handler の logOpsInfo(eventType: "start")
+  が存在しない
+
+=
+
+未実行・未配送・未到達疑い
+```
+
+start が存在する場合は、handler には到達しているため、以降は `logOpsSuccess` または `logOpsError` を確認する。
+
+---
+
+## 12. 予定時刻の定義
+
+### 12.1 基本方針
+
+未実行判定における「予定時刻」または「判定起点時刻」は、対象ごとに異なる。
+
+大きく以下に分類する。
+
+| 分類 | 判定起点時刻 |
+|---|---|
+| Scheduler 直起動系 | Cloud Scheduler / onSchedule の予定実行時刻 |
+| scheduled job 共通実行口 | payload / execution log の plannedRunAt |
+| scheduled job 配下の同期処理 | 親 executeScheduledJobTask の plannedRunAt |
+| HTTP Cloud Task / Task Queue 系 | Cloud Tasks の scheduleTime または payload の scheduledAt |
+| タスクに予定時刻が保存されていない処理 | run 状態や業務状態を基準に別途 SLA 定義 |
+
+### 12.2 対象別の採用予定時刻
+
+| 対象 | 採用する判定起点時刻 | 補助キー・補助確認 | 備考 |
+|---|---|---|---|
+| schedulerSupervisor | Firebase Scheduler の cron 実行時刻。現状は 03:00 JST | planningDate, Cloud Scheduler 履歴, Logs Explorer | planningDate は日付キーであり、予定実行時刻そのものではない |
+| executeScheduledJobTask | payload / execution log の plannedRunAt | jobKey, idempotencyKey, supervisorRunId, Cloud Tasks scheduleTime, schedulerDispatchLogs, schedulerExecutionLogsByCloudTask | 通常経路では plannedRunAt と Cloud Tasks scheduleTime は同一意図。replan 経路は別扱い |
+| payrollNotificationScheduler | 親 executeScheduledJobTask の plannedRunAt | targetDate, 親 jobKey, 親 idempotencyKey | onSchedule 直起動ではなく、scheduled job 配下の処理として扱う |
+| enqueueTournamentTasksByScheduler | 親 executeScheduledJobTask の plannedRunAt | rangeStartAt, rangeEndAt, 親 jobKey, 親 idempotencyKey | onSchedule 直起動ではなく、scheduled job 配下の処理として扱う |
+| generateRecurringTournamentsByScheduler | 親 executeScheduledJobTask の plannedRunAt | evaluationDate, windowEndDate, 親 jobKey, 親 idempotencyKey | onSchedule 直起動ではなく、scheduled job 配下の処理として扱う |
+| openAssessmentTask | HTTP Cloud Task の scheduleTime または body の scheduledAt | intendedBusinessDateKey, idempotencyKey, task name, request log | intendedBusinessDateKey は予定時刻ではなく対象営業日キー |
+| closeAssessmentTask | HTTP Cloud Task の scheduleTime または body の scheduledAt | intendedBusinessDateKey, idempotencyKey, task name, request log | intendedBusinessDateKey は予定時刻ではなく対象営業日キー |
+| controlHookHttp | tournament task の Cloud Tasks scheduleTime。実装上は enqueueDueAt | tournamentId, taskType, planVersion, planHash, taskIndex.enqueueDueAt, taskIndex.taskName | 新 payload / 旧 payload で突合キーが異なる |
+| processPayrollNotifications | notification task の Cloud Tasks scheduleTime。実装上は scheduleUtc | targetDate, todayStr, enqueue task id | 親 payrollNotificationScheduler の plannedRunAt とは別の時刻軸 |
+| processStaffPayroll | 現状、task に予定時刻は保存されていない | runId, staffId, paymentPeriodKey, payrollRuns.startedAt, staffResults.taskStartedAt | 「予定時刻 + 猶予時間」型ではなく、run 起点の SLA 型として定義する |
+| finalizePayrollRun | 現状、task に予定時刻は保存されていない | runId, paymentPeriodKey, payrollRuns, staff 完了状態 | 「予定時刻 + 猶予時間」型ではなく、全 staff 完了後の SLA 型として定義する |
+
+### 12.3 既存認識からの修正点
+
+以下の 3 件は、当初は Scheduler 直起動系として扱っていたが、実コード上は executeScheduledJobTask から実行される scheduled job 配下の処理として扱う。
+
+- payrollNotificationScheduler
+- enqueueTournamentTasksByScheduler
+- generateRecurringTournamentsByScheduler
+
+そのため、未実行判定の予定時刻は onSchedule の時刻ではなく、親 executeScheduledJobTask の plannedRunAt を採用する。
+
+### 12.4 予定時刻が未保存の対象
+
+以下 2 件は、Cloud Tasks / Task Queue の enqueue 時に scheduleTime / scheduleDelaySeconds が指定されておらず、payload にも予定時刻が含まれていない。
+
+- processStaffPayroll
+- finalizePayrollRun
+
+そのため、他の対象と同じく「予定時刻 + 猶予時間」を直接適用することはできない。
+
+この 2 件は、以下のように SLA 型の未実行定義を別途置く。
+
+| 対象 | 暫定定義 |
+|---|---|
+| processStaffPayroll | payroll run 開始後、一定時間以内に対象 staff の logOpsInfo(start) がない場合、staff payroll 未実行疑い |
+| finalizePayrollRun | 全 staff 処理が完了した後、一定時間以内に finalizePayrollRun の logOpsInfo(start) がない場合、finalize 未実行疑い |
+
+より精度を上げる場合は、別 ChangeSpec で以下を検討する。
+
+- staff task 投入時に expectedStartBy / enqueuedAt / deadlineAt を payload または Firestore に保存する
+- finalize task 投入時に expectedStartBy / enqueuedAt / deadlineAt を payload または Firestore に保存する
+- staffResults や payrollRuns に監視用の期待時刻を追加する
+
+ただし、今回は追加実装せず、このまま運用する。
+
+---
+
+## 13. 対象別の未実行定義
+
+### 13.1 schedulerSupervisor
+
+**採用する判定起点時刻**
+
+Firebase Scheduler の cron 実行時刻を採用する。
+
+現状は以下とする。
+
+- 03:00 JST
+
+**未実行疑いの定義**
+
+```text
+03:00 JST + 猶予時間 を過ぎても
+schedulerSupervisor の logOpsInfo(eventType: "start") が存在しない
+=
+schedulerSupervisor 未実行疑い
+```
+
+**主な確認キー**
+
+- functionEntry = schedulerSupervisor
+- eventType = start
+- planningDate
+
+**補助確認**
+
+- Cloud Scheduler 実行履歴
+- Logs Explorer
+- Cloud Functions / Cloud Run request log
+
+### 13.2 executeScheduledJobTask
+
+**採用する判定起点時刻**
+
+payload / execution log の `plannedRunAt` を採用する。
+
+通常経路では、`plannedRunAt` は Cloud Tasks の `scheduleTime` と同一意図で設定される。
+
+**未実行疑いの定義**
+
+```text
+plannedRunAt + 猶予時間 を過ぎても
+executeScheduledJobTask の logOpsInfo(eventType: "start") が存在しない
+=
+scheduled job task 未実行・未配送・未到達疑い
+```
+
+**主な確認キー**
+
+- functionEntry = executeScheduledJobTask
+- eventType = start
+- jobKey
+- idempotencyKey
+- supervisorRunId
+- plannedRunAt
+
+**補助確認**
+
+- Cloud Tasks scheduleTime
+- schedulerDispatchLogs
+- schedulerExecutionLogsByCloudTask
+
+**注意点**
+
+replan 経路では `scheduleDelaySeconds` が使われるため、通常経路の `plannedRunAt` 判定とは分けて扱う。
+
+### 13.3 payrollNotificationScheduler
+
+**採用する判定起点時刻**
+
+親 `executeScheduledJobTask` の `plannedRunAt` を採用する。
+
+**未実行疑いの定義**
+
+```text
+親 scheduled job の plannedRunAt + 猶予時間 を過ぎても
+payrollNotificationScheduler の logOpsInfo(eventType: "start") が存在しない
+=
+payrollNotificationScheduler 未実行疑い
+```
+
+**主な確認キー**
+
+- functionEntry = payrollNotificationScheduler
+- eventType = start
+- targetDate
+- 親 jobKey
+- 親 idempotencyKey
+
+**補助確認**
+
+- executeScheduledJobTask の start
+- schedulerExecutionLogsByCloudTask
+- 親 payload の plannedRunAt
+
+**注意点**
+
+payrollNotificationScheduler の未実行判定と、後続の processPayrollNotifications の未実行判定は分ける。
+
+payrollNotificationScheduler の plannedRunAt は「通知 task を作成する親ジョブの予定時刻」であり、通知 task 自体の実行予定時刻ではない。
+
+### 13.4 processPayrollNotifications
+
+**採用する判定起点時刻**
+
+notification task の Cloud Tasks `scheduleTime` を採用する。
+
+実装上は、`payrollNotificationScheduler` が算出する `scheduleUtc` に相当する。
+
+**未実行疑いの定義**
+
+```text
+notification task の scheduleTime + 猶予時間 を過ぎても
+processPayrollNotifications の logOpsInfo(eventType: "start") が存在しない
+=
+processPayrollNotifications 未配送・未到達疑い
+```
+
+**主な確認キー**
+
+- functionEntry = processPayrollNotifications
+- eventType = start
+- todayStr
+- targetDate
+- notification task id
+
+**補助確認**
+
+- Cloud Tasks queue
+- enqueue task id
+- 親 payrollNotificationScheduler のログ
+
+**注意点**
+
+todayStr は payload の targetDate がない場合、実行時 JST の今日にフォールバックするため、予定時刻そのものではなく処理対象日として扱う。
+
+### 13.5 enqueueTournamentTasksByScheduler
+
+**採用する判定起点時刻**
+
+親 `executeScheduledJobTask` の `plannedRunAt` を採用する。
+
+**未実行疑いの定義**
+
+```text
+親 scheduled job の plannedRunAt + 猶予時間 を過ぎても
+enqueueTournamentTasksByScheduler の logOpsInfo(eventType: "start") が存在しない
+=
+tournament enqueue job 未実行疑い
+```
+
+**主な確認キー**
+
+- functionEntry = enqueueTournamentTasksByScheduler
+- eventType = start
+- rangeStartAt
+- rangeEndAt
+- 親 jobKey
+- 親 idempotencyKey
+
+**補助確認**
+
+- executeScheduledJobTask の start
+- schedulerExecutionLogsByCloudTask
+- 親 payload の plannedRunAt
+
+### 13.6 generateRecurringTournamentsByScheduler
+
+**採用する判定起点時刻**
+
+親 `executeScheduledJobTask` の `plannedRunAt` を採用する。
+
+**未実行疑いの定義**
+
+```text
+親 scheduled job の plannedRunAt + 猶予時間 を過ぎても
+generateRecurringTournamentsByScheduler の logOpsInfo(eventType: "start") が存在しない
+=
+定期トーナメント生成 job 未実行疑い
+```
+
+**主な確認キー**
+
+- functionEntry = generateRecurringTournamentsByScheduler
+- eventType = start
+- evaluationDate
+- windowEndDate
+- 親 jobKey
+- 親 idempotencyKey
+
+**補助確認**
+
+- executeScheduledJobTask の start
+- schedulerExecutionLogsByCloudTask
+- 親 payload の plannedRunAt
+
+### 13.7 openAssessmentTask
+
+**採用する判定起点時刻**
+
+HTTP Cloud Task の `scheduleTime`、または HTTP body の `scheduledAt` を採用する。
+
+**未実行疑いの定義**
+
+```text
+open assessment task の scheduleTime + 猶予時間 を過ぎても
+openAssessmentTask の logOpsInfo(eventType: "start") が存在しない
+=
+openAssessmentTask 未配送・未到達疑い
+```
+
+**主な確認キー**
+
+- functionEntry = openAssessmentTask
+- eventType = start
+- action
+- intendedBusinessDateKey
+- idempotencyKey
+- scheduledAt
+
+**補助確認**
+
+- Cloud Tasks queue
+- HTTP body scheduledAt
+- task name
+- request log
+
+**注意点**
+
+intendedBusinessDateKey は対象営業日キーであり、予定時刻そのものではない。
+
+また、openAssessmentTask は weeklyPlanner 以外の経路からも作成される可能性があるため、経路ごとの task id / payload / scheduledAt の突合ルールを確認対象とする。
+
+### 13.8 closeAssessmentTask
+
+**採用する判定起点時刻**
+
+HTTP Cloud Task の `scheduleTime`、または HTTP body の `scheduledAt` を採用する。
+
+**未実行疑いの定義**
+
+```text
+close assessment task の scheduleTime + 猶予時間 を過ぎても
+closeAssessmentTask の logOpsInfo(eventType: "start") が存在しない
+=
+closeAssessmentTask 未配送・未到達疑い
+```
+
+**主な確認キー**
+
+- functionEntry = closeAssessmentTask
+- eventType = start
+- intendedBusinessDateKey
+- idempotencyKey
+- scheduledAt
+
+**補助確認**
+
+- Cloud Tasks queue
+- HTTP body scheduledAt
+- task name
+- request log
+
+**注意点**
+
+intendedBusinessDateKey は対象営業日キーであり、予定時刻そのものではない。
+
+また、closeAssessmentTask は weeklyPlanner 以外の経路からも作成される可能性があるため、経路ごとの task id / payload / scheduledAt の突合ルールを確認対象とする。
+
+### 13.9 controlHookHttp
+
+**採用する判定起点時刻**
+
+tournament task の Cloud Tasks `scheduleTime` を採用する。
+
+実装上は、`enqueueDueAt` と対応する。
+
+**未実行疑いの定義**
+
+```text
+tournament task の scheduleTime + 猶予時間 を過ぎても
+controlHookHttp の logOpsInfo(eventType: "start") が存在しない
+=
+controlHookHttp 未配送・未到達疑い
+```
+
+**主な確認キー**
+
+新 payload の場合:
+
+- functionEntry = controlHookHttp
+- eventType = start
+- tournamentId
+- taskType
+- planVersion
+- planHash
+
+旧 payload の場合:
+
+- functionEntry = controlHookHttp
+- eventType = start
+- action
+- tournamentId
+- rev
+
+**補助確認**
+
+- Cloud Tasks queue
+- HTTP body scheduledAt
+- taskIndex.enqueueDueAt
+- taskIndex.targetAt
+- taskIndex.planHash
+- taskIndex.taskName
+- request log
+
+**注意点**
+
+新 payload と旧 payload で context のキーが異なるため、Logs Explorer ではまず functionEntry = controlHookHttp と eventType = start で横断し、その後 payload 種別に応じて taskType / planHash または action / rev を見る。
+
+### 13.10 processStaffPayroll
+
+**採用する判定起点時刻**
+
+現状、task payload や enqueue オプションに staff 単位 task の予定時刻は保存されていない。
+
+そのため、本対象は通常の「予定時刻 + 猶予時間」型ではなく、run 起点の SLA 型として扱う。
+
+**暫定の未実行疑いの定義**
+
+```text
+payroll run 開始時刻 + 猶予時間 を過ぎても
+対象 staff の processStaffPayroll logOpsInfo(eventType: "start") が存在しない
+=
+staff payroll task 未実行・未配送・未到達疑い
+```
+
+**主な確認キー**
+
+- functionEntry = processStaffPayroll
+- eventType = start
+- runId
+- staffId
+- paymentPeriodKey
+
+**補助確認**
+
+- payrollRuns.startedAt
+- staffResults.taskStartedAt
+- staffResults.taskFinishedAt
+- staffResults.status
+- Task Queue 状態
+
+**注意点**
+
+この定義は暫定である。
+
+より厳密にする場合は、staff task 投入時に enqueuedAt / expectedStartBy / deadlineAt などの監視用時刻を payload または Firestore に保存する必要がある。
+
+ただし、今回は追加実装せず、このまま運用する。
+
+### 13.11 finalizePayrollRun
+
+**採用する判定起点時刻**
+
+現状、finalize task の payload や enqueue オプションに予定時刻は保存されていない。
+
+また、finalize は全 staff 処理完了後に enqueue される依存関係型の処理である。
+
+そのため、本対象も通常の「予定時刻 + 猶予時間」型ではなく、run / staff 完了状態を起点にした SLA 型として扱う。
+
+**暫定の未実行疑いの定義**
+
+```text
+全 staff 処理完了時刻 + 猶予時間 を過ぎても
+finalizePayrollRun の logOpsInfo(eventType: "start") が存在しない
+=
+finalizePayrollRun 未実行・未配送・未到達疑い
+```
+
+**主な確認キー**
+
+- functionEntry = finalizePayrollRun
+- eventType = start
+- runId
+- paymentPeriodKey
+
+**補助確認**
+
+- payrollRuns.status
+- completedStaffCount
+- targetStaffCount
+- staffResults
+- Task Queue 状態
+
+**注意点**
+
+全 staff 処理完了時刻をどのフィールドから安定して取るかは、別途確認が必要である。
+
+より厳密にする場合は、finalize task 投入時に enqueuedAt / expectedStartBy / deadlineAt などの監視用時刻を payload または Firestore に保存する必要がある。
+
+ただし、今回は追加実装せず、このまま運用する。
+
+---
+
+## 14. 未実行判定の分類
+
+未実行判定は、対象ごとに以下の分類で扱う。
+
+| 分類 | 対象 | 判定方法 |
+|---|---|---|
+| Scheduler cron 型 | schedulerSupervisor | cron 予定時刻 + 猶予時間後に logOpsInfo(start) がない |
+| scheduled job plannedRunAt 型 | executeScheduledJobTask | plannedRunAt + 猶予時間後に logOpsInfo(start) がない |
+| scheduled job 配下処理型 | payrollNotificationScheduler, enqueueTournamentTasksByScheduler, generateRecurringTournamentsByScheduler | 親 executeScheduledJobTask.plannedRunAt + 猶予時間後に各 handler の logOpsInfo(start) がない |
+| Cloud Tasks scheduleTime 型 | openAssessmentTask, closeAssessmentTask, controlHookHttp, processPayrollNotifications | Cloud Tasks scheduleTime または body scheduledAt + 猶予時間後に logOpsInfo(start) がない |
+| SLA 型 | processStaffPayroll, finalizePayrollRun | run 状態・staff 完了状態を起点に定義した期待時刻 + 猶予時間後に logOpsInfo(start) がない |
+
+---
+
+## 15. 追加設計が必要な対象
+
+以下は、未実行判定に必要な予定時刻または突合キーが不十分であるため、後続の ChangeSpec 候補とする。
+
+ただし、今回は追加実装せず、現状の材料で運用する。
+
+| 対象 | 不足している情報 | 影響 | 後続の追加実装候補 |
+|---|---|---|---|
+| processStaffPayroll | staff task の計画実行時刻、投入時刻、期待開始時刻 | 「予定時刻 + 猶予時間」で機械判定しづらい | task 投入時に enqueuedAt / expectedStartBy / deadlineAt を payload または Firestore に保存 |
+| finalizePayrollRun | finalize task の計画実行時刻、投入時刻、期待開始時刻 | finalize 未実行の基準時刻が曖昧 | finalize task 投入時に enqueuedAt / expectedStartBy / deadlineAt を payload または Firestore に保存 |
+| openAssessmentTask / closeAssessmentTask | weeklyPlanner 以外の経路で task id / payload / scheduledAt の統一度が低い | 経路ごとに突合ルールが変わる | 全経路で共通の相関 ID / scheduledAt / taskName を揃える |
+| schedulerSupervisor | start には supervisorRunId が載っていない | start と後続 dispatch / success の突合が弱い | supervisorRunId を handler 先頭で生成できるか検討 |
+| executeScheduledJobTask replan 経路 | plannedRunAt と実際の delay dispatch の関係 | 通常経路と同じ判定ではズレる可能性 | replan 用の予定時刻定義を別途明記 |
+
+---
+
+## 16. 今後決めること
+
+本書の次の段階で、以下を検討する。
+
+- 各対象の猶予時間
+- Logs Explorer で確認する具体的なクエリ
+- Cloud Tasks / Scheduler / Firestore 補助確認の導線
+- 店舗別プロジェクトの情報を将来どのように確認・集約するか
+- 中央監視プロジェクトへ集約するか、店舗プロジェクト側で参照するか
+- processStaffPayroll / finalizePayrollRun の SLA 型監視を補強するか
+- Firestore状態監視を別文書で扱うか
+- 将来的に管理用アプリでどう表示するか
+- 将来的に通知化する条件
+
+---
+
+## 17. 現時点の結論
+
+現時点では、関数内で発生した失敗は `logOpsError` で概ね検知できる前提である。
+
+そのため、GCP側未実行検知では、以下を中心に扱う。
+
+- 関数がそもそも起動していない
+- task が配送されていない
+- HTTP Task が handler に到達していない
+- 本来出るべき到達ログが出ていない
+
+本書では、未実行・未配送・未到達疑いを将来の管理用アプリや運用確認で扱えるようにするため、以下を整理した。
+
+- 到達証跡として `logOpsInfo(eventType: "start")` を使う
+- 完了証跡として `logOpsSuccess` を使う
+- 失敗証跡として `logOpsError` を使う
+- 対象ごとの判定起点時刻を定義する
+- 対象ごとの突合キーと補助確認情報を定義する
+- 現状、判定材料が不足している対象を明記する
+
+通知対象 / 軽め通知 / 画面確認対象の分類は、本段階では行わない。
+
+管理用アプリの具体仕様も本書では決めない。
+
+初期方針として、エラーおよび未実行疑いは原則すべて確認対象とし、実データを見ながら後続で表示優先度や通知条件を検討する。
+
+processStaffPayroll / finalizePayrollRun については、task 単位の予定時刻が現状保存されていないため、精密な未実行判定には不足がある。
+
+ただし、今回は追加実装せず、暫定的に run 起点 / 全 staff 完了起点の SLA 型として運用する。

--- a/docs/エラーログ運用/GCP未実行検知/changeSpec/changeSpec_GCP側未実行検知_logOpsInfo追加.md
+++ b/docs/エラーログ運用/GCP未実行検知/changeSpec/changeSpec_GCP側未実行検知_logOpsInfo追加.md
@@ -1,0 +1,245 @@
+# changeSpec: GCP側未実行検知 — `logOpsInfo` 追加と start ログ
+
+## 1. 文書情報
+
+- **文書名**: changeSpec: GCP側未実行検知 — `logOpsInfo` 追加と start ログ
+- **作成日**: 2026-05-14
+- **対象フェーズ**: Firebase Cloud Functions（ログ出力のみ。GCP アラート設定は含まない）
+- **対象範囲**:
+  - 共通ヘルパ `logOpsInfo` の追加
+  - 本書 §6 に列挙する **11 ターゲット** の handler 入口における **`eventType: "start"`** の構造化ログ追加
+- **非対象範囲**:
+  - §12「今回やらないこと」に記載のものすべて
+  - 本書 §6 に含まれない関数（例: `weeklyPlanner`、`scheduledCleanup`、`scheduleGenerateNextYearBusinessHours`、HTTP Cloud Tasks のみで動く assessment 以外の経路など）
+
+---
+
+## 2. 背景
+
+Cloud Functions 内で発生した業務エラー・外部 API エラー・想定外エラーは、原則 **`logOpsError`** で検知できる前提とする。
+
+一方、次のような異常は **関数コードに到達しない**、または **到達した証跡がログ上で一意に追えない** ことがあり、`logOpsError` だけでは拾えない。
+
+- Scheduler が関数を呼んでいない
+- Task Queue / Cloud Tasks が handler に配送していない
+- HTTP Task が handler 入口に到達していない
+- task は作成済みだが対象 handler が呼ばれていない
+- 本来あるべき「到達」ログが無く、未実行・未配送・未到達と完了・失敗が区別しづらい
+
+既存の **`logOpsSuccess`** は **正常完了の証跡**であり、handler ごとに「完了まで進んだことを意味しないログ」（早期 return、noop、別経路）や **`logger.info` のみ**のケースもあり、**到達証跡として一律には使えない**。
+
+そのため、**handler に到達したことを示す構造化ログ**として、`logOpsInfo`（`eventType: "start"`）を追加する。
+
+---
+
+## 3. 目的
+
+- **handler に到達したこと**を構造化ログで残す。
+- **未実行・未配送・未到達**の検知に使える証跡を用意する（後続の Cloud Monitoring / Logs Explorer / 未実行検知設計で利用可能な検索キーを整える）。
+- **到達（info）・完了（success）・失敗（error）** のログ責務を分離する。
+
+---
+
+## 4. 非目的
+
+- **`logOpsError` の設計変更**（フィールド定義・`*Source` の変更など）はしない。
+- 既存 **`logOpsSuccess` を削除・置換**しない。
+- **業務ロジックの変更**はしない（分岐・計算結果・DB 更新内容を変えない）。※ログ追加および **`logOpsInfo` ヘルパ追加のみ**とする。
+- **retry / replay / 自動復旧**は実装しない。
+- **Firestore 状態監視**（doc の stuck 検知など）は今回の対象外。
+- **GCP アラート設定そのもの**（ポリシー JSON、通知チャネル）は今回の対象外。
+- **大きな payload・個人情報・不要なリクエスト全文**をログに載せない。
+
+---
+
+## 5. 変更方針
+
+### 5.1 ログの役割分担（確定）
+
+| ログ | 役割 |
+|------|------|
+| `logOpsInfo` | handler に**到達した**証跡。未実行・未配送・未到達の検知に使う |
+| `logOpsSuccess` | 処理が**正常完了した**証跡。既存の完了ログとして残す |
+| `logOpsError` | 処理中に**失敗した**証跡。既存の失敗ログとして残す |
+
+### 5.2 `logOpsInfo` 共通ヘルパ
+
+- **`functions/src/shared/logging/logOpsError.ts`**（既存ファイル）に **`logOpsInfo`** を追加する（実装時にファイル分割するかは任意だが、既存 `logOpsSuccess` と同一ファイル内での追加が望ましい）。
+- 出力は **`logger.info`** を使用し、**構造化ペイロード**を第 2 引数として渡す（`logOpsSuccess` と同様のパターン）。
+- 付与するフィールド（基本仕様・確定）:
+
+```text
+{
+  outcome: "info",
+  eventType: "start",
+  service,       // 既存の functionEntry -> service マッピング（serviceByFunctionEntry）に従う
+  functionEntry, // 対象 handler の entry 名（既存 logOps 系と同一命名）
+  operation,     // 原則 "start"
+  projectId,     // 既存 logOps 系と同様に付与
+  context        // 対象特定に必要な最小限の相関 ID のみ（任意キーは実装時に §6 と整合させる）
+}
+```
+
+- **本 ChangeSpec では `eventType` は `"start"` のみを使用する。** 将来的に `checkpoint` や `received`、`skip` など別種の info ログを `logOpsInfo` に載せる場合は、**別 ChangeSpec で用途・検索キー・運用判定を定義する**（必須ではないが、`logOpsInfo` が雑多な info ログの置き場になるのを防ぐための方針）。
+- **メッセージ文字列**（第 1 引数）は実装時に決めるが、`functionEntry` と `eventType` がログ検索で追える短文とすること（例: `` `${functionEntry} start` `` など）。既存 `logOpsSuccess` / `logOpsError` の文体と揃える。
+
+### 5.3 start ログの出力位置（原則）
+
+| 原則 | 内容 |
+|------|------|
+| タイミング | handler 入口で **request / payload から相関 ID を最小限取り出した直後** |
+| 禁止寄りの順序 | **Firestore read より前**、**外部 API より前**、**主要 validation より前**、**業務処理より前** |
+| 例外 | 入口直後では相関 ID が取れない場合は、**無理に遅らせず**取得可能な **最小 ID のみ**で start を出す（詳細は §10） |
+| `controlHookHttp` | **payload 形式の分岐判定の直後**に start を出す（理由: 新 payload と旧 payload で載せられる相関 ID が異なるため。**この時点で取得できないフィールドは context に含めない**） |
+
+### 5.4 既存ログとの関係
+
+- 既存 **`logOpsSuccess` / `logOpsError` はそのまま残す**。
+- start の **`logOpsInfo` は追加のみ**。同一 handler で **start →（処理）→ success または error** の順で残ることを期待する。
+
+---
+
+## 6. 対象関数と start `context`（最小項目）
+
+実装対象は **次の 11 件**。
+
+| # | 対象 | `operation` | `context` 最小項目（目標） |
+|---|------|---------------|---------------------------|
+| 1 | `schedulerSupervisor` | `start` | `planningDate`, `supervisorRunId` |
+| 2 | `executeScheduledJobTask` | `start` | `jobKey`, `idempotencyKey`, `supervisorRunId`, `plannedRunAt` |
+| 3 | `processStaffPayroll` | `start` | `runId`, `paymentPeriodKey`, `staffId` |
+| 4 | `finalizePayrollRun` | `start` | `runId`, `paymentPeriodKey` |
+| 5 | `openAssessmentTask` | `start` | `action`, `intendedBusinessDateKey`, `idempotencyKey` |
+| 6 | `closeAssessmentTask` | `start` | `intendedBusinessDateKey`, `idempotencyKey` |
+| 7 | `controlHookHttp` | `start` | `tournamentId`, `taskType`, `planVersion`, `planHash`（**新 payload で取得できる場合**） |
+| 8 | `processPayrollNotifications` | `start` | `todayStr` **または** `targetDate`、`recentPeriodKey` |
+| 9 | `payrollNotificationScheduler` | `start` | `targetDate`, `notificationHour`, `scheduleTimeUtc` |
+| 10 | `enqueueTournamentTasksByScheduler` | `start` | **スケジュールレンジ相当**（実装上は `rangeStartAt`, `rangeEndAt` など入力フィールド名に合わせる） |
+| 11 | `generateRecurringTournamentsByScheduler` | `start` | `evaluationDate`, `windowEndDate` |
+
+### 6.1 実装時に確認すること（相関 ID と「Firestore read より前」の両立）
+
+- **`schedulerSupervisor`**: 現状、`supervisorRunId` は **`runSchedulerSupervisorCore` 内部で生成**される場合、`handler` 先頭では未取得の可能性がある。**実装時に確認**。対応案の例: （a）start では **`planningDate` のみ**（JST 日付キーをハンドラ先頭で算出できる場合）にし、`supervisorRunId` は省略；（b）**ID 生成だけを業務処理に影響しない形で先頭へ移動できるか**を確認（※業務ロジック変更にならないこと）。
+- **`payrollNotificationScheduler`**: `notificationHour` / `scheduleTimeUtc` は **`getPayrollConfig` 等の読み取り後**でしか確定しない可能性がある。**Firestore read より前**の方針と矛盾する場合は、start の `context` は **`targetDate` のみ**など取得可能な最小セットに留め、時刻系は **`logOpsSuccess` 側で担保**する。実装時に確認。
+- **`processPayrollNotifications`**: `recentPeriodKey` は **store の payroll 設定読み取り後**でしか算出できない場合がある。その場合、start は **`todayStr` / `targetDate` のみ**とし、`recentPeriodKey` は省略する。実装時に確認。
+- **`controlHookHttp`**: **旧 payload** では `taskType` / `planVersion` / `planHash` が無い。**新／旧で context のキー構成が異なる**ため、start の `context` は **その時点で取得可能な最小項目のみ**（例: 旧は `action`, `tournamentId`, `rev` など）。**request ボディ全文は載せない**。
+- **`openAssessmentTask` / `closeAssessmentTask`**: `idempotencyKey` は payload 検証・組み立て後でないと確定しない場合、**確定直後（かつ Firestore read より前）**で start を出す。それでも無理なら **`intendedBusinessDateKey` と `action` のみ**で start する。実装時に確認。
+
+---
+
+## 7. 実装単位
+
+### Step 1: `logOpsInfo` 共通ヘルパ追加
+
+- **ファイル**: `functions/src/shared/logging/logOpsError.ts`
+- **内容**:
+  - 型 `LogOpsInfoArgs`（例: `message`, `functionEntry`, `operation`, `projectId?`, `context?`）を定義
+  - `logOpsInfo(args)` を実装し、`logger.info(message, payload)` で出力
+  - `payload` に **`outcome: "info"`**, **`eventType: "start"`**（今回は start のみ使用）、`service`（既存 `resolveServiceForFunctionEntry` と同等の解決）、`functionEntry`, `projectId`, `operation`, `context` を載せる
+- **`serviceByFunctionEntry.ts`**: §6 の対象はいずれも **既存の `functionEntry` 名**と揃える前提である。その場合は **マッピング変更不要**でよい。一方、`logOpsInfo` 実装で **`service` 解決が必須**となり、**既存マッピングで解決できない `functionEntry` が生じた場合**は、**本 ChangeSpec の実装範囲内で必要最小限の mapping 追加を行う**（ビルド・実行時エラー回避のため）。任意の新規命名で `functionEntry` を増やす場合は避け、増やす場合も別 ChangeSpec で名前と service を明示する。
+
+### Step 2: start ログ追加（11 ターゲット）
+
+- §6 の表に従い、各 handler で **`logOpsInfo`** を 1 回呼ぶ。
+- §5.3 の出力位置方針を守る。
+- **`scheduledJobTaskExecutors.ts`** の `executeScheduledJobTask` は、**payload パース成功直後**かつ **既存の `writeSchedulerExecutionLogByCloudTaskBestEffort({ eventType: "started" })` より前**に start を置くこと（Firestore write より前であること）。
+
+### Step 3: テスト追加・更新
+
+- 既存テスト構成を確認し、必要範囲で以下を検証する。
+  - `logOpsInfo` が **`logger.info` を呼ぶ**
+  - payload に **`outcome: "info"`**, **`eventType: "start"`** が含まれる
+  - `functionEntry` / `operation` / `context` が含まれる
+  - 対象 handler で start が呼ばれる（モックまたはスパイ）
+  - 既存 **`logOpsSuccess` / `logOpsError`** の挙動を壊していない
+
+---
+
+## 8. ログ検索・未実行検知での使い方（考え方）
+
+- **未実行検知の第一候補**: `logOpsInfo` 相当の構造化ログで **`eventType == "start"`**（実装時にフィールド名が Cloud Logging 上でどう見えるかは環境確認）。
+- **`functionEntry`** で対象関数を絞る。
+- 必要に応じて **`context.runId`**, **`context.staffId`**, **`context.jobKey`**, **`context.tournamentId`** などで絞る。
+- **start が無い** → **未実行・未配送・未到達疑い**（GCP 側ログとの併用は別設計）。
+- **start あり + `logOpsError` あり** → handler **到達後に失敗**。
+- **start あり + `logOpsSuccess` あり** → handler **到達後、正常完了**（実装上、noop など完了ログの意味が薄い handler は別紙の運用判定で吸収）。
+
+※ Logs Explorer の正式クエリは **今回の対象外**（§12）。実装マージ後にサンプルログで確定する。
+
+---
+
+## 9. 期待する運用判定（参考）
+
+| 状態 | 判定 |
+|------|------|
+| `logOpsInfo`（`eventType: "start"`）なし | 未実行・未配送・未到達**疑い** |
+| start あり + `logOpsError` あり | handler **到達後に失敗** |
+| start あり + `logOpsSuccess` あり | handler **到達後**、**正常完了**（※完了の定義は既存 success と同じ） |
+| start あり + `logOpsSuccess` なし + `logOpsError` なし | **処理中**、ログ欠落、早期 return、または **追加確認対象** |
+
+---
+
+## 10. リスク・注意点
+
+- start を出す位置が**遅すぎる**と、Cloud Tasks / Scheduler の観点では「到達証跡」として弱い。
+- start を出す位置が**早すぎる**と、相関 ID が不足する（§6.1）。
+- `context` を増やしすぎると **ログサイズ・個人情報リスク**が増える。**最小限**に留める。
+- **`controlHookHttp`** は payload 形式ごとに相関 ID が異なる（§6.1）。
+- **`processPayrollNotifications`** は現状 **完了証跡が弱い**ため、**start 追加の効果が大きい**一方、**完了は引き続き `logOpsSuccess` の有無や既存 info に依存**する点に注意。
+- **start は「正常完了」を意味しない**。完了は **`logOpsSuccess`**、失敗は **`logOpsError`** で判断する。
+
+---
+
+## 11. 検証観点
+
+- **`npm run build`**（`functions`）が通ること。
+- **対象テスト**（追加・更新したもの）が通ること。
+- **`logOpsInfo` 単体テスト**（payload 形状）。
+- 既存 **`logOpsSuccess` / `logOpsError` テスト**への影響がないこと。
+- 各対象 handler で **start が意図したタイミング**で呼ばれること（§5.3）。
+- payload に **不要な個人情報・大きな配列・リクエスト全文**が入っていないこと。
+- **`service`** が既存マッピングから解決できること（解決できない `functionEntry` が無いこと）。
+- **`functionEntry`** が既存命名と一致すること。
+
+---
+
+## 12. 今回やらないこと
+
+- Cloud Monitoring **アラート作成**
+- Logs Explorer **クエリ確定**
+- Firestore **状態監視**
+- **自動復旧**
+- **replay Callable**
+- **retry 設計変更**
+- 既存 **成功ログの意味変更**
+- 既存 **エラーログの大規模改修**
+
+---
+
+## 13. 完了条件
+
+- 本 ChangeSpec がリポジトリに作成されている。
+- `logOpsInfo` の **payload 仕様**と **出力位置方針**が明記されている。
+- 対象 **11 件**と **各 `context` 最小項目**が明記されている。
+- **start / success / error** の役割分担が明記されている。
+- **実装 Step** と **検証観点**が明記されている。
+
+---
+
+## 付録 A: 実装時に確認すべき主なファイル候補
+
+| 種別 | パス |
+|------|------|
+| 共通ログ | `functions/src/shared/logging/logOpsError.ts` |
+| service 解決 | `functions/src/shared/logging/serviceByFunctionEntry.ts` |
+| Supervisor | `functions/src/domains/scheduler/supervisor/schedulerSupervisor.ts` |
+| Scheduled job 実行口 | `functions/src/domains/scheduler/tasks/scheduledJobTaskExecutors.ts` |
+| Payroll tasks | `functions/src/domains/attendance/tasks/processStaffPayroll.ts` |
+| | `functions/src/domains/attendance/tasks/finalizePayrollRun.ts` |
+| | `functions/src/domains/attendance/tasks/processPayrollNotifications.ts` |
+| Payroll scheduler | `functions/src/domains/attendance/scheduler/payrollNotificationScheduler.ts` |
+| HTTP assessment | `functions/src/domains/storeMeta/callables/openAssessmentTask.ts` |
+| | `functions/src/domains/storeMeta/callables/closeAssessmentTask.ts` |
+| Tournament control | `functions/src/shared/http/controlHook.ts` |
+| Tournament scheduler タスク本体 | `functions/src/domains/tournament_createTournament/scheduler/EnqueueTournamentTasksByScheduler.ts` |
+| | `functions/src/domains/tournament_createTournament/scheduler/GenerateRecurringTournamentsByScheduler.ts` |

--- a/functions/__tests__/shared/logging/logOpsInfo.spec.ts
+++ b/functions/__tests__/shared/logging/logOpsInfo.spec.ts
@@ -1,0 +1,105 @@
+import { logger } from 'firebase-functions';
+import {
+  logOpsError,
+  logOpsInfo,
+  logOpsSuccess,
+} from '../../../src/shared/logging/logOpsError';
+
+jest.mock('firebase-functions', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('logOpsInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GCLOUD_PROJECT = 'test-logops-project';
+  });
+
+  afterEach(() => {
+    delete process.env.GCLOUD_PROJECT;
+  });
+
+  it('logger.info に outcome info / eventType start / service / functionEntry / operation / projectId / context を載せる', () => {
+    logOpsInfo({
+      message: 'enqueueTournamentTasksByScheduler start',
+      functionEntry: 'enqueueTournamentTasksByScheduler',
+      context: { rangeStartAt: '2026-05-01', rangeEndAt: '2026-05-08' },
+    });
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    const [message, payload] = (logger.info as jest.Mock).mock.calls[0];
+    expect(message).toBe('enqueueTournamentTasksByScheduler start');
+    expect(payload).toMatchObject({
+      outcome: 'info',
+      eventType: 'start',
+      service: 'tournament_schedule',
+      functionEntry: 'enqueueTournamentTasksByScheduler',
+      operation: 'start',
+      projectId: 'test-logops-project',
+      context: { rangeStartAt: '2026-05-01', rangeEndAt: '2026-05-08' },
+    });
+  });
+
+  it('operation を省略すると start を付与する', () => {
+    logOpsInfo({
+      message: 'x',
+      functionEntry: 'enqueueTournamentTasksByScheduler',
+    });
+    expect((logger.info as jest.Mock).mock.calls[0][1]).toMatchObject({
+      operation: 'start',
+    });
+  });
+
+  it('projectId を明示するとそれを使う', () => {
+    logOpsInfo({
+      message: 'x',
+      functionEntry: 'enqueueTournamentTasksByScheduler',
+      projectId: 'explicit-project',
+    });
+    expect((logger.info as jest.Mock).mock.calls[0][1]).toMatchObject({
+      projectId: 'explicit-project',
+    });
+  });
+});
+
+describe('logOpsInfo と既存 logOpsSuccess / logOpsError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GCLOUD_PROJECT = 'coexist-project';
+  });
+
+  afterEach(() => {
+    delete process.env.GCLOUD_PROJECT;
+  });
+
+  it('logOpsSuccess は outcome success のみで eventType を付けない', () => {
+    logOpsSuccess({
+      message: 'done',
+      functionEntry: 'enqueueTournamentTasksByScheduler',
+      operation: 'runEnqueueSchedulerTask',
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      'done',
+      expect.objectContaining({
+        outcome: 'success',
+        functionEntry: 'enqueueTournamentTasksByScheduler',
+        operation: 'runEnqueueSchedulerTask',
+      }),
+    );
+    const payload = (logger.info as jest.Mock).mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('eventType');
+  });
+
+  it('logOpsError は logger.error を使う（logOpsInfo と独立）', () => {
+    logOpsError({
+      message: 'fail',
+      functionEntry: 'enqueueTournamentTasksByScheduler',
+      cause: new Error('x'),
+    });
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect((logger.error as jest.Mock).mock.calls[0][0]).toBe('fail');
+  });
+});

--- a/functions/src/domains/attendance/scheduler/payrollNotificationScheduler.ts
+++ b/functions/src/domains/attendance/scheduler/payrollNotificationScheduler.ts
@@ -1,4 +1,4 @@
-import { logOpsError, logOpsSuccess } from "../../../shared/logging/logOpsError";
+import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import { getPayrollConfig } from "../../../shared/config/payrollConfigLoader";
 import { getRegionalTaskQueue } from "../../../shared/tasks/getRegionalTaskQueue";
 
@@ -46,6 +46,13 @@ export async function runPayrollNotificationSchedulerTask(
   let scheduleTimeUtc: string | undefined;
 
   try {
+    logOpsInfo({
+      message: "payrollNotificationScheduler start",
+      functionEntry: "payrollNotificationScheduler",
+      operation: "start",
+      context: {targetDate: input.targetDate},
+    });
+
     const payrollConfig = await getPayrollConfig();
     notificationHour = payrollConfig.schedulerNotificationHour;
 

--- a/functions/src/domains/attendance/tasks/finalizePayrollRun.ts
+++ b/functions/src/domains/attendance/tasks/finalizePayrollRun.ts
@@ -8,7 +8,7 @@
 import { onTaskDispatched } from 'firebase-functions/v2/tasks';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions';
-import { logOpsError, logOpsSuccess } from '../../../shared/logging/logOpsError';
+import { logOpsError, logOpsInfo, logOpsSuccess } from '../../../shared/logging/logOpsError';
 
 import { aggregateStaffResults } from '../helpers/payrollRunHelpers';
 import { generateAnomalyFlags } from '../helpers/generateAnomalyFlags';
@@ -30,6 +30,13 @@ export const finalizePayrollRun = onTaskDispatched(
   async (req) => {
     const { runId, paymentPeriodKey } = req.data as TaskPayload;
     const db = getFirestore();
+
+    logOpsInfo({
+      message: 'finalizePayrollRun start',
+      functionEntry: 'finalizePayrollRun',
+      operation: 'start',
+      context: {runId, paymentPeriodKey},
+    });
 
     const runRef = db
       .collection('monthlyPayroll').doc(paymentPeriodKey)

--- a/functions/src/domains/attendance/tasks/processPayrollNotifications.ts
+++ b/functions/src/domains/attendance/tasks/processPayrollNotifications.ts
@@ -10,6 +10,7 @@
 import { onTaskDispatched } from 'firebase-functions/v2/tasks';
 import { getFirestore } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions';
+import { logOpsInfo } from '../../../shared/logging/logOpsError';
 
 import { getPayrollConfig } from '../../../shared/config/payrollConfigLoader';
 import { getStoreConfig } from '../../../shared/config/configLoader';
@@ -190,19 +191,6 @@ export const processPayrollNotifications = onTaskDispatched(
     retryConfig: { maxAttempts: 3, minBackoffSeconds: 10, maxBackoffSeconds: 60 },
   },
   async (request) => {
-    const db = getFirestore();
-
-    const [payrollConfig, storeConfig] = await Promise.all([
-      getPayrollConfig(db),
-      getStoreConfig(db),
-    ]);
-
-    const startDay = storeConfig.payroll?.startDay ?? DEFAULT_PAYROLL_START_DAY;
-    const endDay = storeConfig.payroll?.endDay ?? DEFAULT_PAYROLL_END_DAY;
-    const paymentDayOfMonth = payrollConfig.paymentDayOfMonth;
-    const paymentMonthOffset = payrollConfig.paymentMonthOffset;
-    const reminderStartDays = payrollConfig.reminderStartDaysAfterPeriodEnd;
-
     const payload = (request.data ?? {}) as ProcessPayrollNotificationsTaskPayload;
     const todayStr = payload.targetDate && /^\d{4}-\d{2}-\d{2}$/.test(payload.targetDate) ?
       payload.targetDate :
@@ -218,6 +206,26 @@ export const processPayrollNotifications = onTaskDispatched(
           String(jstDate.getDate()).padStart(2, '0'),
         ].join('-');
       })();
+
+    logOpsInfo({
+      message: 'processPayrollNotifications start',
+      functionEntry: 'processPayrollNotifications',
+      operation: 'start',
+      context: {todayStr},
+    });
+
+    const db = getFirestore();
+
+    const [payrollConfig, storeConfig] = await Promise.all([
+      getPayrollConfig(db),
+      getStoreConfig(db),
+    ]);
+
+    const startDay = storeConfig.payroll?.startDay ?? DEFAULT_PAYROLL_START_DAY;
+    const endDay = storeConfig.payroll?.endDay ?? DEFAULT_PAYROLL_END_DAY;
+    const paymentDayOfMonth = payrollConfig.paymentDayOfMonth;
+    const paymentMonthOffset = payrollConfig.paymentMonthOffset;
+    const reminderStartDays = payrollConfig.reminderStartDaysAfterPeriodEnd;
 
     // 対象期間: today が属する期間 → その直前の期間
     const activePeriod = getPayrollPeriodRange(todayStr, startDay, endDay);

--- a/functions/src/domains/attendance/tasks/processStaffPayroll.ts
+++ b/functions/src/domains/attendance/tasks/processStaffPayroll.ts
@@ -8,7 +8,7 @@
 import { onTaskDispatched } from 'firebase-functions/v2/tasks';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { logger } from 'firebase-functions';
-import { logOpsError, logOpsSuccess } from '../../../shared/logging/logOpsError';
+import { logOpsError, logOpsInfo, logOpsSuccess } from '../../../shared/logging/logOpsError';
 import { getRegionalTaskQueue } from '../../../shared/tasks/getRegionalTaskQueue';
 
 import { calculateStaffPayroll, calculateCarryOverPayroll } from '../helpers/payrollCalcEngine';
@@ -30,6 +30,13 @@ export const processStaffPayroll = onTaskDispatched(
   async (req) => {
     const { runId, paymentPeriodKey, staffId } = req.data as TaskPayload;
     const db = getFirestore();
+
+    logOpsInfo({
+      message: 'processStaffPayroll start',
+      functionEntry: 'processStaffPayroll',
+      operation: 'start',
+      context: {runId, paymentPeriodKey, staffId},
+    });
 
     const runRef = db
       .collection('monthlyPayroll').doc(paymentPeriodKey)

--- a/functions/src/domains/scheduler/supervisor/schedulerSupervisor.ts
+++ b/functions/src/domains/scheduler/supervisor/schedulerSupervisor.ts
@@ -1,8 +1,18 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
-import { logOpsError, logOpsSuccess } from '../../../shared/logging/logOpsError';
+import { logOpsError, logOpsInfo, logOpsSuccess } from '../../../shared/logging/logOpsError';
 import { runSchedulerSupervisorCore } from './schedulerSupervisorCore';
 
 const SCHEDULER_SUPERVISOR_CRON = '0 3 * * *';
+
+/** `schedulerSupervisorCore.toJstDateKey` と同一の JST 日付キー（Firestore read なし） */
+function supervisorPlanningDateKey(now: Date): string {
+  const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  const jst = new Date(now.getTime() + JST_OFFSET_MS);
+  const year = jst.getUTCFullYear();
+  const month = String(jst.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(jst.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
 
 export const schedulerSupervisor = onSchedule(
   {
@@ -13,6 +23,13 @@ export const schedulerSupervisor = onSchedule(
   },
   async () => {
     try {
+      const planningDate = supervisorPlanningDateKey(new Date());
+      logOpsInfo({
+        message: 'schedulerSupervisor start',
+        functionEntry: 'schedulerSupervisor',
+        operation: 'start',
+        context: {planningDate},
+      });
       const result = await runSchedulerSupervisorCore();
       logOpsSuccess({
         message: 'schedulerSupervisor 成功',

--- a/functions/src/domains/scheduler/tasks/scheduledJobTaskExecutors.ts
+++ b/functions/src/domains/scheduler/tasks/scheduledJobTaskExecutors.ts
@@ -1,5 +1,5 @@
 import type { SchedulerJobKey } from "../../../shared/config/schedulerConfigTypes";
-import { logOpsError, logOpsSuccess } from "../../../shared/logging/logOpsError";
+import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import {
   assertScheduledJobTaskPayloadMatchesExpectedJobKey,
   assertValidScheduledJobTaskPayload,
@@ -254,6 +254,18 @@ export async function executeScheduledJobTask(
   rawPayload: unknown
 ): Promise<void> {
   const payload = parsePayload(expectedJobKey, rawPayload);
+
+  logOpsInfo({
+    message: "executeScheduledJobTask start",
+    functionEntry: "executeScheduledJobTask",
+    operation: "start",
+    context: {
+      jobKey: payload.jobKey,
+      idempotencyKey: payload.idempotencyKey,
+      supervisorRunId: payload.supervisorRunId,
+      plannedRunAt: payload.plannedRunAt,
+    },
+  });
 
   await writeSchedulerExecutionLogByCloudTaskBestEffort({
     eventType: "started",

--- a/functions/src/domains/storeMeta/callables/closeAssessmentTask.ts
+++ b/functions/src/domains/storeMeta/callables/closeAssessmentTask.ts
@@ -17,7 +17,7 @@
 import { onRequest } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
 import { Timestamp } from 'firebase-admin/firestore';
-import { logOpsError, logOpsSuccess } from "../../../shared/logging/logOpsError";
+import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import { FunctionCustomError } from '../../../shared/logging/functionCustomError';
 
 type ManualOverrideLike = {
@@ -70,6 +70,16 @@ export const closeAssessmentTask = onRequest(
 
       // idempotencyKeyの生成
       const idempotencyKey = `close_assessment_${payload.intendedBusinessDateKey}_${payload.scheduledAt}`;
+
+      logOpsInfo({
+        message: 'closeAssessmentTask start',
+        functionEntry: 'closeAssessmentTask',
+        operation: 'start',
+        context: {
+          intendedBusinessDateKey: payload.intendedBusinessDateKey,
+          idempotencyKey,
+        },
+      });
 
       // トランザクション内で認定処理を実行
       await db.runTransaction(async (transaction) => {

--- a/functions/src/domains/storeMeta/callables/openAssessmentTask.ts
+++ b/functions/src/domains/storeMeta/callables/openAssessmentTask.ts
@@ -17,7 +17,7 @@
 import { onRequest } from 'firebase-functions/v2/https';
 import { getFirestore } from 'firebase-admin/firestore';
 import { Timestamp } from 'firebase-admin/firestore';
-import { logOpsError, logOpsSuccess } from "../../../shared/logging/logOpsError";
+import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import { FunctionCustomError } from '../../../shared/logging/functionCustomError';
 
 type OpenAssessmentAction = 'open_assessment' | 'open_assessment_recheck';
@@ -87,6 +87,17 @@ export const openAssessmentTask = onRequest(
 
       // idempotencyKeyの生成
       const idempotencyKey = `${action}_${payload.intendedBusinessDateKey}_${payload.scheduledAt}`;
+
+      logOpsInfo({
+        message: 'openAssessmentTask start',
+        functionEntry: 'openAssessmentTask',
+        operation: 'start',
+        context: {
+          action,
+          intendedBusinessDateKey: payload.intendedBusinessDateKey,
+          idempotencyKey,
+        },
+      });
 
       // トランザクション内で認定処理を実行
       await db.runTransaction(async (transaction) => {

--- a/functions/src/domains/tournament_createTournament/scheduler/EnqueueTournamentTasksByScheduler.ts
+++ b/functions/src/domains/tournament_createTournament/scheduler/EnqueueTournamentTasksByScheduler.ts
@@ -1,5 +1,5 @@
 import { logger } from "firebase-functions";
-import { logOpsError, logOpsSuccess } from "../../../shared/logging/logOpsError";
+import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import {
   runEnqueueTournamentTasks,
   type RunEnqueueResult,
@@ -13,6 +13,16 @@ export interface EnqueueTournamentTasksBySchedulerInput {
 export async function runEnqueueTournamentTasksBySchedulerTask(
   input: EnqueueTournamentTasksBySchedulerInput
 ): Promise<RunEnqueueResult> {
+  logOpsInfo({
+    message: "enqueueTournamentTasksByScheduler start",
+    functionEntry: "enqueueTournamentTasksByScheduler",
+    operation: "start",
+    context: {
+      rangeStartAt: input.rangeStartAt,
+      rangeEndAt: input.rangeEndAt,
+    },
+  });
+
   try {
     const result = await runEnqueueTournamentTasks({
       rangeStartAt: input.rangeStartAt,

--- a/functions/src/domains/tournament_createTournament/scheduler/GenerateRecurringTournamentsByScheduler.ts
+++ b/functions/src/domains/tournament_createTournament/scheduler/GenerateRecurringTournamentsByScheduler.ts
@@ -1,4 +1,4 @@
-import { logOpsError, logOpsSuccess } from "../../../shared/logging/logOpsError";
+import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import {
   runGenerateRecurringTournaments,
   type GenerateRecurringTournamentsResult,
@@ -12,6 +12,16 @@ export interface GenerateRecurringTournamentsBySchedulerInput {
 export async function runGenerateRecurringTournamentsBySchedulerTask(
   input: GenerateRecurringTournamentsBySchedulerInput
 ): Promise<GenerateRecurringTournamentsResult> {
+  logOpsInfo({
+    message: "generateRecurringTournamentsByScheduler start",
+    functionEntry: "generateRecurringTournamentsByScheduler",
+    operation: "start",
+    context: {
+      evaluationDate: input.evaluationDate,
+      windowEndDate: input.windowEndDate,
+    },
+  });
+
   try {
     const result = await runGenerateRecurringTournaments({
       evaluationDate: input.evaluationDate,

--- a/functions/src/shared/http/controlHook.ts
+++ b/functions/src/shared/http/controlHook.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { logger } from 'firebase-functions';
-import { logOpsError, logOpsSuccess } from '../logging/logOpsError';
+import { logOpsError, logOpsInfo, logOpsSuccess } from '../logging/logOpsError';
 import { getFirestore, Timestamp } from 'firebase-admin/firestore';
 
 /**
@@ -133,6 +133,18 @@ async function handleNewPayload(
   res: Response,
   body: NewPayload
 ): Promise<void> {
+  logOpsInfo({
+    message: 'controlHookHttp start',
+    functionEntry: 'controlHookHttp',
+    operation: 'start',
+    context: {
+      tournamentId: body.tournamentId,
+      taskType: body.taskType,
+      planVersion: body.planVersion,
+      planHash: body.planHash,
+    },
+  });
+
   const { tournamentId, taskType, planVersion, planHash } = body;
   const db = getFirestore();
   const taskIndexRef = db
@@ -371,6 +383,17 @@ async function handleOldPayload(
   res: Response,
   body: { action: string; tournamentId: string; rev: number }
 ): Promise<void> {
+  logOpsInfo({
+    message: 'controlHookHttp start',
+    functionEntry: 'controlHookHttp',
+    operation: 'start',
+    context: {
+      action: body.action,
+      tournamentId: body.tournamentId,
+      rev: body.rev,
+    },
+  });
+
   const { action, tournamentId, rev } = body;
 
   if (!action || !tournamentId || rev === undefined) {

--- a/functions/src/shared/logging/logOpsError.ts
+++ b/functions/src/shared/logging/logOpsError.ts
@@ -185,6 +185,34 @@ export function logOpsSuccess(args: LogOpsSuccessArgs): void {
   logger.info(args.message, payload);
 }
 
+export type LogOpsInfoArgs = {
+  message: string;
+  functionEntry: string;
+  operation?: string;
+  projectId?: string;
+  context?: Record<string, unknown>;
+};
+
+/**
+ * handler 到達などの情報ログ（未実行検知用）。`outcome: info` / `eventType: start`。
+ */
+export function logOpsInfo(args: LogOpsInfoArgs): void {
+  const projectId = args.projectId ?? resolveProjectId();
+  const service = resolveService(args);
+  const payload: Record<string, unknown> = {
+    outcome: "info" as const,
+    eventType: "start" as const,
+    service,
+    functionEntry: args.functionEntry,
+    projectId,
+    operation: args.operation ?? "start",
+  };
+  if (args.context !== undefined && Object.keys(args.context).length > 0) {
+    payload.context = args.context;
+  }
+  logger.info(args.message, payload);
+}
+
 /** postback 等、全文を載せず先頭だけ残す */
 export function truncateForLog(value: string, maxLen = 64): string {
   if (value.length <= maxLen) return value;


### PR DESCRIPTION
- logOpsInfo を追加し、11 対象 handler 入口で eventType: start の構造化ログを出力
- GCP 未実行検知の要件定義・ChangeSpec を docs に追加
- Scheduler/Task 系追加時の開始ログ・予定時刻ルールを Cursor rule に追加
- logOpsInfo の単体テストを追加（既存 logOpsSuccess/logOpsError との共存を確認）