### PR TITLE
fix: CENTRAL_PROJECT_ID 未設定時に amuse-central-monitoring へフォールバック

### DIFF
--- a/functions/src/shared/centralFirestore/writeToCentralFirestore.ts
+++ b/functions/src/shared/centralFirestore/writeToCentralFirestore.ts
@@ -4,11 +4,11 @@ import { logger } from 'firebase-functions';
 
 const CENTRAL_APP_NAME = 'centralMonitoring';
 
+const CENTRAL_PROJECT_ID_FALLBACK = 'amuse-central-monitoring';
+
 function getCentralFirestore(): FirebaseFirestore.Firestore | null {
-  const centralProjectId = process.env.CENTRAL_PROJECT_ID;
-  if (!centralProjectId) {
-    return null;
-  }
+  const centralProjectId =
+    process.env.CENTRAL_PROJECT_ID ?? CENTRAL_PROJECT_ID_FALLBACK;
 
   const existingApp = getApps().find((app) => app.name === CENTRAL_APP_NAME);
   if (existingApp) {


### PR DESCRIPTION
env ファイルが gitignore される環境でも中央 Firestore への書き込みが
スキップされないよう、fallback 値をハードコードで追加。