### PR TITLE
feat: 中央監視向けスケジューラログ拡張と dispatch 相関を追加

### DIFF
--- a/functions/__tests__/scheduler/payrollNotificationScheduler.spec.ts
+++ b/functions/__tests__/scheduler/payrollNotificationScheduler.spec.ts
@@ -1,0 +1,102 @@
+import { runPayrollNotificationSchedulerTask } from '../../src/domains/attendance/scheduler/payrollNotificationScheduler';
+import { getPayrollConfig } from '../../src/shared/config/payrollConfigLoader';
+import { getRegionalTaskQueue } from '../../src/shared/tasks/getRegionalTaskQueue';
+import { writeSchedulerTaskDispatchLogFromParentBestEffort } from '../../src/domains/scheduler/supervisor/schedulerTaskDispatchLogs';
+
+jest.mock('../../src/shared/config/payrollConfigLoader', () => ({
+  getPayrollConfig: jest.fn(),
+}));
+
+jest.mock('../../src/shared/tasks/getRegionalTaskQueue', () => ({
+  getRegionalTaskQueue: jest.fn(),
+}));
+
+jest.mock('../../src/domains/scheduler/supervisor/schedulerTaskDispatchLogs', () => ({
+  writeSchedulerTaskDispatchLogFromParentBestEffort: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/shared/logging/logOpsError', () => ({
+  logOpsInfo: jest.fn(),
+  logOpsSuccess: jest.fn(),
+  logOpsError: jest.fn(),
+}));
+
+describe('runPayrollNotificationSchedulerTask', () => {
+  const mockGetPayrollConfig = getPayrollConfig as jest.MockedFunction<
+    typeof getPayrollConfig
+  >;
+  const mockGetRegionalTaskQueue = getRegionalTaskQueue as jest.MockedFunction<
+    typeof getRegionalTaskQueue
+  >;
+  const mockWriteSchedulerTaskDispatchLog =
+    writeSchedulerTaskDispatchLogFromParentBestEffort as jest.MockedFunction<
+      typeof writeSchedulerTaskDispatchLogFromParentBestEffort
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('親 scheduler metadata 付きで child task を enqueue し dispatch log を残す', async () => {
+    mockGetPayrollConfig.mockResolvedValue({
+      schedulerNotificationHour: 6,
+    } as Awaited<ReturnType<typeof getPayrollConfig>>);
+
+    const enqueue = jest.fn().mockResolvedValue(undefined);
+    mockGetRegionalTaskQueue.mockReturnValue({
+      enqueue,
+    } as unknown as ReturnType<typeof getRegionalTaskQueue>);
+
+    const schedulerParent = {
+      storeId: 'test-project',
+      schedulerParentJobKey: 'payrollNotificationScheduler' as const,
+      schedulerParentPlanningDate: '2026-04-04',
+      schedulerParentPlannedRunAt: '2026-04-03T20:00:00.000Z',
+      schedulerParentIdempotencyKey: 'payrollNotificationScheduler:2026-04-03T20:00:00.000Z',
+      schedulerParentSupervisorRunId: 'supervisor_20260403T180000Z_abcdef12',
+    };
+
+    const result = await runPayrollNotificationSchedulerTask({
+      targetDate: '2026-04-04',
+      schedulerParent,
+    });
+
+    expect(result).toEqual({
+      notificationHour: 6,
+      scheduleTimeUtc: '2026-04-03T21:00:00.000Z',
+    });
+    expect(enqueue).toHaveBeenCalledWith(
+      {
+        targetDate: '2026-04-04',
+        schedulerParentJobKey: 'payrollNotificationScheduler',
+        schedulerParentPlanningDate: '2026-04-04',
+        schedulerParentPlannedRunAt: '2026-04-03T20:00:00.000Z',
+        schedulerParentIdempotencyKey:
+          'payrollNotificationScheduler:2026-04-03T20:00:00.000Z',
+        schedulerParentSupervisorRunId: 'supervisor_20260403T180000Z_abcdef12',
+        schedulerChildUnitKey: 'processPayrollNotifications:2026-04-04',
+        schedulerChildFunctionEntry: 'processPayrollNotifications',
+      },
+      expect.objectContaining({
+        id: 'payroll-notification-2026-04-04-6',
+        dispatchDeadlineSeconds: 300,
+      })
+    );
+    expect(mockWriteSchedulerTaskDispatchLog).toHaveBeenCalledWith(
+      schedulerParent,
+      {
+        childFunctionEntry: 'processPayrollNotifications',
+        childUnitKey: 'processPayrollNotifications:2026-04-04',
+        childScheduledAt: '2026-04-03T21:00:00.000Z',
+        childTargetSummary: {
+          targetDate: '2026-04-04',
+          notificationHour: 6,
+        },
+        eventType: 'enqueued',
+        context: {
+          taskId: 'payroll-notification-2026-04-04-6',
+        },
+      }
+    );
+  });
+});

--- a/functions/__tests__/scheduler/scheduledJobTaskExecutors.spec.ts
+++ b/functions/__tests__/scheduler/scheduledJobTaskExecutors.spec.ts
@@ -117,10 +117,32 @@ describe("scheduledJobTaskExecutors", () => {
 
     expect(mockRunWeeklyPlannerTask).toHaveBeenCalledWith({
       targetWeekStartDate: "2026-04-06",
+      schedulerParent: {
+        storeId: "test-project",
+        schedulerParentJobKey: "weeklyPlanner",
+        schedulerParentPlanningDate: "2026-04-04",
+        schedulerParentPlannedRunAt: "2026-04-03T20:00:00.000Z",
+        schedulerParentIdempotencyKey: "weeklyPlanner:2026-04-03T20:00:00.000Z",
+        schedulerParentSupervisorRunId: "supervisor_20260403T180000Z_abcdef12",
+      },
     });
     expect(mockWriteExecutionLog).toHaveBeenCalledTimes(2);
-    expect(mockWriteExecutionLog.mock.calls[0][0].eventType).toBe("started");
-    expect(mockWriteExecutionLog.mock.calls[1][0].eventType).toBe("completed");
+    expect(mockWriteExecutionLog.mock.calls[0][0]).toMatchObject({
+      phase: "execution",
+      eventType: "started",
+      rawEventType: "started",
+      targetScope: {
+        targetWeekStartDate: "2026-04-06",
+      },
+    });
+    expect(mockWriteExecutionLog.mock.calls[1][0]).toMatchObject({
+      phase: "execution",
+      eventType: "completed",
+      rawEventType: "completed",
+      targetScope: {
+        targetWeekStartDate: "2026-04-06",
+      },
+    });
   });
 
   it("expected jobKey と payload.jobKey が不一致ならエラー", async () => {
@@ -175,7 +197,15 @@ describe("scheduledJobTaskExecutors", () => {
       evaluationDate: "2026-04-04",
       windowEndDate: "2026-07-04",
     });
-    expect(mockWriteExecutionLog.mock.calls[1][0].eventType).toBe("completed");
+    expect(mockWriteExecutionLog.mock.calls[1][0]).toMatchObject({
+      phase: "execution",
+      eventType: "completed",
+      rawEventType: "completed",
+      targetScope: {
+        evaluationDate: "2026-04-04",
+        windowEndDate: "2026-07-04",
+      },
+    });
   });
 
   it("scheduledCleanup payload を正しく実行する", async () => {
@@ -191,7 +221,14 @@ describe("scheduledJobTaskExecutors", () => {
     expect(mockRunScheduledCleanup).toHaveBeenCalledWith({
       cutoffDate: "2026-03-28",
     });
-    expect(mockWriteExecutionLog.mock.calls[1][0].eventType).toBe("completed");
+    expect(mockWriteExecutionLog.mock.calls[1][0]).toMatchObject({
+      phase: "execution",
+      eventType: "completed",
+      rawEventType: "completed",
+      targetScope: {
+        cutoffDate: "2026-03-28",
+      },
+    });
   });
 
   it("scheduleGenerateNextYearBusinessHours payload を正しく実行する", async () => {
@@ -210,7 +247,14 @@ describe("scheduledJobTaskExecutors", () => {
     expect(mockRunGenerateNextYearBusinessHours).toHaveBeenCalledWith({
       targetYear: 2027,
     });
-    expect(mockWriteExecutionLog.mock.calls[1][0].eventType).toBe("completed");
+    expect(mockWriteExecutionLog.mock.calls[1][0]).toMatchObject({
+      phase: "execution",
+      eventType: "completed",
+      rawEventType: "completed",
+      targetScope: {
+        targetYear: 2027,
+      },
+    });
   });
 
   it("payrollNotificationScheduler payload を正しく実行する", async () => {
@@ -225,8 +269,23 @@ describe("scheduledJobTaskExecutors", () => {
 
     expect(mockRunPayrollNotification).toHaveBeenCalledWith({
       targetDate: "2026-04-04",
+      schedulerParent: {
+        storeId: "test-project",
+        schedulerParentJobKey: "payrollNotificationScheduler",
+        schedulerParentPlanningDate: "2026-04-04",
+        schedulerParentPlannedRunAt: "2026-04-03T20:00:00.000Z",
+        schedulerParentIdempotencyKey: "payrollNotificationScheduler:2026-04-03T20:00:00.000Z",
+        schedulerParentSupervisorRunId: "supervisor_20260403T180000Z_abcdef12",
+      },
     });
-    expect(mockWriteExecutionLog.mock.calls[1][0].eventType).toBe("completed");
+    expect(mockWriteExecutionLog.mock.calls[1][0]).toMatchObject({
+      phase: "execution",
+      eventType: "completed",
+      rawEventType: "completed",
+      targetScope: {
+        targetDate: "2026-04-04",
+      },
+    });
   });
 
   it("replan 実行時に enqueue 失敗なら request を release して error を記録する", async () => {
@@ -253,7 +312,23 @@ describe("scheduledJobTaskExecutors", () => {
     expect(mockMarkReplanCompleted).toHaveBeenCalledTimes(0);
     expect(mockReleaseReplan).toHaveBeenCalledTimes(1);
     expect(mockWriteExecutionLog).toHaveBeenCalledTimes(2);
-    expect(mockWriteExecutionLog.mock.calls[0][0].eventType).toBe("started");
-    expect(mockWriteExecutionLog.mock.calls[1][0].eventType).toBe("error");
+    expect(mockWriteExecutionLog.mock.calls[0][0]).toMatchObject({
+      phase: "execution",
+      eventType: "started",
+      rawEventType: "started",
+      targetScope: {
+        rangeStartAt: "2026-04-03T12:00:00.000Z",
+        rangeEndAt: "2026-04-17T20:00:00.000Z",
+      },
+    });
+    expect(mockWriteExecutionLog.mock.calls[1][0]).toMatchObject({
+      phase: "execution",
+      eventType: "error",
+      rawEventType: "error",
+      targetScope: {
+        rangeStartAt: "2026-04-03T12:00:00.000Z",
+        rangeEndAt: "2026-04-17T20:00:00.000Z",
+      },
+    });
   });
 });

--- a/functions/__tests__/scheduler/schedulerSupervisorCore.spec.ts
+++ b/functions/__tests__/scheduler/schedulerSupervisorCore.spec.ts
@@ -118,10 +118,15 @@ describe('schedulerSupervisorCore', () => {
     expect(enqueue).toHaveBeenCalledTimes(0);
     expect(mockWriteDispatchLog).toHaveBeenCalledTimes(1);
     expect(mockWriteDispatchLog.mock.calls[0][0]).toMatchObject({
+      phase: 'dispatch',
       eventType: 'skip',
+      rawEventType: 'skip',
       reason: 'planned_run_at_in_past',
       jobKey: 'scheduledCleanup',
       functionName: 'scheduledCleanup',
+      targetScope: {
+        cutoffDate: '2026-03-25',
+      },
     });
   });
 
@@ -146,10 +151,15 @@ describe('schedulerSupervisorCore', () => {
     expect(enqueue).toHaveBeenCalledTimes(1);
     expect(mockWriteDispatchLog).toHaveBeenCalledTimes(1);
     expect(mockWriteDispatchLog.mock.calls[0][0]).toMatchObject({
+      phase: 'dispatch',
       eventType: 'enqueued',
+      rawEventType: 'enqueued',
       jobKey: 'scheduledCleanup',
       functionName: 'scheduledCleanup',
       queueName: 'scheduled-job-scheduled-cleanup',
+      targetScope: {
+        cutoffDate: '2026-03-25',
+      },
     });
   });
 
@@ -174,9 +184,14 @@ describe('schedulerSupervisorCore', () => {
     expect(result.failedCount).toBe(0);
     expect(mockWriteDispatchLog).toHaveBeenCalledTimes(1);
     expect(mockWriteDispatchLog.mock.calls[0][0]).toMatchObject({
+      phase: 'dispatch',
       eventType: 'skip',
+      rawEventType: 'skip',
       reason: 'task_already_exists',
       jobKey: 'scheduledCleanup',
+      targetScope: {
+        cutoffDate: '2026-03-25',
+      },
     });
   });
 
@@ -201,10 +216,15 @@ describe('schedulerSupervisorCore', () => {
 
     expect(mockWriteDispatchLog).toHaveBeenCalledTimes(1);
     expect(mockWriteDispatchLog.mock.calls[0][0]).toMatchObject({
+      phase: 'dispatch',
       eventType: 'error',
+      rawEventType: 'error',
       isSuccess: false,
       reason: 'enqueue failed',
       jobKey: 'scheduledCleanup',
+      targetScope: {
+        cutoffDate: '2026-03-25',
+      },
     });
   });
 });

--- a/functions/src/domains/attendance/scheduler/payrollNotificationScheduler.ts
+++ b/functions/src/domains/attendance/scheduler/payrollNotificationScheduler.ts
@@ -1,16 +1,40 @@
 import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import { getPayrollConfig } from "../../../shared/config/payrollConfigLoader";
 import { getRegionalTaskQueue } from "../../../shared/tasks/getRegionalTaskQueue";
+import {
+  buildSchedulerChildExecutionMetadata,
+  type SchedulerTaskDispatchParentContext,
+} from "../../scheduler/supervisor/schedulerCorrelation";
+import { writeSchedulerTaskDispatchLogFromParentBestEffort } from "../../scheduler/supervisor/schedulerTaskDispatchLogs";
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const PROCESS_PAYROLL_NOTIFICATIONS_FUNCTION_ENTRY = "processPayrollNotifications";
 
 export interface PayrollNotificationSchedulerTaskInput {
   targetDate: string;
+  schedulerParent?: SchedulerTaskDispatchParentContext;
 }
 
 export interface PayrollNotificationSchedulerTaskResult {
   notificationHour: number;
   scheduleTimeUtc: string;
+}
+
+function isTaskAlreadyExistsError(error: unknown): boolean {
+  const err = error as {code?: unknown; message?: unknown};
+  const code = typeof err?.code === "string" ? err.code : String(err?.code ?? "");
+  const message = typeof err?.message === "string" ? err.message : "";
+
+  return (
+    code === "6" ||
+    code === "functions/task-already-exists" ||
+    message.includes("ALREADY_EXISTS") ||
+    message.includes("task-already-exists")
+  );
+}
+
+function buildPayrollChildUnitKey(targetDate: string): string {
+  return `${PROCESS_PAYROLL_NOTIFICATIONS_FUNCTION_ENTRY}:${targetDate}`;
 }
 
 function buildScheduleDateFromTargetDateAndHour(
@@ -66,6 +90,13 @@ export async function runPayrollNotificationSchedulerTask(
     await queue.enqueue(
       {
         targetDate: input.targetDate,
+        ...(input.schedulerParent ?
+          buildSchedulerChildExecutionMetadata(
+            input.schedulerParent,
+            PROCESS_PAYROLL_NOTIFICATIONS_FUNCTION_ENTRY,
+            buildPayrollChildUnitKey(input.targetDate)
+          ) :
+          {}),
       },
       {
         id: `payroll-notification-${input.targetDate}-${notificationHour}`,
@@ -73,6 +104,21 @@ export async function runPayrollNotificationSchedulerTask(
         dispatchDeadlineSeconds: 300,
       }
     );
+    if (input.schedulerParent) {
+      await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+        childFunctionEntry: PROCESS_PAYROLL_NOTIFICATIONS_FUNCTION_ENTRY,
+        childUnitKey: buildPayrollChildUnitKey(input.targetDate),
+        childScheduledAt: scheduleUtc.toISOString(),
+        childTargetSummary: {
+          targetDate: input.targetDate,
+          notificationHour,
+        },
+        eventType: "enqueued",
+        context: {
+          taskId: `payroll-notification-${input.targetDate}-${notificationHour}`,
+        },
+      });
+    }
     logOpsSuccess({
   message: "payrollNotificationScheduler 成功",
   functionEntry: "payrollNotificationScheduler",
@@ -90,6 +136,28 @@ export async function runPayrollNotificationSchedulerTask(
       scheduleTimeUtc,
     };
   } catch (error) {
+    if (input.schedulerParent && scheduleTimeUtc !== undefined) {
+      await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+        childFunctionEntry: PROCESS_PAYROLL_NOTIFICATIONS_FUNCTION_ENTRY,
+        childUnitKey: buildPayrollChildUnitKey(input.targetDate),
+        childScheduledAt: scheduleTimeUtc,
+        childTargetSummary: {
+          targetDate: input.targetDate,
+          ...(notificationHour !== undefined && {notificationHour}),
+        },
+        eventType: isTaskAlreadyExistsError(error) ? "skip" : "error",
+        reason:
+          isTaskAlreadyExistsError(error) ?
+            "task_already_exists" :
+            error instanceof Error ? error.message : String(error),
+        context: {
+          taskId:
+            notificationHour !== undefined ?
+              `payroll-notification-${input.targetDate}-${notificationHour}` :
+              null,
+        },
+      });
+    }
     logOpsError({
       message: "payrollNotificationScheduler task execution failed",
       functionEntry: "payrollNotificationScheduler",

--- a/functions/src/domains/attendance/tasks/processPayrollNotifications.ts
+++ b/functions/src/domains/attendance/tasks/processPayrollNotifications.ts
@@ -10,6 +10,7 @@
 import { onTaskDispatched } from 'firebase-functions/v2/tasks';
 import { getFirestore } from 'firebase-admin/firestore';
 import { logOpsInfo, logOpsSuccess } from '../../../shared/logging/logOpsError';
+import { extractSchedulerChildExecutionMetadata } from '../../scheduler/supervisor/schedulerCorrelation';
 
 import { getPayrollConfig } from '../../../shared/config/payrollConfigLoader';
 import { getStoreConfig } from '../../../shared/config/configLoader';
@@ -28,6 +29,13 @@ import {
 
 interface ProcessPayrollNotificationsTaskPayload {
   targetDate?: string;
+  schedulerParentJobKey?: string;
+  schedulerParentPlanningDate?: string;
+  schedulerParentPlannedRunAt?: string;
+  schedulerParentIdempotencyKey?: string;
+  schedulerParentSupervisorRunId?: string;
+  schedulerChildUnitKey?: string;
+  schedulerChildFunctionEntry?: string;
 }
 
 // ─── Pure types & helpers (Firestore-independent, unit-testable) ───
@@ -191,6 +199,7 @@ export const processPayrollNotifications = onTaskDispatched(
   },
   async (request) => {
     const payload = (request.data ?? {}) as ProcessPayrollNotificationsTaskPayload;
+    const schedulerMetadata = extractSchedulerChildExecutionMetadata(payload);
     const todayStr = payload.targetDate && /^\d{4}-\d{2}-\d{2}$/.test(payload.targetDate) ?
       payload.targetDate :
       (() => {
@@ -210,7 +219,10 @@ export const processPayrollNotifications = onTaskDispatched(
       message: 'processPayrollNotifications start',
       functionEntry: 'processPayrollNotifications',
       operation: 'start',
-      context: {todayStr},
+      context: {
+        todayStr,
+        ...schedulerMetadata,
+      },
     });
 
     const db = getFirestore();
@@ -285,6 +297,7 @@ export const processPayrollNotifications = onTaskDispatched(
         recentPeriodKey,
         actionsCount: actions.length,
         triggerTypes: actions.map((a) => a.triggerType),
+        ...schedulerMetadata,
       },
     });
   }

--- a/functions/src/domains/scheduler/supervisor/schedulerCorrelation.ts
+++ b/functions/src/domains/scheduler/supervisor/schedulerCorrelation.ts
@@ -1,0 +1,101 @@
+import type { SchedulerJobKey } from '../../../shared/config/schedulerConfigTypes';
+import type { ScheduledJobTaskPayload } from './schedulerTaskPayload';
+
+export interface SchedulerParentMetadata {
+  schedulerParentJobKey: SchedulerJobKey;
+  schedulerParentPlanningDate: string;
+  schedulerParentPlannedRunAt: string;
+  schedulerParentIdempotencyKey: string;
+  schedulerParentSupervisorRunId: string;
+}
+
+export interface SchedulerTaskDispatchParentContext extends SchedulerParentMetadata {
+  storeId: string;
+}
+
+export interface SchedulerChildExecutionMetadata extends SchedulerParentMetadata {
+  schedulerChildUnitKey: string;
+  schedulerChildFunctionEntry: string;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function buildSchedulerParentMetadata(
+  payload: Pick<
+    ScheduledJobTaskPayload,
+    'jobKey' | 'planningDate' | 'plannedRunAt' | 'idempotencyKey' | 'supervisorRunId'
+  >
+): SchedulerParentMetadata {
+  return {
+    schedulerParentJobKey: payload.jobKey,
+    schedulerParentPlanningDate: payload.planningDate,
+    schedulerParentPlannedRunAt: payload.plannedRunAt,
+    schedulerParentIdempotencyKey: payload.idempotencyKey,
+    schedulerParentSupervisorRunId: payload.supervisorRunId,
+  };
+}
+
+export function buildSchedulerTaskDispatchParentContext(
+  payload: Pick<
+    ScheduledJobTaskPayload,
+    'jobKey' | 'planningDate' | 'plannedRunAt' | 'idempotencyKey' | 'supervisorRunId' | 'projectId'
+  >
+): SchedulerTaskDispatchParentContext {
+  return {
+    storeId: payload.projectId,
+    ...buildSchedulerParentMetadata(payload),
+  };
+}
+
+export function buildSchedulerChildExecutionMetadata(
+  parent: SchedulerParentMetadata,
+  childFunctionEntry: string,
+  childUnitKey: string
+): SchedulerChildExecutionMetadata {
+  return {
+    schedulerParentJobKey: parent.schedulerParentJobKey,
+    schedulerParentPlanningDate: parent.schedulerParentPlanningDate,
+    schedulerParentPlannedRunAt: parent.schedulerParentPlannedRunAt,
+    schedulerParentIdempotencyKey: parent.schedulerParentIdempotencyKey,
+    schedulerParentSupervisorRunId: parent.schedulerParentSupervisorRunId,
+    schedulerChildUnitKey: childUnitKey,
+    schedulerChildFunctionEntry: childFunctionEntry,
+  };
+}
+
+export function extractSchedulerChildExecutionMetadata(
+  value: unknown
+): Partial<SchedulerChildExecutionMetadata> {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const record = value as Record<string, unknown>;
+  const context: Partial<SchedulerChildExecutionMetadata> = {};
+
+  if (isNonEmptyString(record.schedulerParentJobKey)) {
+    context.schedulerParentJobKey = record.schedulerParentJobKey as SchedulerJobKey;
+  }
+  if (isNonEmptyString(record.schedulerParentPlanningDate)) {
+    context.schedulerParentPlanningDate = record.schedulerParentPlanningDate;
+  }
+  if (isNonEmptyString(record.schedulerParentPlannedRunAt)) {
+    context.schedulerParentPlannedRunAt = record.schedulerParentPlannedRunAt;
+  }
+  if (isNonEmptyString(record.schedulerParentIdempotencyKey)) {
+    context.schedulerParentIdempotencyKey = record.schedulerParentIdempotencyKey;
+  }
+  if (isNonEmptyString(record.schedulerParentSupervisorRunId)) {
+    context.schedulerParentSupervisorRunId = record.schedulerParentSupervisorRunId;
+  }
+  if (isNonEmptyString(record.schedulerChildUnitKey)) {
+    context.schedulerChildUnitKey = record.schedulerChildUnitKey;
+  }
+  if (isNonEmptyString(record.schedulerChildFunctionEntry)) {
+    context.schedulerChildFunctionEntry = record.schedulerChildFunctionEntry;
+  }
+
+  return context;
+}

--- a/functions/src/domains/scheduler/supervisor/schedulerLogs.ts
+++ b/functions/src/domains/scheduler/supervisor/schedulerLogs.ts
@@ -1,6 +1,7 @@
 import { FieldValue, getFirestore } from 'firebase-admin/firestore';
 import type { SchedulerJobKey } from '../../../shared/config/schedulerConfigTypes';
 import { logOpsError, logOpsSuccess } from '../../../shared/logging/logOpsError';
+import type { SchedulerTargetScope } from './schedulerTargetScope';
 import {
   writeCentralSchedulerLog,
 } from '../../../shared/centralFirestore/writeToCentralFirestore';
@@ -17,7 +18,9 @@ function omitUndefinedFields(
 }
 
 export interface SchedulerDispatchLog {
+  phase: 'dispatch';
   eventType: 'enqueued' | 'skip' | 'error';
+  rawEventType: 'enqueued' | 'skip' | 'error';
   isSuccess: boolean;
   reason?: string;
   jobKey: SchedulerJobKey;
@@ -25,6 +28,7 @@ export interface SchedulerDispatchLog {
   queueName: string;
   plannedRunAt: string;
   planningDate: string;
+  targetScope: SchedulerTargetScope;
   projectId: string;
   idempotencyKey: string;
   supervisorRunId: string;
@@ -33,15 +37,41 @@ export interface SchedulerDispatchLog {
 }
 
 export interface SchedulerExecutionLogByCloudTask {
+  phase: 'execution';
   eventType: 'started' | 'completed' | 'skip' | 'error';
+  rawEventType: 'started' | 'completed' | 'skip' | 'error';
   isSuccess: boolean;
   reason?: string;
   jobKey: SchedulerJobKey;
   functionName: string;
+  planningDate: string;
+  plannedRunAt: string;
+  targetScope: SchedulerTargetScope;
   projectId: string;
   idempotencyKey: string;
   supervisorRunId?: string;
   decisionSnapshot?: Record<string, boolean | number | string>;
+}
+
+function toLegacySchedulerEventType(
+  phase: SchedulerDispatchLog['phase'] | SchedulerExecutionLogByCloudTask['phase'],
+  rawEventType:
+    | SchedulerDispatchLog['rawEventType']
+    | SchedulerExecutionLogByCloudTask['rawEventType']
+): 'start' | 'skip' | 'error' | 'success' {
+  if (phase === 'dispatch' && rawEventType === 'enqueued') {
+    return 'start';
+  }
+  if (phase === 'execution' && rawEventType === 'started') {
+    return 'start';
+  }
+  if (phase === 'execution' && rawEventType === 'completed') {
+    return 'success';
+  }
+  if (rawEventType === 'skip') {
+    return 'skip';
+  }
+  return 'error';
 }
 
 export async function writeSchedulerDispatchLogBestEffort(
@@ -70,9 +100,12 @@ export async function writeSchedulerDispatchLogBestEffort(
     void writeCentralSchedulerLog(entry.projectId, {
       jobKey: entry.jobKey,
       planningDate: entry.planningDate,
-      eventType: entry.eventType === 'enqueued' ? 'start' : entry.eventType,
-      idempotencyKey: entry.idempotencyKey,
       plannedRunAt: entry.plannedRunAt,
+      targetScope: entry.targetScope,
+      phase: entry.phase,
+      rawEventType: entry.rawEventType,
+      eventType: toLegacySchedulerEventType(entry.phase, entry.rawEventType),
+      idempotencyKey: entry.idempotencyKey,
       supervisorRunId: entry.supervisorRunId,
       functionEntry: entry.functionName,
       ...(entry.reason !== undefined ? { reason: entry.reason } : {}),
@@ -120,12 +153,12 @@ export async function writeSchedulerExecutionLogByCloudTaskBestEffort(
 
     void writeCentralSchedulerLog(entry.projectId, {
       jobKey: entry.jobKey,
-      eventType:
-        entry.eventType === 'started'
-          ? 'start'
-          : entry.eventType === 'completed'
-          ? 'success'
-          : entry.eventType,
+      planningDate: entry.planningDate,
+      plannedRunAt: entry.plannedRunAt,
+      targetScope: entry.targetScope,
+      phase: entry.phase,
+      rawEventType: entry.rawEventType,
+      eventType: toLegacySchedulerEventType(entry.phase, entry.rawEventType),
       idempotencyKey: entry.idempotencyKey,
       functionEntry: entry.functionName,
       ...(entry.supervisorRunId !== undefined ? { supervisorRunId: entry.supervisorRunId } : {}),

--- a/functions/src/domains/scheduler/supervisor/schedulerSupervisorCore.ts
+++ b/functions/src/domains/scheduler/supervisor/schedulerSupervisorCore.ts
@@ -194,11 +194,18 @@ export async function runSchedulerSupervisorCore(
       }
 
       const plannedRunAt = toUtcFromJstDateAndTime(targetJstDate, jobConfig.runAtJst);
+      const targetScope = buildSchedulerTargetScope(
+        jobKey,
+        plannedRunAt
+      ) as SchedulerTargetScope<typeof jobKey>;
+      const scheduleFingerprint = buildScheduleFingerprint(jobKey, schedulerConfig);
       if (plannedRunAt.getTime() <= now.getTime()) {
         skippedCount++;
         const queueName = getScheduledJobQueueName(jobKey);
         await writeSchedulerDispatchLogBestEffort({
+          phase: 'dispatch',
           eventType: 'skip',
+          rawEventType: 'skip',
           isSuccess: true,
           reason: 'planned_run_at_in_past',
           jobKey,
@@ -206,10 +213,11 @@ export async function runSchedulerSupervisorCore(
           queueName,
           plannedRunAt: plannedRunAt.toISOString(),
           planningDate,
+          targetScope,
           projectId,
           idempotencyKey: createIdempotencyKey(jobKey, plannedRunAt),
           supervisorRunId,
-          scheduleFingerprint: buildScheduleFingerprint(jobKey, schedulerConfig),
+          scheduleFingerprint,
           decisionSnapshot: {
             offsetDays: offset,
             isPastRun: true,
@@ -221,11 +229,6 @@ export async function runSchedulerSupervisorCore(
       const queueName = getScheduledJobQueueName(jobKey);
       const taskId = buildScheduledJobTaskId(jobKey, plannedRunAt);
       const idempotencyKey = createIdempotencyKey(jobKey, plannedRunAt);
-      const targetScope = buildSchedulerTargetScope(
-        jobKey,
-        plannedRunAt
-      ) as SchedulerTargetScope<typeof jobKey>;
-      const scheduleFingerprint = buildScheduleFingerprint(jobKey, schedulerConfig);
 
       const payload: ScheduledJobTaskPayload<typeof jobKey> = {
         schemaVersion: SCHEDULER_TASK_PAYLOAD_SCHEMA_VERSION,
@@ -250,13 +253,16 @@ export async function runSchedulerSupervisorCore(
         });
         enqueuedCount++;
         await writeSchedulerDispatchLogBestEffort({
+          phase: 'dispatch',
           eventType: 'enqueued',
+          rawEventType: 'enqueued',
           isSuccess: true,
           jobKey,
           functionName: jobKey,
           queueName,
           plannedRunAt: plannedRunAt.toISOString(),
           planningDate,
+          targetScope,
           projectId,
           idempotencyKey,
           supervisorRunId,
@@ -270,7 +276,9 @@ export async function runSchedulerSupervisorCore(
         if (isTaskAlreadyExistsError(error)) {
           skippedCount++;
           await writeSchedulerDispatchLogBestEffort({
+            phase: 'dispatch',
             eventType: 'skip',
+            rawEventType: 'skip',
             isSuccess: true,
             reason: 'task_already_exists',
             jobKey,
@@ -278,6 +286,7 @@ export async function runSchedulerSupervisorCore(
             queueName,
             plannedRunAt: plannedRunAt.toISOString(),
             planningDate,
+            targetScope,
             projectId,
             idempotencyKey,
             supervisorRunId,
@@ -294,7 +303,9 @@ export async function runSchedulerSupervisorCore(
         const message = error instanceof Error ? error.message : String(error);
         hardErrors.push(`${jobKey}:${message}`);
         await writeSchedulerDispatchLogBestEffort({
+          phase: 'dispatch',
           eventType: 'error',
+          rawEventType: 'error',
           isSuccess: false,
           reason: message,
           jobKey,
@@ -302,6 +313,7 @@ export async function runSchedulerSupervisorCore(
           queueName,
           plannedRunAt: plannedRunAt.toISOString(),
           planningDate,
+          targetScope,
           projectId,
           idempotencyKey,
           supervisorRunId,

--- a/functions/src/domains/scheduler/supervisor/schedulerTaskDispatchLogs.ts
+++ b/functions/src/domains/scheduler/supervisor/schedulerTaskDispatchLogs.ts
@@ -1,0 +1,80 @@
+import type { SchedulerJobKey } from '../../../shared/config/schedulerConfigTypes';
+import { logger } from 'firebase-functions';
+import { writeCentralSchedulerTaskDispatchLog } from '../../../shared/centralFirestore/writeToCentralFirestore';
+import type { SchedulerTaskDispatchParentContext } from './schedulerCorrelation';
+
+export interface SchedulerTaskDispatchLogEntry {
+  storeId: string;
+  parentJobKey: SchedulerJobKey;
+  parentPlanningDate: string;
+  parentPlannedRunAt: string;
+  parentSchedulerIdempotencyKey: string;
+  parentSupervisorRunId: string;
+  childFunctionEntry: string;
+  childUnitKey: string;
+  childScheduledAt: string;
+  childTargetSummary: Record<string, unknown>;
+  eventType: 'enqueued' | 'skip' | 'error';
+  reason?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface SchedulerTaskDispatchEvent {
+  childFunctionEntry: string;
+  childUnitKey: string;
+  childScheduledAt: string;
+  childTargetSummary: Record<string, unknown>;
+  eventType: 'enqueued' | 'skip' | 'error';
+  reason?: string;
+  context?: Record<string, unknown>;
+}
+
+export async function writeSchedulerTaskDispatchLogBestEffort(
+  entry: SchedulerTaskDispatchLogEntry
+): Promise<void> {
+  try {
+    await writeCentralSchedulerTaskDispatchLog(entry.storeId, {
+      parentJobKey: entry.parentJobKey,
+      parentPlanningDate: entry.parentPlanningDate,
+      parentPlannedRunAt: entry.parentPlannedRunAt,
+      parentSchedulerIdempotencyKey: entry.parentSchedulerIdempotencyKey,
+      parentSupervisorRunId: entry.parentSupervisorRunId,
+      childFunctionEntry: entry.childFunctionEntry,
+      childUnitKey: entry.childUnitKey,
+      childScheduledAt: entry.childScheduledAt,
+      childTargetSummary: entry.childTargetSummary,
+      eventType: entry.eventType,
+      ...(entry.reason !== undefined ? { reason: entry.reason } : {}),
+      ...(entry.context !== undefined ? { context: entry.context } : {}),
+    });
+  } catch (error) {
+    logger.warn('writeSchedulerTaskDispatchLogBestEffort failed', {
+      storeId: entry.storeId,
+      parentJobKey: entry.parentJobKey,
+      childFunctionEntry: entry.childFunctionEntry,
+      childUnitKey: entry.childUnitKey,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function writeSchedulerTaskDispatchLogFromParentBestEffort(
+  parent: SchedulerTaskDispatchParentContext,
+  entry: SchedulerTaskDispatchEvent
+): Promise<void> {
+  await writeSchedulerTaskDispatchLogBestEffort({
+    storeId: parent.storeId,
+    parentJobKey: parent.schedulerParentJobKey,
+    parentPlanningDate: parent.schedulerParentPlanningDate,
+    parentPlannedRunAt: parent.schedulerParentPlannedRunAt,
+    parentSchedulerIdempotencyKey: parent.schedulerParentIdempotencyKey,
+    parentSupervisorRunId: parent.schedulerParentSupervisorRunId,
+    childFunctionEntry: entry.childFunctionEntry,
+    childUnitKey: entry.childUnitKey,
+    childScheduledAt: entry.childScheduledAt,
+    childTargetSummary: entry.childTargetSummary,
+    eventType: entry.eventType,
+    ...(entry.reason !== undefined ? { reason: entry.reason } : {}),
+    ...(entry.context !== undefined ? { context: entry.context } : {}),
+  });
+}

--- a/functions/src/domains/scheduler/tasks/scheduledJobTaskExecutors.ts
+++ b/functions/src/domains/scheduler/tasks/scheduledJobTaskExecutors.ts
@@ -5,6 +5,10 @@ import {
   assertValidScheduledJobTaskPayload,
   type ScheduledJobTaskPayload,
 } from "../supervisor/schedulerTaskPayload";
+import {
+  buildSchedulerParentMetadata,
+  buildSchedulerTaskDispatchParentContext,
+} from "../supervisor/schedulerCorrelation";
 import { writeSchedulerExecutionLogByCloudTaskBestEffort } from "../supervisor/schedulerLogs";
 import { runWeeklyPlannerTask } from "../../storeMeta/scheduler/weeklyPlanner";
 import { runEnqueueTournamentTasksBySchedulerTask } from "../../tournament_createTournament/scheduler/EnqueueTournamentTasksByScheduler";
@@ -104,7 +108,10 @@ async function executeWeeklyPlanner(
     "targetWeekStartDate"
   );
 
-  const result = await runWeeklyPlannerTask({targetWeekStartDate});
+  const result = await runWeeklyPlannerTask({
+    targetWeekStartDate,
+    schedulerParent: buildSchedulerTaskDispatchParentContext(payload),
+  });
   return {
     eventType: "completed",
     decisionSnapshot: {
@@ -127,6 +134,7 @@ async function executeEnqueueTournamentTasks(
   const result = await runEnqueueTournamentTasksBySchedulerTask({
     rangeStartAt,
     rangeEndAt,
+    schedulerParent: buildSchedulerTaskDispatchParentContext(payload),
   });
   if (!result.success) {
     const errorSummary = (result.errors ?? [])
@@ -216,7 +224,10 @@ async function executePayrollNotificationScheduler(
     ({} as Record<string, unknown>);
   const targetDate = assertDateKey(targetScope.targetDate, "targetDate");
 
-  const result = await runPayrollNotificationSchedulerTask({targetDate});
+  const result = await runPayrollNotificationSchedulerTask({
+    targetDate,
+    schedulerParent: buildSchedulerTaskDispatchParentContext(payload),
+  });
   return {
     eventType: "completed",
     decisionSnapshot: {
@@ -255,6 +266,8 @@ export async function executeScheduledJobTask(
 ): Promise<void> {
   const payload = parsePayload(expectedJobKey, rawPayload);
 
+  const schedulerParentMetadata = buildSchedulerParentMetadata(payload);
+
   logOpsInfo({
     message: "executeScheduledJobTask start",
     functionEntry: "executeScheduledJobTask",
@@ -268,10 +281,15 @@ export async function executeScheduledJobTask(
   });
 
   await writeSchedulerExecutionLogByCloudTaskBestEffort({
+    phase: "execution",
     eventType: "started",
+    rawEventType: "started",
     isSuccess: true,
     jobKey: payload.jobKey,
     functionName: payload.jobKey,
+    planningDate: payload.planningDate,
+    plannedRunAt: payload.plannedRunAt,
+    targetScope: payload.targetScope,
     projectId: payload.projectId,
     idempotencyKey: payload.idempotencyKey,
     supervisorRunId: payload.supervisorRunId,
@@ -285,11 +303,16 @@ export async function executeScheduledJobTask(
     const outcome = await runScheduledJob(payload);
 
     await writeSchedulerExecutionLogByCloudTaskBestEffort({
+      phase: "execution",
       eventType: outcome.eventType,
+      rawEventType: outcome.eventType,
       isSuccess: true,
       reason: outcome.reason,
       jobKey: payload.jobKey,
       functionName: payload.jobKey,
+      planningDate: payload.planningDate,
+      plannedRunAt: payload.plannedRunAt,
+      targetScope: payload.targetScope,
       projectId: payload.projectId,
       idempotencyKey: payload.idempotencyKey,
       supervisorRunId: payload.supervisorRunId,
@@ -306,6 +329,7 @@ export async function executeScheduledJobTask(
         supervisorRunId: payload.supervisorRunId,
         planningDate: payload.planningDate,
         plannedRunAt: payload.plannedRunAt,
+        ...schedulerParentMetadata,
         outcomeEventType: outcome.eventType,
         outcomeReason: outcome.reason ?? null,
       },
@@ -317,11 +341,16 @@ export async function executeScheduledJobTask(
   } catch (error) {
     const reason = toErrorReason(error);
     await writeSchedulerExecutionLogByCloudTaskBestEffort({
+      phase: "execution",
       eventType: "error",
+      rawEventType: "error",
       isSuccess: false,
       reason,
       jobKey: payload.jobKey,
       functionName: payload.jobKey,
+      planningDate: payload.planningDate,
+      plannedRunAt: payload.plannedRunAt,
+      targetScope: payload.targetScope,
       projectId: payload.projectId,
       idempotencyKey: payload.idempotencyKey,
       supervisorRunId: payload.supervisorRunId,
@@ -343,6 +372,7 @@ export async function executeScheduledJobTask(
         supervisorRunId: payload.supervisorRunId,
         planningDate: payload.planningDate,
         plannedRunAt: payload.plannedRunAt,
+        ...schedulerParentMetadata,
       },
     });
     throw error;

--- a/functions/src/domains/storeMeta/callables/closeAssessmentTask.ts
+++ b/functions/src/domains/storeMeta/callables/closeAssessmentTask.ts
@@ -19,6 +19,7 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { Timestamp } from 'firebase-admin/firestore';
 import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import { FunctionCustomError } from '../../../shared/logging/functionCustomError';
+import { extractSchedulerChildExecutionMetadata } from '../../scheduler/supervisor/schedulerCorrelation';
 
 type ManualOverrideLike = {
   type?: string;
@@ -61,11 +62,19 @@ export const closeAssessmentTask = onRequest(
     region: 'asia-northeast1',
   },
   async (req, res) => {
+    const schedulerMetadata = extractSchedulerChildExecutionMetadata(req.body);
     try {
       const payload = req.body as {
         action: string;
         intendedBusinessDateKey: string;
         scheduledAt: string;
+        schedulerParentJobKey?: string;
+        schedulerParentPlanningDate?: string;
+        schedulerParentPlannedRunAt?: string;
+        schedulerParentIdempotencyKey?: string;
+        schedulerParentSupervisorRunId?: string;
+        schedulerChildUnitKey?: string;
+        schedulerChildFunctionEntry?: string;
       };
 
       if (payload.action !== 'close_assessment') {
@@ -77,6 +86,13 @@ export const closeAssessmentTask = onRequest(
       const now = new Date();
       const jstNow = new Date(now.getTime() + 9 * 60 * 60 * 1000);  // UTC+9
       const serverNowJst = jstNow;
+      let taskResult = 'unknown';
+      let taskBlockers: string[] = [];
+
+      const setTaskOutcome = (result: string, blockers: string[] = []) => {
+        taskResult = result;
+        taskBlockers = [...blockers];
+      };
 
       // idempotencyKeyの生成
       const idempotencyKey = `close_assessment_${payload.intendedBusinessDateKey}_${payload.scheduledAt}`;
@@ -91,6 +107,7 @@ export const closeAssessmentTask = onRequest(
           intendedBusinessDateKey: payload.intendedBusinessDateKey,
           idempotencyKey,
           scheduledAt: payload.scheduledAt,
+          ...schedulerMetadata,
         },
       });
 
@@ -113,6 +130,7 @@ export const closeAssessmentTask = onRequest(
         // 冪等性チェック
         if (closeAssessment?.idempotencyKey === idempotencyKey) {
           console.log(`既に同じidempotencyKeyで更新済みです: ${idempotencyKey}`);
+          setTaskOutcome('duplicate_idempotency');
           return;  // no-op
         }
 
@@ -150,6 +168,7 @@ export const closeAssessmentTask = onRequest(
             idempotencyKey,
             createdAt: decidedAt,
           });
+          setTaskOutcome('skipped', ['date_out_of_range']);
           return;
         }
 
@@ -191,6 +210,7 @@ export const closeAssessmentTask = onRequest(
             idempotencyKey,
             createdAt: decidedAt,
           });
+          setTaskOutcome('already_closed');
           return;
         }
 
@@ -236,6 +256,7 @@ export const closeAssessmentTask = onRequest(
             currentBusinessDateKey: currentBusinessDateKey ?? null,
             lastClosedBusinessDateKey: lastClosedBusinessDateKey ?? null,
           });
+          setTaskOutcome('skipped', ['target_day_already_closed']);
           return;
         }
 
@@ -265,6 +286,7 @@ export const closeAssessmentTask = onRequest(
             idempotencyKey,
             createdAt: decidedAt,
           });
+          setTaskOutcome('next_day_started');
           return;
         }
 
@@ -328,6 +350,7 @@ export const closeAssessmentTask = onRequest(
           logData.suppressedByOverride = suppressedByOverride;
         }
         transaction.set(logRef, logData);
+        setTaskOutcome(result, blockers);
       });
 
       if (staleSkipLogContext != null) {
@@ -346,6 +369,9 @@ export const closeAssessmentTask = onRequest(
           intendedBusinessDateKey: payload.intendedBusinessDateKey,
           scheduledAt: payload.scheduledAt,
           idempotencyKey: `close_assessment_${payload.intendedBusinessDateKey}_${payload.scheduledAt}`,
+          result: taskResult,
+          blockers: taskBlockers,
+          ...schedulerMetadata,
         },
       });
 
@@ -358,6 +384,7 @@ export const closeAssessmentTask = onRequest(
         context: {
           intendedBusinessDateKey: (req.body as { intendedBusinessDateKey?: string })?.intendedBusinessDateKey,
           action: (req.body as { action?: string })?.action,
+          ...schedulerMetadata,
         },
       });
       res.status(500).json({ error: error.message });

--- a/functions/src/domains/storeMeta/callables/openAssessmentTask.ts
+++ b/functions/src/domains/storeMeta/callables/openAssessmentTask.ts
@@ -19,6 +19,7 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { Timestamp } from 'firebase-admin/firestore';
 import { logOpsError, logOpsInfo, logOpsSuccess } from "../../../shared/logging/logOpsError";
 import { FunctionCustomError } from '../../../shared/logging/functionCustomError';
+import { extractSchedulerChildExecutionMetadata } from '../../scheduler/supervisor/schedulerCorrelation';
 
 type OpenAssessmentAction = 'open_assessment' | 'open_assessment_recheck';
 
@@ -53,11 +54,19 @@ export const openAssessmentTask = onRequest(
     region: 'asia-northeast1',
   },
   async (req, res) => {
+    const schedulerMetadata = extractSchedulerChildExecutionMetadata(req.body);
     try {
       const payload = req.body as {
         action: string;
         intendedBusinessDateKey: string;
         scheduledAt: string;
+        schedulerParentJobKey?: string;
+        schedulerParentPlanningDate?: string;
+        schedulerParentPlannedRunAt?: string;
+        schedulerParentIdempotencyKey?: string;
+        schedulerParentSupervisorRunId?: string;
+        schedulerChildUnitKey?: string;
+        schedulerChildFunctionEntry?: string;
       };
 
       const action = payload.action as OpenAssessmentAction;
@@ -84,6 +93,13 @@ export const openAssessmentTask = onRequest(
       const now = new Date();
       const jstNow = new Date(now.getTime() + 9 * 60 * 60 * 1000);  // UTC+9
       const serverNowJst = jstNow;
+      let taskResult = 'unknown';
+      let taskBlockers: string[] = [];
+
+      const setTaskOutcome = (result: string, blockers: string[] = []) => {
+        taskResult = result;
+        taskBlockers = [...blockers];
+      };
 
       // idempotencyKeyの生成
       const idempotencyKey = `${action}_${payload.intendedBusinessDateKey}_${payload.scheduledAt}`;
@@ -96,6 +112,7 @@ export const openAssessmentTask = onRequest(
           action,
           intendedBusinessDateKey: payload.intendedBusinessDateKey,
           idempotencyKey,
+          ...schedulerMetadata,
         },
       });
 
@@ -118,6 +135,7 @@ export const openAssessmentTask = onRequest(
         // 冪等性チェック
         if (openAssessment?.idempotencyKey === idempotencyKey) {
           console.log(`既に同じidempotencyKeyで更新済みです: ${idempotencyKey}`);
+          setTaskOutcome('duplicate_idempotency');
           return;  // no-op
         }
 
@@ -157,6 +175,7 @@ export const openAssessmentTask = onRequest(
               idempotencyKey,
               createdAt: decidedAt,
             });
+            setTaskOutcome('skipped', ['date_out_of_range']);
             return;
           }
         }
@@ -206,6 +225,7 @@ export const openAssessmentTask = onRequest(
             idempotencyKey,
             createdAt: decidedAt,
           });
+          setTaskOutcome('already_running');
           return;
         }
 
@@ -243,6 +263,7 @@ export const openAssessmentTask = onRequest(
             logData.suppressedByOverride = true;
           }
           transaction.set(logRef, logData);
+          setTaskOutcome('skipped', ['already_running_different_date']);
           return;
         }
 
@@ -314,6 +335,7 @@ export const openAssessmentTask = onRequest(
           logData.suppressedByOverride = suppressedByOverride;
         }
         transaction.set(logRef, logData);
+        setTaskOutcome(result, blockers);
       });
 
       logOpsSuccess({
@@ -324,6 +346,9 @@ export const openAssessmentTask = onRequest(
           intendedBusinessDateKey: payload.intendedBusinessDateKey,
           scheduledAt: payload.scheduledAt,
           idempotencyKey: `${action}_${payload.intendedBusinessDateKey}_${payload.scheduledAt}`,
+          result: taskResult,
+          blockers: taskBlockers,
+          ...schedulerMetadata,
         },
       });
 
@@ -336,6 +361,7 @@ export const openAssessmentTask = onRequest(
         context: {
           intendedBusinessDateKey: (req.body as { intendedBusinessDateKey?: string })?.intendedBusinessDateKey,
           action: (req.body as { action?: string })?.action,
+          ...schedulerMetadata,
         },
       });
       res.status(500).json({ error: error.message });

--- a/functions/src/domains/storeMeta/scheduler/weeklyPlanner.ts
+++ b/functions/src/domains/storeMeta/scheduler/weeklyPlanner.ts
@@ -22,12 +22,20 @@ import {
   DEFAULT_TASK_OPEN_OFFSET_MINUTES,
 } from "../../../shared/config/defaults";
 import { getTaskEndpoints } from "../../../shared/secrets/secretManager";
+import {
+  buildSchedulerChildExecutionMetadata,
+  type SchedulerTaskDispatchParentContext,
+} from "../../scheduler/supervisor/schedulerCorrelation";
+import { writeSchedulerTaskDispatchLogFromParentBestEffort } from "../../scheduler/supervisor/schedulerTaskDispatchLogs";
 
 const tasksClient = new CloudTasksClient();
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const OPEN_ASSESSMENT_FUNCTION_ENTRY = "openAssessmentTask";
+const CLOSE_ASSESSMENT_FUNCTION_ENTRY = "closeAssessmentTask";
 
 export interface WeeklyPlannerTaskInput {
   targetWeekStartDate: string;
+  schedulerParent?: SchedulerTaskDispatchParentContext;
 }
 
 export interface WeeklyPlannerTaskResult {
@@ -79,6 +87,13 @@ function buildScheduleTimeFromJstMinutes(
   minuteOfDay: number
 ): Date {
   return new Date(jstDateAtMidnight.getTime() + minuteOfDay * 60 * 1000);
+}
+
+function buildAssessmentChildUnitKey(
+  functionEntry: typeof OPEN_ASSESSMENT_FUNCTION_ENTRY | typeof CLOSE_ASSESSMENT_FUNCTION_ENTRY,
+  intendedBusinessDateKey: string
+): string {
+  return `${functionEntry}:${intendedBusinessDateKey}`;
 }
 
 export async function runWeeklyPlannerTask(
@@ -186,6 +201,13 @@ export async function runWeeklyPlannerTask(
         action: "open_assessment",
         intendedBusinessDateKey: dateKey,
         scheduledAt: openScheduleTime.toISOString(),
+        ...(input.schedulerParent ?
+          buildSchedulerChildExecutionMetadata(
+            input.schedulerParent,
+            OPEN_ASSESSMENT_FUNCTION_ENTRY,
+            buildAssessmentChildUnitKey(OPEN_ASSESSMENT_FUNCTION_ENTRY, dateKey)
+          ) :
+          {}),
       };
 
       try {
@@ -210,10 +232,60 @@ export async function runWeeklyPlannerTask(
           },
         });
         openTasksEnqueued += 1;
+        if (input.schedulerParent) {
+          await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+            childFunctionEntry: OPEN_ASSESSMENT_FUNCTION_ENTRY,
+            childUnitKey: buildAssessmentChildUnitKey(OPEN_ASSESSMENT_FUNCTION_ENTRY, dateKey),
+            childScheduledAt: openScheduleTime.toISOString(),
+            childTargetSummary: {
+              action: "open_assessment",
+              intendedBusinessDateKey: dateKey,
+            },
+            eventType: "enqueued",
+            context: {
+              queueName: tasksQueue,
+              taskId: openTaskId,
+            },
+          });
+        }
       } catch (error) {
         if (isTaskAlreadyExistsError(error)) {
           logger.info("weeklyPlanner: open task already exists", {dateKey});
+          if (input.schedulerParent) {
+            await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+              childFunctionEntry: OPEN_ASSESSMENT_FUNCTION_ENTRY,
+              childUnitKey: buildAssessmentChildUnitKey(OPEN_ASSESSMENT_FUNCTION_ENTRY, dateKey),
+              childScheduledAt: openScheduleTime.toISOString(),
+              childTargetSummary: {
+                action: "open_assessment",
+                intendedBusinessDateKey: dateKey,
+              },
+              eventType: "skip",
+              reason: "task_already_exists",
+              context: {
+                queueName: tasksQueue,
+                taskId: openTaskId,
+              },
+            });
+          }
         } else {
+          if (input.schedulerParent) {
+            await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+              childFunctionEntry: OPEN_ASSESSMENT_FUNCTION_ENTRY,
+              childUnitKey: buildAssessmentChildUnitKey(OPEN_ASSESSMENT_FUNCTION_ENTRY, dateKey),
+              childScheduledAt: openScheduleTime.toISOString(),
+              childTargetSummary: {
+                action: "open_assessment",
+                intendedBusinessDateKey: dateKey,
+              },
+              eventType: "error",
+              reason: error instanceof Error ? error.message : String(error),
+              context: {
+                queueName: tasksQueue,
+                taskId: openTaskId,
+              },
+            });
+          }
           throw error;
         }
       }
@@ -229,6 +301,13 @@ export async function runWeeklyPlannerTask(
         action: "close_assessment",
         intendedBusinessDateKey: dateKey,
         scheduledAt: closeScheduleTime.toISOString(),
+        ...(input.schedulerParent ?
+          buildSchedulerChildExecutionMetadata(
+            input.schedulerParent,
+            CLOSE_ASSESSMENT_FUNCTION_ENTRY,
+            buildAssessmentChildUnitKey(CLOSE_ASSESSMENT_FUNCTION_ENTRY, dateKey)
+          ) :
+          {}),
       };
 
       try {
@@ -253,10 +332,60 @@ export async function runWeeklyPlannerTask(
           },
         });
         closeTasksEnqueued += 1;
+        if (input.schedulerParent) {
+          await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+            childFunctionEntry: CLOSE_ASSESSMENT_FUNCTION_ENTRY,
+            childUnitKey: buildAssessmentChildUnitKey(CLOSE_ASSESSMENT_FUNCTION_ENTRY, dateKey),
+            childScheduledAt: closeScheduleTime.toISOString(),
+            childTargetSummary: {
+              action: "close_assessment",
+              intendedBusinessDateKey: dateKey,
+            },
+            eventType: "enqueued",
+            context: {
+              queueName: tasksQueue,
+              taskId: closeTaskId,
+            },
+          });
+        }
       } catch (error) {
         if (isTaskAlreadyExistsError(error)) {
           logger.info("weeklyPlanner: close task already exists", {dateKey});
+          if (input.schedulerParent) {
+            await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+              childFunctionEntry: CLOSE_ASSESSMENT_FUNCTION_ENTRY,
+              childUnitKey: buildAssessmentChildUnitKey(CLOSE_ASSESSMENT_FUNCTION_ENTRY, dateKey),
+              childScheduledAt: closeScheduleTime.toISOString(),
+              childTargetSummary: {
+                action: "close_assessment",
+                intendedBusinessDateKey: dateKey,
+              },
+              eventType: "skip",
+              reason: "task_already_exists",
+              context: {
+                queueName: tasksQueue,
+                taskId: closeTaskId,
+              },
+            });
+          }
         } else {
+          if (input.schedulerParent) {
+            await writeSchedulerTaskDispatchLogFromParentBestEffort(input.schedulerParent, {
+              childFunctionEntry: CLOSE_ASSESSMENT_FUNCTION_ENTRY,
+              childUnitKey: buildAssessmentChildUnitKey(CLOSE_ASSESSMENT_FUNCTION_ENTRY, dateKey),
+              childScheduledAt: closeScheduleTime.toISOString(),
+              childTargetSummary: {
+                action: "close_assessment",
+                intendedBusinessDateKey: dateKey,
+              },
+              eventType: "error",
+              reason: error instanceof Error ? error.message : String(error),
+              context: {
+                queueName: tasksQueue,
+                taskId: closeTaskId,
+              },
+            });
+          }
           throw error;
         }
       }

--- a/functions/src/domains/tournament_createTournament/scheduler/EnqueueTournamentTasksByScheduler.ts
+++ b/functions/src/domains/tournament_createTournament/scheduler/EnqueueTournamentTasksByScheduler.ts
@@ -4,10 +4,12 @@ import {
   runEnqueueTournamentTasks,
   type RunEnqueueResult,
 } from "../services/enqueueTournamentTasksCore";
+import type { SchedulerTaskDispatchParentContext } from "../../scheduler/supervisor/schedulerCorrelation";
 
 export interface EnqueueTournamentTasksBySchedulerInput {
   rangeStartAt: string;
   rangeEndAt: string;
+  schedulerParent?: SchedulerTaskDispatchParentContext;
 }
 
 export async function runEnqueueTournamentTasksBySchedulerTask(
@@ -27,6 +29,7 @@ export async function runEnqueueTournamentTasksBySchedulerTask(
     const result = await runEnqueueTournamentTasks({
       rangeStartAt: input.rangeStartAt,
       rangeEndAt: input.rangeEndAt,
+      schedulerParent: input.schedulerParent,
     });
     // schedulerSupervisor と同様: store config 欠落等でタスク生成を止めたときは logOpsSuccess にしない
     if (result.skippedReason) {

--- a/functions/src/domains/tournament_createTournament/services/enqueueTournamentTasksCore.ts
+++ b/functions/src/domains/tournament_createTournament/services/enqueueTournamentTasksCore.ts
@@ -13,6 +13,11 @@ import { FunctionCustomError } from '../../../shared/logging/functionCustomError
 import { validateStoreTenantForProduction, isProductionRuntime } from '../../../shared/runtime';
 import { resolveStoreTenantForWrite } from '../../../shared/runtime/storeTenantIdentity';
 import { enqueueTournamentTask } from './tasks';
+import {
+  buildSchedulerChildExecutionMetadata,
+  type SchedulerTaskDispatchParentContext,
+} from '../../scheduler/supervisor/schedulerCorrelation';
+import { writeSchedulerTaskDispatchLogFromParentBestEffort } from '../../scheduler/supervisor/schedulerTaskDispatchLogs';
 
 const HORIZON_DAYS = 14;
 const LOOKBACK_HOURS = 6;
@@ -31,6 +36,7 @@ export interface RunEnqueueOptions {
   rangeStartAt?: string;
   rangeEndAt?: string;
   now?: Date;
+  schedulerParent?: SchedulerTaskDispatchParentContext;
 }
 
 export interface RunEnqueueResult {
@@ -139,6 +145,43 @@ export function validateRequiredFields(data: FirebaseFirestore.DocumentData): st
   return null;
 }
 
+function buildTournamentChildUnitKey(tournamentId: string, taskType: TaskType): string {
+  return `controlHookHttp:${taskType}:${tournamentId}`;
+}
+
+async function logTournamentChildDispatch(
+  schedulerParent: SchedulerTaskDispatchParentContext | undefined,
+  params: {
+    tournamentId: string;
+    taskType: TaskType;
+    planVersion: number;
+    planHash?: string;
+    childScheduledAt: string;
+    eventType: 'enqueued' | 'skip' | 'error';
+    reason?: string;
+    context?: Record<string, unknown>;
+  }
+): Promise<void> {
+  if (!schedulerParent) {
+    return;
+  }
+
+  await writeSchedulerTaskDispatchLogFromParentBestEffort(schedulerParent, {
+    childFunctionEntry: 'controlHookHttp',
+    childUnitKey: buildTournamentChildUnitKey(params.tournamentId, params.taskType),
+    childScheduledAt: params.childScheduledAt,
+    childTargetSummary: {
+      tournamentId: params.tournamentId,
+      taskType: params.taskType,
+      planVersion: params.planVersion,
+      planHash: params.planHash ?? null,
+    },
+    eventType: params.eventType,
+    ...(params.reason !== undefined ? { reason: params.reason } : {}),
+    ...(params.context !== undefined ? { context: params.context } : {}),
+  });
+}
+
 /**
  * 対象 tournament について taskIndex を突合し、必要に応じて Cloud Tasks を投入
  */
@@ -147,7 +190,8 @@ async function processTournament(
   tournamentId: string,
   doc: FirebaseFirestore.DocumentData,
   now: Date,
-  thirtyDaysFromNow: Date
+  thirtyDaysFromNow: Date,
+  schedulerParent?: SchedulerTaskDispatchParentContext
 ): Promise<{ enqueued: number }> {
   let enqueued = 0;
   const planVersion = doc.schedulePlanVersion ?? 0;
@@ -176,6 +220,17 @@ async function processTournament(
     const targetAt =
       taskType === 'startTournament' ? startAt : taskType === 'closeRegistration' ? regEndAt : null;
     if (!targetAt) {
+      await logTournamentChildDispatch(schedulerParent, {
+        tournamentId,
+        taskType,
+        planVersion,
+        childScheduledAt: startAt.toISOString(),
+        eventType: 'skip',
+        reason: 'target_at_unresolved',
+        context: {
+          targetAtResolved: false,
+        },
+      });
       // closeRegistration が blindTemplate 欠落でスキップ(null) の場合は「未完」扱い。
       // results.closeRegistration は初期値 'pending' のまま → taskSyncNeeded を false に落とさない（再試行対象として残す）。
       continue;
@@ -200,6 +255,18 @@ async function processTournament(
 
     if (currentPlanHash && currentPlanHash === planHash) {
       if (currentState === 'enqueued' || currentState === 'executed') {
+        await logTournamentChildDispatch(schedulerParent, {
+          tournamentId,
+          taskType,
+          planVersion,
+          planHash,
+          childScheduledAt: enqueueDueDate.toISOString(),
+          eventType: 'skip',
+          reason: 'task_already_synced',
+          context: {
+            currentState,
+          },
+        });
         results[taskType] = 'done';
         continue;
       }
@@ -230,7 +297,14 @@ async function processTournament(
           planHash,
           enqueueDueDate.toISOString(),
           storeId,
-          enqueueDueDate
+          enqueueDueDate,
+          schedulerParent ?
+            buildSchedulerChildExecutionMetadata(
+              schedulerParent,
+              'controlHookHttp',
+              buildTournamentChildUnitKey(tournamentId, taskType)
+            ) :
+            undefined
         );
         enqueued++;
         const deterministicName = `${tournamentId}-${taskType}-${planHash}`;
@@ -238,6 +312,18 @@ async function processTournament(
           enqueueState: 'enqueued',
           taskName: taskName || deterministicName,
           lastEnqueuedAt: Timestamp.now(),
+        });
+        await logTournamentChildDispatch(schedulerParent, {
+          tournamentId,
+          taskType,
+          planVersion,
+          planHash,
+          childScheduledAt: enqueueDueDate.toISOString(),
+          eventType: 'enqueued',
+          context: {
+            enqueueState: 'enqueued',
+            taskName: taskName || deterministicName,
+          },
         });
         results[taskType] = 'done';
       } catch (err) {
@@ -257,8 +343,32 @@ async function processTournament(
             at: Timestamp.now(),
           },
         });
+        await logTournamentChildDispatch(schedulerParent, {
+          tournamentId,
+          taskType,
+          planVersion,
+          planHash,
+          childScheduledAt: enqueueDueDate.toISOString(),
+          eventType: 'error',
+          reason: err instanceof Error ? err.message : String(err),
+          context: {
+            enqueueState: 'failed',
+          },
+        });
       }
     } else {
+      await logTournamentChildDispatch(schedulerParent, {
+        tournamentId,
+        taskType,
+        planVersion,
+        planHash,
+        childScheduledAt: enqueueDueDate.toISOString(),
+        eventType: 'skip',
+        reason: 'enqueue_due_at_beyond_cloud_tasks_window',
+        context: {
+          enqueueDueAt: enqueueDueDate.toISOString(),
+        },
+      });
       results[taskType] = 'pending';
     }
   }
@@ -391,7 +501,8 @@ export async function runEnqueueTournamentTasks(
             id,
             data,
             now,
-            thirtyDaysFromNow
+            thirtyDaysFromNow,
+            options.schedulerParent
           );
           return { success: true as const, enqueued };
         } catch (err) {

--- a/functions/src/domains/tournament_createTournament/services/tasks.ts
+++ b/functions/src/domains/tournament_createTournament/services/tasks.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../shared/config/cloudTasksConfig';
 import { getRequiredProjectId } from '../../../shared/runtime/projectId';
 import { getTaskEndpoints } from '../../../shared/secrets/secretManager';
+import type { SchedulerChildExecutionMetadata } from '../../scheduler/supervisor/schedulerCorrelation';
 const client = new CloudTasksClient();
 
 /**
@@ -20,7 +21,8 @@ export async function enqueueTournamentTask(
   planHash: string,
   scheduledAt: string,
   storeId: string,
-  enqueueDueAt: Date
+  enqueueDueAt: Date,
+  schedulerMetadata?: SchedulerChildExecutionMetadata
 ): Promise<string> {
   const projectId = getRequiredProjectId();
   const { controlHookUrl } = await getTaskEndpoints();
@@ -40,6 +42,7 @@ export async function enqueueTournamentTask(
     planHash,
     scheduledAt,
     storeId,
+    ...(schedulerMetadata ?? {}),
   };
 
   // changeSpec 13: deterministic taskName で重複投入防止

--- a/functions/src/shared/centralFirestore/writeToCentralFirestore.ts
+++ b/functions/src/shared/centralFirestore/writeToCentralFirestore.ts
@@ -87,6 +87,39 @@ export async function writeCentralSchedulerLog(
 }
 
 /**
+ * 中央 Firestore の schedulerTaskDispatchLogs サブコレクションに best-effort write する。
+ * TTL: 30日。
+ */
+export async function writeCentralSchedulerTaskDispatchLog(
+  storeId: string,
+  data: Record<string, unknown>
+): Promise<void> {
+  const db = getCentralFirestore();
+  if (!db) return;
+
+  try {
+    const expireAt = new Date();
+    expireAt.setDate(expireAt.getDate() + 30);
+
+    await db
+      .collection('schedulerTaskDispatchLogs')
+      .doc(storeId)
+      .collection('runs')
+      .add({
+        ...data,
+        storeId,
+        loggedAt: FieldValue.serverTimestamp(),
+        expireAt,
+      });
+  } catch (err) {
+    logger.warn('writeCentralSchedulerTaskDispatchLog failed (best-effort)', {
+      storeId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
  * 中央 Firestore の taskLogs サブコレクションに best-effort write する。
  * TTL: 30日。
  */

--- a/functions/src/shared/http/controlHook.ts
+++ b/functions/src/shared/http/controlHook.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { logger } from 'firebase-functions';
 import { logOpsError, logOpsInfo, logOpsSuccess } from '../logging/logOpsError';
 import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { extractSchedulerChildExecutionMetadata } from '../../domains/scheduler/supervisor/schedulerCorrelation';
 
 /**
  * Cloud Tasks からの HTTP リクエストを受け付けるエンドポイント
@@ -20,6 +21,13 @@ interface NewPayload {
   planHash: string;
   scheduledAt?: string;
   storeId?: string;
+  schedulerParentJobKey?: string;
+  schedulerParentPlanningDate?: string;
+  schedulerParentPlannedRunAt?: string;
+  schedulerParentIdempotencyKey?: string;
+  schedulerParentSupervisorRunId?: string;
+  schedulerChildUnitKey?: string;
+  schedulerChildFunctionEntry?: string;
 }
 
 function isNewPayload(body: unknown): body is NewPayload {
@@ -84,6 +92,23 @@ function isTaskIndexMissingSuspiciousExecutionGap(
   return false;
 }
 
+function logNewPayloadTaskOutcome(
+  context: {
+    tournamentId: string;
+    taskType: string;
+    planVersion: number;
+    planHash: string;
+    lastRunResult: 'success' | 'noop';
+  } & Record<string, unknown>
+): void {
+  logOpsSuccess({
+    message: 'controlHook 新payload 処理完了',
+    functionEntry: 'controlHookHttp',
+    operation: 'executeNewPayloadTask',
+    context,
+  });
+}
+
 export const controlHook = async (req: Request, res: Response) => {
   try {
     if (req.method !== 'POST') {
@@ -133,6 +158,7 @@ async function handleNewPayload(
   res: Response,
   body: NewPayload
 ): Promise<void> {
+  const schedulerMetadata = extractSchedulerChildExecutionMetadata(body);
   logOpsInfo({
     message: 'controlHookHttp start',
     functionEntry: 'controlHookHttp',
@@ -142,10 +168,18 @@ async function handleNewPayload(
       taskType: body.taskType,
       planVersion: body.planVersion,
       planHash: body.planHash,
+      ...schedulerMetadata,
     },
   });
 
   const { tournamentId, taskType, planVersion, planHash } = body;
+  const baseSuccessContext = {
+    tournamentId,
+    taskType,
+    planVersion,
+    planHash,
+    ...schedulerMetadata,
+  };
   const db = getFirestore();
   const taskIndexRef = db
     .collection('scheduledTournaments')
@@ -252,6 +286,7 @@ async function handleNewPayload(
           taskType,
           planVersion,
           planHash,
+          ...schedulerMetadata,
           cloudTaskName: cloudTaskName ?? null,
           tournamentStatus: (tournamentData.status as string | undefined) ?? null,
           hasStartedAt: Boolean(runtimeData.startedAt),
@@ -261,6 +296,10 @@ async function handleNewPayload(
     } else {
       logTaskIndexMissing(tournamentId, taskType, planVersion, planHash, cloudTaskName);
     }
+    logNewPayloadTaskOutcome({
+      ...baseSuccessContext,
+      lastRunResult: 'noop',
+    });
     res.status(200).json({ success: true, message: 'no-op (taskIndex missing)' });
     return;
   }
@@ -282,6 +321,10 @@ async function handleNewPayload(
       schedulePlanVersion,
       planVersion,
     });
+    logNewPayloadTaskOutcome({
+      ...baseSuccessContext,
+      lastRunResult: 'noop',
+    });
     res.status(200).json({ success: true, message: 'no-op (version mismatch)' });
     return;
   }
@@ -298,11 +341,16 @@ async function handleNewPayload(
       tournamentId,
       taskType,
     });
+    logNewPayloadTaskOutcome({
+      ...baseSuccessContext,
+      lastRunResult: 'noop',
+    });
     res.status(200).json({ success: true, message: 'no-op (hash mismatch)' });
     return;
   }
 
   // 6. トランザクション内で本処理
+  let lastRunResult: 'success' | 'noop' = 'noop';
   await db.runTransaction(async (transaction) => {
     const [tDoc, rDoc] = await Promise.all([
       transaction.get(tournamentRef),
@@ -335,19 +383,18 @@ async function handleNewPayload(
       }
     }
 
-    const lastRunResult = mainSuccess ? 'success' : 'noop';
+    const currentLastRunResult = mainSuccess ? 'success' : 'noop';
+    lastRunResult = currentLastRunResult;
     transaction.update(taskIndexRef, {
       enqueueState: 'executed',
       lastRunAt: now,
-      lastRunResult,
+      lastRunResult: currentLastRunResult,
     });
   });
 
-  logOpsSuccess({
-    message: 'controlHook 新payload 処理完了',
-    functionEntry: 'controlHookHttp',
-    operation: 'executeNewPayloadTask',
-    context: { tournamentId, taskType, planVersion, planHash },
+  logNewPayloadTaskOutcome({
+    ...baseSuccessContext,
+    lastRunResult,
   });
 
   res.status(200).json({
@@ -369,6 +416,7 @@ async function handleNewPayload(
       operation: 'executeNewPayloadTask',
       cause: err,
       sourceProductHint: 'firestore',
+      context: baseSuccessContext,
     });
     res.status(500).json({
       error: 'Internal server error',

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1476,6 +1476,8 @@ PODS:
     - Flutter
     - FlutterMacOS
   - PromisesObjC (2.4.0)
+  - share_plus (0.0.1):
+    - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -1491,6 +1493,7 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 SPEC REPOS:
@@ -1542,6 +1545,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
 
@@ -1581,6 +1586,7 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  share_plus: 1fa619de8392a4398bfaf176d441853922614e89
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009


### PR DESCRIPTION
schedulerTaskDispatchLogs・schedulerCorrelation を導入し、各 scheduler/job から 中央 Firestore への reachability ログを拡張。weeklyPlanner・tournament・ payroll 周辺のテストと controlHook を更新。